### PR TITLE
Docker Compose 開発環境構築

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# MariaDB
+PERIGEE_DB_ROOT_PASSWORD=rootpassword
+PERIGEE_DB_HOST=mariadb
+PERIGEE_DB_PORT=3306
+PERIGEE_DB_USER=perigee
+PERIGEE_DB_PASSWORD=perigee
+PERIGEE_DB_NAME=perigee
+
+# Application
+PERIGEE_DEBUG=true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.13-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project
+
+COPY . .
+
+CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  mariadb:
+    image: mariadb:11.8.6
+    ports:
+      - "3306:3306"
+    environment:
+      MARIADB_ROOT_PASSWORD: ${PERIGEE_DB_ROOT_PASSWORD:-rootpassword}
+      MARIADB_DATABASE: ${PERIGEE_DB_NAME:-perigee}
+      MARIADB_USER: ${PERIGEE_DB_USER:-perigee}
+      MARIADB_PASSWORD: ${PERIGEE_DB_PASSWORD:-perigee}
+    volumes:
+      - mariadb_data:/var/lib/mysql
+      - ./docker/mariadb/initdb.sql:/docker-entrypoint-initdb.d/initdb.sql:ro
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      PERIGEE_DB_HOST: mariadb
+      PERIGEE_DB_PORT: "3306"
+      PERIGEE_DB_USER: ${PERIGEE_DB_USER:-perigee}
+      PERIGEE_DB_PASSWORD: ${PERIGEE_DB_PASSWORD:-perigee}
+      PERIGEE_DB_NAME: ${PERIGEE_DB_NAME:-perigee}
+      PERIGEE_DEBUG: "true"
+    volumes:
+      - ./backend:/app
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    depends_on:
+      - backend
+
+volumes:
+  mariadb_data:
+  frontend_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MARIADB_PASSWORD: ${PERIGEE_DB_PASSWORD:-perigee}
     volumes:
       - mariadb_data:/var/lib/mysql
-      - ./docker/mariadb/initdb.sql:/docker-entrypoint-initdb.d/initdb.sql:ro
+      - ./docker/mariadb/initdb.sh:/docker-entrypoint-initdb.d/initdb.sh:ro
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s

--- a/docker/mariadb/initdb.sh
+++ b/docker/mariadb/initdb.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" <<-EOSQL
+    CREATE DATABASE IF NOT EXISTS perigee_test;
+    GRANT ALL PRIVILEGES ON perigee_test.* TO '${MARIADB_USER}'@'%';
+    FLUSH PRIVILEGES;
+EOSQL

--- a/docker/mariadb/initdb.sql
+++ b/docker/mariadb/initdb.sql
@@ -1,3 +1,0 @@
-CREATE DATABASE IF NOT EXISTS perigee_test;
-GRANT ALL PRIVILEGES ON perigee_test.* TO 'perigee'@'%';
-FLUSH PRIVILEGES;

--- a/docker/mariadb/initdb.sql
+++ b/docker/mariadb/initdb.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS perigee_test;
+GRANT ALL PRIVILEGES ON perigee_test.* TO 'perigee'@'%';
+FLUSH PRIVILEGES;

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,4 +9,4 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-CMD ["pnpm", "dev", "--host", "0.0.0.0"]
+CMD ["sh", "-c", "pnpm install --frozen-lockfile && pnpm dev --host 0.0.0.0"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24-slim
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+CMD ["pnpm", "dev", "--host", "0.0.0.0"]


### PR DESCRIPTION
## 変更内容

- `docker-compose.yml` を作成（mariadb, backend, frontend の3サービス）
- MariaDB 11.8.6（LTS）コンテナ + initdb スクリプトで開発用DB・テスト用DB (`perigee_test`) を作成
- backend 用 `Dockerfile`（Python 3.13 + uv、uvicorn --reload でホットリロード）
- frontend 用 `Dockerfile`（Node.js 24 + pnpm、vite dev --host でホットリロード）
- `.env.example` を作成（`PERIGEE_` プレフィックスの環境変数テンプレート）
- ポート設定: backend=8000, frontend=5173, mariadb=3306
- ソースコードはボリュームマウントでホストと共有

## テスト結果

- `docker compose config` で設定の妥当性を確認済み

Closes #1
