### PR TITLE
Scheduling: ドメインモデル（Schedule等）の実装

### DIFF
--- a/backend/contexts/scheduling/domain/confirmation_request.py
+++ b/backend/contexts/scheduling/domain/confirmation_request.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.scheduling.domain.value_objects import (
+    ConfirmationRequestId,
+    ConfirmationRequestType,
+    ConfirmationResolution,
+)
+from shared.domain.value_objects import UserId
+
+
+@dataclass
+class ConfirmationRequest:
+    """Child entity of Schedule representing an approval request.
+
+    Created when a schedule is first created (Creation type) or when
+    a reschedule is proposed (Reschedule type). Tracks the resolution
+    lifecycle: Pending -> Approved/Rejected/Superseded.
+    """
+
+    id: ConfirmationRequestId
+    request_type: ConfirmationRequestType
+    requested_by: UserId
+    proposed_at: datetime
+    _resolution: ConfirmationResolution
+    _resolved_by: UserId | None
+    created_at: datetime
+
+    @property
+    def resolution(self) -> ConfirmationResolution:
+        return self._resolution
+
+    @property
+    def resolved_by(self) -> UserId | None:
+        return self._resolved_by
+
+    @property
+    def is_pending(self) -> bool:
+        return self._resolution == ConfirmationResolution.PENDING
+
+    def approve(self, resolved_by: UserId | None) -> None:
+        """Mark this request as approved."""
+        self._resolution = ConfirmationResolution.APPROVED
+        self._resolved_by = resolved_by
+
+    def reject(self, resolved_by: UserId) -> None:
+        """Mark this request as rejected."""
+        self._resolution = ConfirmationResolution.REJECTED
+        self._resolved_by = resolved_by
+
+    def supersede(self) -> None:
+        """Mark this request as superseded by a newer request."""
+        self._resolution = ConfirmationResolution.SUPERSEDED
+
+    @staticmethod
+    def create(
+        *,
+        request_type: ConfirmationRequestType,
+        requested_by: UserId,
+        proposed_at: datetime,
+        now: datetime,
+    ) -> ConfirmationRequest:
+        """Factory method to create a new pending confirmation request."""
+        return ConfirmationRequest(
+            id=ConfirmationRequestId.generate(),
+            request_type=request_type,
+            requested_by=requested_by,
+            proposed_at=proposed_at,
+            _resolution=ConfirmationResolution.PENDING,
+            _resolved_by=None,
+            created_at=now,
+        )

--- a/backend/contexts/scheduling/domain/events.py
+++ b/backend/contexts/scheduling/domain/events.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.scheduling.domain.value_objects import ScheduleId
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class ScheduleCreated:
+    """Raised when a new schedule is created."""
+
+    schedule_id: ScheduleId
+    organizer_id: UserId
+    counterpart_id: UserId
+    scheduled_at: datetime
+    requested_by: UserId
+    occurred_at: datetime
+
+
+@dataclass(frozen=True)
+class ScheduleConfirmed:
+    """Raised when a schedule is confirmed (manually or automatically)."""
+
+    schedule_id: ScheduleId
+    organizer_id: UserId
+    counterpart_id: UserId
+    scheduled_at: datetime
+    confirmed_by: UserId | None
+    is_auto: bool
+    occurred_at: datetime
+
+
+@dataclass(frozen=True)
+class ScheduleRejected:
+    """Raised when a reschedule proposal is rejected."""
+
+    schedule_id: ScheduleId
+    organizer_id: UserId
+    counterpart_id: UserId
+    rejected_by: UserId
+    occurred_at: datetime
+
+
+@dataclass(frozen=True)
+class ScheduleRescheduled:
+    """Raised when a reschedule is proposed."""
+
+    schedule_id: ScheduleId
+    organizer_id: UserId
+    counterpart_id: UserId
+    new_proposed_at: datetime
+    requested_by: UserId
+    occurred_at: datetime
+
+
+@dataclass(frozen=True)
+class ScheduleCancelled:
+    """Raised when a schedule is cancelled."""
+
+    schedule_id: ScheduleId
+    organizer_id: UserId
+    counterpart_id: UserId
+    cancelled_by: UserId
+    occurred_at: datetime

--- a/backend/contexts/scheduling/domain/exceptions.py
+++ b/backend/contexts/scheduling/domain/exceptions.py
@@ -1,0 +1,36 @@
+"""Domain exceptions for the scheduling context."""
+
+
+class ScheduleAlreadyCancelledError(Exception):
+    """Raised when attempting to operate on a cancelled schedule."""
+
+    def __init__(self, message: str = "Schedule is already cancelled.") -> None:
+        super().__init__(message)
+
+
+class UnauthorizedScheduleOperationError(Exception):
+    """Raised when a user without permission attempts a schedule operation."""
+
+    def __init__(self, message: str = "Unauthorized schedule operation.") -> None:
+        super().__init__(message)
+
+
+class ScheduleConflictError(Exception):
+    """Raised when a schedule conflicts with an existing one."""
+
+    def __init__(self, message: str = "Schedule conflict detected.") -> None:
+        super().__init__(message)
+
+
+class InvalidScheduleOperationError(Exception):
+    """Raised when a schedule operation is invalid."""
+
+    def __init__(self, message: str = "Invalid schedule operation.") -> None:
+        super().__init__(message)
+
+
+class NoPendingConfirmationRequestError(Exception):
+    """Raised when confirm/reject is attempted without a pending request."""
+
+    def __init__(self, message: str = "No pending confirmation request.") -> None:
+        super().__init__(message)

--- a/backend/contexts/scheduling/domain/exceptions.py
+++ b/backend/contexts/scheduling/domain/exceptions.py
@@ -15,13 +15,6 @@ class UnauthorizedScheduleOperationError(Exception):
         super().__init__(message)
 
 
-class ScheduleConflictError(Exception):
-    """Raised when a schedule conflicts with an existing one."""
-
-    def __init__(self, message: str = "Schedule conflict detected.") -> None:
-        super().__init__(message)
-
-
 class InvalidScheduleOperationError(Exception):
     """Raised when a schedule operation is invalid."""
 

--- a/backend/contexts/scheduling/domain/schedule.py
+++ b/backend/contexts/scheduling/domain/schedule.py
@@ -199,7 +199,9 @@ class Schedule:
 
         If the pending request is a Creation type, rejecting it cancels
         the schedule entirely (ScheduleCancelled event, not ScheduleRejected).
-        If it is a Reschedule type, the schedule reverts to Confirmed.
+        If it is a Reschedule type:
+        - If previously confirmed (approved request exists), reverts to Confirmed.
+        - If never confirmed, cancels the schedule (ScheduleCancelled event).
 
         Raises:
             ScheduleAlreadyCancelledError: If already cancelled.
@@ -227,8 +229,8 @@ class Schedule:
                     occurred_at=now,
                 )
             )
-        else:
-            # Rejecting reschedule = revert to Confirmed
+        elif self._has_approved_request():
+            # Rejecting reschedule when previously confirmed = revert to Confirmed
             self._status = ScheduleStatus.CONFIRMED
             self._events.append(
                 ScheduleRejected(
@@ -236,6 +238,18 @@ class Schedule:
                     organizer_id=self.organizer_id,
                     counterpart_id=self.counterpart_id,
                     rejected_by=actor_id,
+                    occurred_at=now,
+                )
+            )
+        else:
+            # Rejecting reschedule when never confirmed = cancellation
+            self._status = ScheduleStatus.CANCELLED
+            self._events.append(
+                ScheduleCancelled(
+                    schedule_id=self.id,
+                    organizer_id=self.organizer_id,
+                    counterpart_id=self.counterpart_id,
+                    cancelled_by=actor_id,
                     occurred_at=now,
                 )
             )
@@ -369,6 +383,13 @@ class Schedule:
             raise UnauthorizedScheduleOperationError(
                 "Cannot confirm or reject your own request."
             )
+
+    def _has_approved_request(self) -> bool:
+        """Check whether any confirmation request has been approved."""
+        return any(
+            req.resolution == ConfirmationResolution.APPROVED
+            for req in self._confirmation_requests
+        )
 
     def _find_pending_request(self) -> ConfirmationRequest | None:
         """Find the pending confirmation request (if any)."""

--- a/backend/contexts/scheduling/domain/schedule.py
+++ b/backend/contexts/scheduling/domain/schedule.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from contexts.scheduling.domain.confirmation_request import ConfirmationRequest
+from contexts.scheduling.domain.events import (
+    ScheduleCancelled,
+    ScheduleConfirmed,
+    ScheduleCreated,
+    ScheduleRejected,
+    ScheduleRescheduled,
+)
+from contexts.scheduling.domain.exceptions import (
+    InvalidScheduleOperationError,
+    NoPendingConfirmationRequestError,
+    ScheduleAlreadyCancelledError,
+    UnauthorizedScheduleOperationError,
+)
+from contexts.scheduling.domain.value_objects import (
+    ConfirmationRequestType,
+    ConfirmationResolution,
+    ScheduleId,
+    ScheduleStatus,
+)
+from shared.domain.value_objects import UserId
+
+type _ScheduleEvent = (
+    ScheduleCreated
+    | ScheduleConfirmed
+    | ScheduleRejected
+    | ScheduleRescheduled
+    | ScheduleCancelled
+)
+
+
+@dataclass
+class Schedule:
+    """Aggregate root: a 1-on-1 meeting schedule.
+
+    Business rules:
+    - Organizer and counterpart must be different users.
+    - Schedule cannot be created in the past.
+    - Confirm/reject requires a pending confirmation request and must be
+      done by the counterpart of the request (not the requester).
+    - Cancelled schedules cannot be modified.
+    - Reschedule creates a new confirmation request; existing pending
+      requests are resolved (superseded or rejected depending on actor).
+    - Auto-confirm is a system operation that skips permission checks.
+    """
+
+    id: ScheduleId
+    organizer_id: UserId
+    counterpart_id: UserId
+    _scheduled_at: datetime
+    _status: ScheduleStatus
+    _confirmation_requests: list[ConfirmationRequest]
+    created_at: datetime
+    _updated_at: datetime
+    _events: list[_ScheduleEvent] = field(default_factory=list, repr=False)
+
+    @property
+    def scheduled_at(self) -> datetime:
+        return self._scheduled_at
+
+    @property
+    def status(self) -> ScheduleStatus:
+        return self._status
+
+    @property
+    def confirmation_requests(self) -> list[ConfirmationRequest]:
+        return list(self._confirmation_requests)
+
+    @property
+    def updated_at(self) -> datetime:
+        return self._updated_at
+
+    def collect_events(self) -> list[_ScheduleEvent]:
+        """Return accumulated events and clear the internal list."""
+        events = list(self._events)
+        self._events.clear()
+        return events
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create(
+        *,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+        scheduled_at: datetime,
+        requested_by: UserId,
+        now: datetime | None = None,
+    ) -> Schedule:
+        """Create a new schedule in Requested status.
+
+        Args:
+            organizer_id: The organizer of the 1-on-1.
+            counterpart_id: The counterpart of the 1-on-1.
+            scheduled_at: Proposed datetime for the meeting.
+            requested_by: The user creating the schedule (must be
+                organizer or counterpart).
+            now: Current time (defaults to UTC now).
+
+        Raises:
+            InvalidScheduleOperationError: If organizer == counterpart
+                or scheduled_at is in the past.
+            UnauthorizedScheduleOperationError: If requested_by is
+                neither the organizer nor the counterpart.
+        """
+        ts = now or datetime.now(UTC)
+
+        if organizer_id == counterpart_id:
+            raise InvalidScheduleOperationError(
+                "Organizer and counterpart must be different users."
+            )
+
+        # Compare at second precision in UTC
+        if _truncate_to_seconds(scheduled_at) < _truncate_to_seconds(ts):
+            raise InvalidScheduleOperationError("Cannot create a schedule in the past.")
+
+        if requested_by != organizer_id and requested_by != counterpart_id:
+            raise UnauthorizedScheduleOperationError(
+                "Only the organizer or counterpart can create a schedule."
+            )
+
+        schedule_id = ScheduleId.generate()
+        creation_request = ConfirmationRequest.create(
+            request_type=ConfirmationRequestType.CREATION,
+            requested_by=requested_by,
+            proposed_at=scheduled_at,
+            now=ts,
+        )
+
+        schedule = Schedule(
+            id=schedule_id,
+            organizer_id=organizer_id,
+            counterpart_id=counterpart_id,
+            _scheduled_at=scheduled_at,
+            _status=ScheduleStatus.REQUESTED,
+            _confirmation_requests=[creation_request],
+            created_at=ts,
+            _updated_at=ts,
+        )
+        schedule._events.append(
+            ScheduleCreated(
+                schedule_id=schedule_id,
+                organizer_id=organizer_id,
+                counterpart_id=counterpart_id,
+                scheduled_at=scheduled_at,
+                requested_by=requested_by,
+                occurred_at=ts,
+            )
+        )
+        return schedule
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+
+    def confirm(self, *, actor_id: UserId, now: datetime) -> None:
+        """Confirm the pending confirmation request.
+
+        Check order: Cancelled -> Pending existence -> Permission.
+
+        Raises:
+            ScheduleAlreadyCancelledError: If already cancelled.
+            NoPendingConfirmationRequestError: If no pending request.
+            UnauthorizedScheduleOperationError: If actor is the requester
+                or not a participant.
+        """
+        self._assert_not_cancelled()
+        pending = self._get_pending_request()
+        self._assert_participant(actor_id)
+        self._assert_not_requester(actor_id, pending)
+
+        pending.approve(resolved_by=actor_id)
+        self._scheduled_at = pending.proposed_at
+        self._status = ScheduleStatus.CONFIRMED
+        self._updated_at = now
+        self._events.append(
+            ScheduleConfirmed(
+                schedule_id=self.id,
+                organizer_id=self.organizer_id,
+                counterpart_id=self.counterpart_id,
+                scheduled_at=self._scheduled_at,
+                confirmed_by=actor_id,
+                is_auto=False,
+                occurred_at=now,
+            )
+        )
+
+    def reject(self, *, actor_id: UserId, now: datetime) -> None:
+        """Reject the pending confirmation request.
+
+        Check order: Cancelled -> Pending existence -> Permission.
+
+        If the pending request is a Creation type, rejecting it cancels
+        the schedule entirely (ScheduleCancelled event, not ScheduleRejected).
+        If it is a Reschedule type, the schedule reverts to Confirmed.
+
+        Raises:
+            ScheduleAlreadyCancelledError: If already cancelled.
+            NoPendingConfirmationRequestError: If no pending request.
+            UnauthorizedScheduleOperationError: If actor is the requester
+                or not a participant.
+        """
+        self._assert_not_cancelled()
+        pending = self._get_pending_request()
+        self._assert_participant(actor_id)
+        self._assert_not_requester(actor_id, pending)
+
+        pending.reject(resolved_by=actor_id)
+        self._updated_at = now
+
+        if pending.request_type == ConfirmationRequestType.CREATION:
+            # Rejecting creation = cancellation
+            self._status = ScheduleStatus.CANCELLED
+            self._events.append(
+                ScheduleCancelled(
+                    schedule_id=self.id,
+                    organizer_id=self.organizer_id,
+                    counterpart_id=self.counterpart_id,
+                    cancelled_by=actor_id,
+                    occurred_at=now,
+                )
+            )
+        else:
+            # Rejecting reschedule = revert to Confirmed
+            self._status = ScheduleStatus.CONFIRMED
+            self._events.append(
+                ScheduleRejected(
+                    schedule_id=self.id,
+                    organizer_id=self.organizer_id,
+                    counterpart_id=self.counterpart_id,
+                    rejected_by=actor_id,
+                    occurred_at=now,
+                )
+            )
+
+    def reschedule(
+        self,
+        *,
+        actor_id: UserId,
+        new_proposed_at: datetime,
+        now: datetime,
+    ) -> None:
+        """Propose a reschedule.
+
+        If there is an existing pending request:
+        - If actor is the same as pending requester -> Superseded
+        - If actor is the counterpart of pending requester -> Rejected
+
+        Raises:
+            ScheduleAlreadyCancelledError: If already cancelled.
+            UnauthorizedScheduleOperationError: If actor is not a participant.
+        """
+        self._assert_not_cancelled()
+        self._assert_participant(actor_id)
+
+        # Resolve existing pending request if any
+        existing_pending = self._find_pending_request()
+        if existing_pending is not None:
+            if existing_pending.requested_by == actor_id:
+                existing_pending.supersede()
+            else:
+                existing_pending.reject(resolved_by=actor_id)
+
+        new_request = ConfirmationRequest.create(
+            request_type=ConfirmationRequestType.RESCHEDULE,
+            requested_by=actor_id,
+            proposed_at=new_proposed_at,
+            now=now,
+        )
+        self._confirmation_requests.append(new_request)
+        self._status = ScheduleStatus.REQUESTED
+        self._updated_at = now
+        self._events.append(
+            ScheduleRescheduled(
+                schedule_id=self.id,
+                organizer_id=self.organizer_id,
+                counterpart_id=self.counterpart_id,
+                new_proposed_at=new_proposed_at,
+                requested_by=actor_id,
+                occurred_at=now,
+            )
+        )
+
+    def cancel(self, *, actor_id: UserId, now: datetime) -> None:
+        """Cancel the schedule.
+
+        Raises:
+            ScheduleAlreadyCancelledError: If already cancelled.
+            UnauthorizedScheduleOperationError: If actor is not a participant.
+        """
+        self._assert_not_cancelled()
+        self._assert_participant(actor_id)
+
+        # Resolve any pending request
+        existing_pending = self._find_pending_request()
+        if existing_pending is not None:
+            existing_pending.supersede()
+
+        self._status = ScheduleStatus.CANCELLED
+        self._updated_at = now
+        self._events.append(
+            ScheduleCancelled(
+                schedule_id=self.id,
+                organizer_id=self.organizer_id,
+                counterpart_id=self.counterpart_id,
+                cancelled_by=actor_id,
+                occurred_at=now,
+            )
+        )
+
+    def auto_confirm(self, *, now: datetime) -> None:
+        """Auto-confirm triggered by record creation.
+
+        System operation: no actor, no permission check.
+        - Requested: confirm the pending request.
+        - Confirmed: idempotent (no-op).
+        - Cancelled: error.
+
+        Raises:
+            ScheduleAlreadyCancelledError: If cancelled.
+        """
+        self._assert_not_cancelled()
+
+        if self._status == ScheduleStatus.CONFIRMED:
+            return  # idempotent
+
+        pending = self._get_pending_request()
+        pending.approve(resolved_by=None)
+        self._scheduled_at = pending.proposed_at
+        self._status = ScheduleStatus.CONFIRMED
+        self._updated_at = now
+        self._events.append(
+            ScheduleConfirmed(
+                schedule_id=self.id,
+                organizer_id=self.organizer_id,
+                counterpart_id=self.counterpart_id,
+                scheduled_at=self._scheduled_at,
+                confirmed_by=None,
+                is_auto=True,
+                occurred_at=now,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _assert_not_cancelled(self) -> None:
+        if self._status == ScheduleStatus.CANCELLED:
+            raise ScheduleAlreadyCancelledError()
+
+    def _assert_participant(self, actor_id: UserId) -> None:
+        if actor_id != self.organizer_id and actor_id != self.counterpart_id:
+            raise UnauthorizedScheduleOperationError(
+                "Only the organizer or counterpart can operate on this schedule."
+            )
+
+    def _assert_not_requester(
+        self, actor_id: UserId, pending: ConfirmationRequest
+    ) -> None:
+        if actor_id == pending.requested_by:
+            raise UnauthorizedScheduleOperationError(
+                "Cannot confirm or reject your own request."
+            )
+
+    def _find_pending_request(self) -> ConfirmationRequest | None:
+        """Find the pending confirmation request (if any)."""
+        for req in reversed(self._confirmation_requests):
+            if req.resolution == ConfirmationResolution.PENDING:
+                return req
+        return None
+
+    def _get_pending_request(self) -> ConfirmationRequest:
+        """Get the pending confirmation request or raise."""
+        pending = self._find_pending_request()
+        if pending is None:
+            raise NoPendingConfirmationRequestError()
+        return pending
+
+
+def _truncate_to_seconds(dt: datetime) -> datetime:
+    """Truncate datetime to second precision for comparison."""
+    return dt.replace(microsecond=0)

--- a/backend/contexts/scheduling/domain/value_objects.py
+++ b/backend/contexts/scheduling/domain/value_objects.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from enum import Enum
 
 
 @dataclass(frozen=True)
@@ -17,3 +18,42 @@ class ScheduleId:
     @staticmethod
     def from_str(raw: str) -> ScheduleId:
         return ScheduleId(value=uuid.UUID(raw))
+
+
+@dataclass(frozen=True)
+class ConfirmationRequestId:
+    """ConfirmationRequest identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> ConfirmationRequestId:
+        return ConfirmationRequestId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> ConfirmationRequestId:
+        return ConfirmationRequestId(value=uuid.UUID(raw))
+
+
+class ScheduleStatus(Enum):
+    """Schedule status: Requested -> Confirmed -> Cancelled."""
+
+    REQUESTED = "requested"
+    CONFIRMED = "confirmed"
+    CANCELLED = "cancelled"
+
+
+class ConfirmationRequestType(Enum):
+    """Type of confirmation request."""
+
+    CREATION = "creation"
+    RESCHEDULE = "reschedule"
+
+
+class ConfirmationResolution(Enum):
+    """Resolution of a confirmation request."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    SUPERSEDED = "superseded"

--- a/backend/tests/contexts/scheduling/domain/test_schedule.py
+++ b/backend/tests/contexts/scheduling/domain/test_schedule.py
@@ -1,0 +1,642 @@
+from datetime import datetime
+
+import pytest
+
+from contexts.scheduling.domain.events import (
+    ScheduleCancelled,
+    ScheduleConfirmed,
+    ScheduleCreated,
+    ScheduleRejected,
+    ScheduleRescheduled,
+)
+from contexts.scheduling.domain.exceptions import (
+    InvalidScheduleOperationError,
+    NoPendingConfirmationRequestError,
+    ScheduleAlreadyCancelledError,
+    UnauthorizedScheduleOperationError,
+)
+from contexts.scheduling.domain.schedule import Schedule
+from contexts.scheduling.domain.value_objects import (
+    ConfirmationRequestType,
+    ConfirmationResolution,
+    ScheduleStatus,
+)
+from shared.domain.value_objects import UserId
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 3, 20, 10, 0)
+_FUTURE = datetime(2026, 4, 1, 10, 0)
+_FUTURE2 = datetime(2026, 4, 2, 10, 0)
+_LATER = datetime(2026, 3, 20, 11, 0)
+
+
+def _make_schedule(
+    *,
+    organizer_id: UserId | None = None,
+    counterpart_id: UserId | None = None,
+    scheduled_at: datetime = _FUTURE,
+    requested_by: UserId | None = None,
+    now: datetime = _NOW,
+) -> Schedule:
+    """Create a schedule with sensible defaults (organizer creates it)."""
+    org = organizer_id or UserId.generate()
+    cp = counterpart_id or UserId.generate()
+    return Schedule.create(
+        organizer_id=org,
+        counterpart_id=cp,
+        scheduled_at=scheduled_at,
+        requested_by=requested_by or org,
+        now=now,
+    )
+
+
+def _make_confirmed_schedule(
+    *,
+    organizer_id: UserId | None = None,
+    counterpart_id: UserId | None = None,
+    scheduled_at: datetime = _FUTURE,
+    now: datetime = _NOW,
+) -> Schedule:
+    """Create a confirmed schedule."""
+    org = organizer_id or UserId.generate()
+    cp = counterpart_id or UserId.generate()
+    schedule = Schedule.create(
+        organizer_id=org,
+        counterpart_id=cp,
+        scheduled_at=scheduled_at,
+        requested_by=org,
+        now=now,
+    )
+    schedule.confirm(actor_id=cp, now=_LATER)
+    schedule.collect_events()  # clear events
+    return schedule
+
+
+def _make_cancelled_schedule(
+    *,
+    organizer_id: UserId | None = None,
+    counterpart_id: UserId | None = None,
+) -> Schedule:
+    """Create a cancelled schedule."""
+    org = organizer_id or UserId.generate()
+    cp = counterpart_id or UserId.generate()
+    schedule = Schedule.create(
+        organizer_id=org,
+        counterpart_id=cp,
+        scheduled_at=_FUTURE,
+        requested_by=org,
+        now=_NOW,
+    )
+    schedule.cancel(actor_id=org, now=_LATER)
+    schedule.collect_events()
+    return schedule
+
+
+# ===========================================================================
+# Schedule Creation
+# ===========================================================================
+
+
+class TestScheduleCreate:
+    def test_creates_requested_with_creation_confirmation(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+
+        assert schedule.status == ScheduleStatus.REQUESTED
+        assert schedule.organizer_id == org
+        assert schedule.counterpart_id == cp
+        assert schedule.scheduled_at == _FUTURE
+        reqs = schedule.confirmation_requests
+        assert len(reqs) == 1
+        assert reqs[0].request_type == ConfirmationRequestType.CREATION
+        assert reqs[0].resolution == ConfirmationResolution.PENDING
+        assert reqs[0].requested_by == org
+
+    def test_emits_schedule_created_event(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = Schedule.create(
+            organizer_id=org,
+            counterpart_id=cp,
+            scheduled_at=_FUTURE,
+            requested_by=org,
+            now=_NOW,
+        )
+        events = schedule.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, ScheduleCreated)
+        assert event.schedule_id == schedule.id
+        assert event.organizer_id == org
+        assert event.counterpart_id == cp
+        assert event.scheduled_at == _FUTURE
+        assert event.requested_by == org
+        assert event.occurred_at == _NOW
+
+    def test_counterpart_can_create(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = Schedule.create(
+            organizer_id=org,
+            counterpart_id=cp,
+            scheduled_at=_FUTURE,
+            requested_by=cp,
+            now=_NOW,
+        )
+        assert schedule.confirmation_requests[0].requested_by == cp
+
+    def test_past_datetime_raises_error(self) -> None:
+        past = datetime(2020, 1, 1, 0, 0)
+        with pytest.raises(InvalidScheduleOperationError, match="past"):
+            _make_schedule(scheduled_at=past)
+
+    def test_same_datetime_as_now_is_allowed(self) -> None:
+        now = datetime(2026, 3, 20, 10, 0)
+        schedule = _make_schedule(scheduled_at=now, now=now)
+        assert schedule.scheduled_at == now
+
+    def test_same_user_raises_error(self) -> None:
+        user = UserId.generate()
+        with pytest.raises(InvalidScheduleOperationError, match="different users"):
+            Schedule.create(
+                organizer_id=user,
+                counterpart_id=user,
+                scheduled_at=_FUTURE,
+                requested_by=user,
+                now=_NOW,
+            )
+
+    def test_non_participant_cannot_create(self) -> None:
+        other = UserId.generate()
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            Schedule.create(
+                organizer_id=UserId.generate(),
+                counterpart_id=UserId.generate(),
+                scheduled_at=_FUTURE,
+                requested_by=other,
+                now=_NOW,
+            )
+
+    def test_sets_timestamps(self) -> None:
+        schedule = _make_schedule(now=_NOW)
+        assert schedule.created_at == _NOW
+        assert schedule.updated_at == _NOW
+
+    def test_collect_events_clears_list(self) -> None:
+        schedule = _make_schedule()
+        events = schedule.collect_events()
+        assert len(events) == 1
+        assert schedule.collect_events() == []
+
+
+# ===========================================================================
+# Confirm
+# ===========================================================================
+
+
+class TestScheduleConfirm:
+    def test_counterpart_confirms_creation(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        schedule.collect_events()
+
+        schedule.confirm(actor_id=cp, now=_LATER)
+
+        assert schedule.status == ScheduleStatus.CONFIRMED
+        assert schedule.scheduled_at == _FUTURE
+        assert schedule.updated_at == _LATER
+        reqs = schedule.confirmation_requests
+        assert reqs[0].resolution == ConfirmationResolution.APPROVED
+        assert reqs[0].resolved_by == cp
+
+    def test_emits_schedule_confirmed_event(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        schedule.collect_events()
+
+        schedule.confirm(actor_id=cp, now=_LATER)
+
+        events = schedule.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, ScheduleConfirmed)
+        assert event.confirmed_by == cp
+        assert event.is_auto is False
+        assert event.scheduled_at == _FUTURE
+
+    def test_requester_cannot_self_confirm(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+
+        with pytest.raises(UnauthorizedScheduleOperationError, match="own request"):
+            schedule.confirm(actor_id=org, now=_LATER)
+
+    def test_confirmed_schedule_has_no_pending(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+
+        with pytest.raises(NoPendingConfirmationRequestError):
+            schedule.confirm(actor_id=org, now=_LATER)
+
+    def test_cancelled_schedule_raises_error(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_cancelled_schedule(organizer_id=org, counterpart_id=cp)
+
+        with pytest.raises(ScheduleAlreadyCancelledError):
+            schedule.confirm(actor_id=cp, now=_LATER)
+
+    def test_non_participant_cannot_confirm(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        other = UserId.generate()
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            schedule.confirm(actor_id=other, now=_LATER)
+
+    def test_confirm_reschedule_updates_scheduled_at(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+        schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=_LATER)
+        schedule.collect_events()
+
+        confirm_time = datetime(2026, 3, 20, 12, 0)
+        schedule.confirm(actor_id=cp, now=confirm_time)
+
+        assert schedule.status == ScheduleStatus.CONFIRMED
+        assert schedule.scheduled_at == _FUTURE2
+
+
+# ===========================================================================
+# Reject
+# ===========================================================================
+
+
+class TestScheduleReject:
+    def test_reject_reschedule_reverts_to_confirmed(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+        original_scheduled_at = schedule.scheduled_at
+        schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=_LATER)
+        schedule.collect_events()
+
+        reject_time = datetime(2026, 3, 20, 12, 0)
+        schedule.reject(actor_id=cp, now=reject_time)
+
+        assert schedule.status == ScheduleStatus.CONFIRMED
+        assert schedule.scheduled_at == original_scheduled_at
+
+    def test_reject_reschedule_emits_schedule_rejected(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+        schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=_LATER)
+        schedule.collect_events()
+
+        reject_time = datetime(2026, 3, 20, 12, 0)
+        schedule.reject(actor_id=cp, now=reject_time)
+
+        events = schedule.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, ScheduleRejected)
+        assert event.rejected_by == cp
+
+    def test_reject_creation_cancels_schedule(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+        schedule.collect_events()
+
+        schedule.reject(actor_id=cp, now=_LATER)
+
+        assert schedule.status == ScheduleStatus.CANCELLED
+
+    def test_reject_creation_emits_schedule_cancelled(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+        schedule.collect_events()
+
+        schedule.reject(actor_id=cp, now=_LATER)
+
+        events = schedule.collect_events()
+        assert len(events) == 1
+        assert isinstance(events[0], ScheduleCancelled)
+        assert events[0].cancelled_by == cp
+
+    def test_requester_cannot_self_reject(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+
+        with pytest.raises(UnauthorizedScheduleOperationError, match="own request"):
+            schedule.reject(actor_id=org, now=_LATER)
+
+    def test_cancelled_schedule_raises_error(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_cancelled_schedule(organizer_id=org, counterpart_id=cp)
+
+        with pytest.raises(ScheduleAlreadyCancelledError):
+            schedule.reject(actor_id=cp, now=_LATER)
+
+    def test_confirmed_without_pending_raises_error(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+
+        with pytest.raises(NoPendingConfirmationRequestError):
+            schedule.reject(actor_id=org, now=_LATER)
+
+
+# ===========================================================================
+# Reschedule
+# ===========================================================================
+
+
+class TestScheduleReschedule:
+    def test_reschedule_confirmed_creates_new_request(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+
+        schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=_LATER)
+
+        assert schedule.status == ScheduleStatus.REQUESTED
+        # scheduled_at should NOT change until confirmed
+        assert schedule.scheduled_at == _FUTURE
+        reqs = schedule.confirmation_requests
+        assert len(reqs) == 2  # original creation + reschedule
+        latest = reqs[-1]
+        assert latest.request_type == ConfirmationRequestType.RESCHEDULE
+        assert latest.resolution == ConfirmationResolution.PENDING
+        assert latest.requested_by == org
+        assert latest.proposed_at == _FUTURE2
+
+    def test_reschedule_emits_event(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+
+        schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=_LATER)
+
+        events = schedule.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, ScheduleRescheduled)
+        assert event.new_proposed_at == _FUTURE2
+        assert event.requested_by == org
+
+    def test_same_requester_supersedes_existing_pending(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+        schedule.collect_events()
+
+        schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=_LATER)
+
+        reqs = schedule.confirmation_requests
+        assert reqs[0].resolution == ConfirmationResolution.SUPERSEDED
+        assert reqs[1].resolution == ConfirmationResolution.PENDING
+        assert reqs[1].requested_by == org
+
+    def test_counterpart_rejects_existing_pending(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+        schedule.collect_events()
+
+        schedule.reschedule(actor_id=cp, new_proposed_at=_FUTURE2, now=_LATER)
+
+        reqs = schedule.confirmation_requests
+        assert reqs[0].resolution == ConfirmationResolution.REJECTED
+        assert reqs[0].resolved_by == cp
+        assert reqs[1].resolution == ConfirmationResolution.PENDING
+        assert reqs[1].requested_by == cp
+
+    def test_cancelled_schedule_raises_error(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_cancelled_schedule(organizer_id=org, counterpart_id=cp)
+
+        with pytest.raises(ScheduleAlreadyCancelledError):
+            schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=_LATER)
+
+    def test_non_participant_cannot_reschedule(self) -> None:
+        schedule = _make_confirmed_schedule()
+        other = UserId.generate()
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            schedule.reschedule(actor_id=other, new_proposed_at=_FUTURE2, now=_LATER)
+
+
+# ===========================================================================
+# Cancel
+# ===========================================================================
+
+
+class TestScheduleCancel:
+    def test_cancel_confirmed_schedule(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+
+        cancel_time = datetime(2026, 3, 20, 12, 0)
+        schedule.cancel(actor_id=cp, now=cancel_time)
+
+        assert schedule.status == ScheduleStatus.CANCELLED
+        assert schedule.updated_at == cancel_time
+
+    def test_cancel_emits_schedule_cancelled_event(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer_id=org, counterpart_id=cp)
+
+        cancel_time = datetime(2026, 3, 20, 12, 0)
+        schedule.cancel(actor_id=cp, now=cancel_time)
+
+        events = schedule.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, ScheduleCancelled)
+        assert event.cancelled_by == cp
+
+    def test_cancel_already_cancelled_raises_error(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_cancelled_schedule(organizer_id=org, counterpart_id=cp)
+
+        with pytest.raises(ScheduleAlreadyCancelledError):
+            schedule.cancel(actor_id=org, now=_LATER)
+
+    def test_non_participant_cannot_cancel(self) -> None:
+        schedule = _make_confirmed_schedule()
+        other = UserId.generate()
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            schedule.cancel(actor_id=other, now=_LATER)
+
+    def test_cancel_requested_supersedes_pending(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+
+        schedule.cancel(actor_id=org, now=_LATER)
+
+        assert schedule.status == ScheduleStatus.CANCELLED
+        reqs = schedule.confirmation_requests
+        assert reqs[0].resolution == ConfirmationResolution.SUPERSEDED
+
+
+# ===========================================================================
+# Auto-confirm
+# ===========================================================================
+
+
+class TestScheduleAutoConfirm:
+    def test_auto_confirm_requested_schedule(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        schedule.collect_events()
+
+        schedule.auto_confirm(now=_LATER)
+
+        assert schedule.status == ScheduleStatus.CONFIRMED
+        assert schedule.scheduled_at == _FUTURE
+        reqs = schedule.confirmation_requests
+        assert reqs[0].resolution == ConfirmationResolution.APPROVED
+        assert reqs[0].resolved_by is None
+
+    def test_auto_confirm_emits_event_with_is_auto(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        schedule.collect_events()
+
+        schedule.auto_confirm(now=_LATER)
+
+        events = schedule.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, ScheduleConfirmed)
+        assert event.is_auto is True
+        assert event.confirmed_by is None
+
+    def test_auto_confirm_confirmed_is_idempotent(self) -> None:
+        schedule = _make_confirmed_schedule()
+
+        schedule.auto_confirm(now=_LATER)
+
+        # No events, no error
+        assert schedule.collect_events() == []
+        assert schedule.status == ScheduleStatus.CONFIRMED
+
+    def test_auto_confirm_cancelled_raises_error(self) -> None:
+        schedule = _make_cancelled_schedule()
+
+        with pytest.raises(ScheduleAlreadyCancelledError):
+            schedule.auto_confirm(now=_LATER)
+
+
+# ===========================================================================
+# Aggregate Invariants
+# ===========================================================================
+
+
+class TestAggregateInvariants:
+    def test_requested_has_exactly_one_pending(self) -> None:
+        schedule = _make_schedule()
+        pending = [
+            r
+            for r in schedule.confirmation_requests
+            if r.resolution == ConfirmationResolution.PENDING
+        ]
+        assert len(pending) == 1
+
+    def test_confirmed_has_no_pending(self) -> None:
+        schedule = _make_confirmed_schedule()
+        pending = [
+            r
+            for r in schedule.confirmation_requests
+            if r.resolution == ConfirmationResolution.PENDING
+        ]
+        assert len(pending) == 0
+
+    def test_cancelled_has_no_pending(self) -> None:
+        schedule = _make_cancelled_schedule()
+        pending = [
+            r
+            for r in schedule.confirmation_requests
+            if r.resolution == ConfirmationResolution.PENDING
+        ]
+        assert len(pending) == 0
+
+    def test_confirmation_requests_never_empty(self) -> None:
+        schedule = _make_schedule()
+        assert len(schedule.confirmation_requests) >= 1
+
+        confirmed = _make_confirmed_schedule()
+        assert len(confirmed.confirmation_requests) >= 1
+
+        cancelled = _make_cancelled_schedule()
+        assert len(cancelled.confirmation_requests) >= 1
+
+    def test_multiple_operations_maintain_invariants(self) -> None:
+        """Exercise a complex flow.
+
+        create -> reschedule -> reject -> reschedule -> confirm.
+        """
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = Schedule.create(
+            organizer_id=org,
+            counterpart_id=cp,
+            scheduled_at=_FUTURE,
+            requested_by=org,
+            now=_NOW,
+        )
+
+        # Organizer reschedules their own request (supersede)
+        t1 = datetime(2026, 3, 20, 11, 0)
+        schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=t1)
+        assert schedule.status == ScheduleStatus.REQUESTED
+
+        # Counterpart rejects the reschedule
+        t2 = datetime(2026, 3, 20, 12, 0)
+        # Creation was superseded, so latest pending is reschedule by org
+        schedule.reject(actor_id=cp, now=t2)
+        assert schedule.status == ScheduleStatus.CONFIRMED
+
+        # Counterpart reschedules
+        new_time = datetime(2026, 5, 1, 10, 0)
+        t3 = datetime(2026, 3, 20, 13, 0)
+        schedule.reschedule(actor_id=cp, new_proposed_at=new_time, now=t3)
+        assert schedule.status == ScheduleStatus.REQUESTED
+
+        # Organizer confirms
+        t4 = datetime(2026, 3, 20, 14, 0)
+        schedule.confirm(actor_id=org, now=t4)
+        assert schedule.status == ScheduleStatus.CONFIRMED
+        assert schedule.scheduled_at == new_time
+
+        # Verify invariants
+        pending_count = sum(
+            1
+            for r in schedule.confirmation_requests
+            if r.resolution == ConfirmationResolution.PENDING
+        )
+        assert pending_count == 0
+        assert len(schedule.confirmation_requests) == 3

--- a/backend/tests/contexts/scheduling/domain/test_schedule.py
+++ b/backend/tests/contexts/scheduling/domain/test_schedule.py
@@ -360,6 +360,45 @@ class TestScheduleReject:
         with pytest.raises(NoPendingConfirmationRequestError):
             schedule.reject(actor_id=org, now=_LATER)
 
+    def test_reject_reschedule_never_confirmed_cancels(self) -> None:
+        """Reject reschedule when schedule was never confirmed (no approved request).
+
+        Flow: create(org) -> counterpart reschedules (rejects creation) ->
+        organizer rejects reschedule -> should cancel (not revert to Confirmed).
+        """
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+        schedule.collect_events()
+
+        # Counterpart reschedules, which rejects the pending creation request
+        schedule.reschedule(actor_id=cp, new_proposed_at=_FUTURE2, now=_LATER)
+        schedule.collect_events()
+
+        # Organizer rejects the reschedule; no request was ever approved
+        reject_time = datetime(2026, 3, 20, 12, 0)
+        schedule.reject(actor_id=org, now=reject_time)
+
+        assert schedule.status == ScheduleStatus.CANCELLED
+
+    def test_reject_reschedule_never_confirmed_emits_cancelled(self) -> None:
+        """Rejecting reschedule when never confirmed emits ScheduleCancelled."""
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp, requested_by=org)
+        schedule.collect_events()
+
+        schedule.reschedule(actor_id=cp, new_proposed_at=_FUTURE2, now=_LATER)
+        schedule.collect_events()
+
+        reject_time = datetime(2026, 3, 20, 12, 0)
+        schedule.reject(actor_id=org, now=reject_time)
+
+        events = schedule.collect_events()
+        assert len(events) == 1
+        assert isinstance(events[0], ScheduleCancelled)
+        assert events[0].cancelled_by == org
+
 
 # ===========================================================================
 # Reschedule
@@ -597,7 +636,7 @@ class TestAggregateInvariants:
     def test_multiple_operations_maintain_invariants(self) -> None:
         """Exercise a complex flow.
 
-        create -> reschedule -> reject -> reschedule -> confirm.
+        create -> confirm -> reschedule -> reject -> reschedule -> confirm.
         """
         org = UserId.generate()
         cp = UserId.generate()
@@ -609,14 +648,18 @@ class TestAggregateInvariants:
             now=_NOW,
         )
 
-        # Organizer reschedules their own request (supersede)
+        # Counterpart confirms creation
+        t0 = datetime(2026, 3, 20, 10, 30)
+        schedule.confirm(actor_id=cp, now=t0)
+        assert schedule.status == ScheduleStatus.CONFIRMED
+
+        # Organizer reschedules
         t1 = datetime(2026, 3, 20, 11, 0)
         schedule.reschedule(actor_id=org, new_proposed_at=_FUTURE2, now=t1)
         assert schedule.status == ScheduleStatus.REQUESTED
 
-        # Counterpart rejects the reschedule
+        # Counterpart rejects the reschedule (has prior approval -> revert)
         t2 = datetime(2026, 3, 20, 12, 0)
-        # Creation was superseded, so latest pending is reschedule by org
         schedule.reject(actor_id=cp, now=t2)
         assert schedule.status == ScheduleStatus.CONFIRMED
 


### PR DESCRIPTION
## 概要

Schedulingコンテキストのドメインモデル（Schedule集約）を実装。Issue #19 の設計に従い、エンティティ・値オブジェクト・ドメインイベント・ドメイン例外・ユニットテストを追加。

### 実装内容

- **値オブジェクト**: `ScheduleStatus`, `ConfirmationRequestId`, `ConfirmationRequestType`, `ConfirmationResolution`
- **子エンティティ**: `ConfirmationRequest`（承認リクエストのライフサイクル管理）
- **集約ルート**: `Schedule`（create / confirm / reject / reschedule / cancel / auto_confirm）
- **ドメインイベント**: `ScheduleCreated`, `ScheduleConfirmed`, `ScheduleRejected`, `ScheduleRescheduled`, `ScheduleCancelled`
- **ドメイン例外**: `ScheduleAlreadyCancelledError`, `UnauthorizedScheduleOperationError`, `InvalidScheduleOperationError`, `NoPendingConfirmationRequestError`
- **ユニットテスト**: 45件（受け入れ基準の全シナリオ + 集約不変条件テスト）

### 設計ポイント

- 競合判定はアプリケーション層で実施する設計のため、このPRのスコープ外。`ScheduleConflictError` は未使用のため削除済み
- `ConfirmationRequest` は Schedule の子エンティティとして内包し、履歴を保持
- `scheduled_at` は confirm 時のみ更新（reschedule 提案中は変わらない）
- 自動承認（`auto_confirm`）は actor 不要のシステム操作として実装
- reschedule の reject 時、過去に承認済みリクエストが存在する場合のみ CONFIRMED に戻し、未承認の場合は CANCELLED に遷移

## テスト計画

- [x] `ruff check` / `ruff format --check` パス
- [x] `pyright` 型チェック 0 errors
- [x] `pytest -m "not integration"` 110件全テストパス（新規45件含む）

Refs #19
