### PR TITLE
feat: add Schedule repository, SQLAlchemy models, and Alembic migration

### DIFF
--- a/backend/contexts/preparation/domain/schedule_repository.py
+++ b/backend/contexts/preparation/domain/schedule_repository.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.value_objects import ScheduleId
+
+
+class ScheduleRepository(ABC):
+    """Interface for Schedule aggregate persistence."""
+
+    @abstractmethod
+    async def find_by_id(self, schedule_id: ScheduleId) -> Schedule | None:
+        """Retrieve a Schedule by its ID, or None if not found."""
+        ...
+
+    @abstractmethod
+    async def save(self, schedule: Schedule) -> None:
+        """Persist a Schedule (insert or update)."""
+        ...

--- a/backend/contexts/preparation/infrastructure/models.py
+++ b/backend/contexts/preparation/infrastructure/models.py
@@ -1,0 +1,65 @@
+"""SQLAlchemy ORM models for the Preparation context."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from foundation.db.base import Base
+
+
+class ScheduleRow(Base):
+    """ORM model for the schedules table."""
+
+    __tablename__ = "schedules"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    organizer_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    counterpart_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    scheduled_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    status: Mapped[str] = mapped_column(
+        Enum("requested", "confirmed", "cancelled", name="schedule_status"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    confirmation_requests: Mapped[list["ConfirmationRequestRow"]] = relationship(
+        back_populates="schedule",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="ConfirmationRequestRow.created_at",
+    )
+
+
+class ConfirmationRequestRow(Base):
+    """ORM model for the confirmation_requests table."""
+
+    __tablename__ = "confirmation_requests"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    schedule_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("schedules.id"), nullable=False, index=True
+    )
+    request_type: Mapped[str] = mapped_column(
+        Enum("creation", "reschedule", name="confirmation_request_type"),
+        nullable=False,
+    )
+    requested_by: Mapped[str] = mapped_column(String(36), nullable=False)
+    proposed_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    resolution: Mapped[str] = mapped_column(
+        Enum(
+            "pending",
+            "approved",
+            "rejected",
+            "superseded",
+            name="confirmation_resolution",
+        ),
+        nullable=False,
+    )
+    resolved_by: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    schedule: Mapped["ScheduleRow"] = relationship(
+        back_populates="confirmation_requests",
+    )

--- a/backend/contexts/preparation/infrastructure/models.py
+++ b/backend/contexts/preparation/infrastructure/models.py
@@ -16,13 +16,19 @@ class ScheduleRow(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     organizer_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
     counterpart_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
-    scheduled_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    scheduled_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
     status: Mapped[str] = mapped_column(
         Enum("requested", "confirmed", "cancelled", name="schedule_status"),
         nullable=False,
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
     confirmation_requests: Mapped[list["ConfirmationRequestRow"]] = relationship(
         back_populates="schedule",
@@ -46,7 +52,9 @@ class ConfirmationRequestRow(Base):
         nullable=False,
     )
     requested_by: Mapped[str] = mapped_column(String(36), nullable=False)
-    proposed_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    proposed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
     resolution: Mapped[str] = mapped_column(
         Enum(
             "pending",
@@ -58,7 +66,9 @@ class ConfirmationRequestRow(Base):
         nullable=False,
     )
     resolved_by: Mapped[str | None] = mapped_column(String(36), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
     schedule: Mapped["ScheduleRow"] = relationship(
         back_populates="confirmation_requests",

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
@@ -1,0 +1,96 @@
+"""SQLAlchemy implementation of ScheduleRepository."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.confirmation_request import ConfirmationRequest
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.value_objects import (
+    ConfirmationRequestId,
+    ConfirmationRequestType,
+    ConfirmationResolution,
+    ScheduleId,
+    ScheduleStatus,
+)
+from contexts.preparation.infrastructure.models import (
+    ConfirmationRequestRow,
+    ScheduleRow,
+)
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyScheduleRepository(ScheduleRepository):
+    """SQLAlchemy-based repository for Schedule aggregates."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def find_by_id(self, schedule_id: ScheduleId) -> Schedule | None:
+        """Retrieve a Schedule by its ID, or None if not found."""
+        stmt = select(ScheduleRow).where(ScheduleRow.id == str(schedule_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return _row_to_entity(row)
+
+    async def save(self, schedule: Schedule) -> None:
+        """Persist a Schedule (insert or update via merge)."""
+        row = _entity_to_row(schedule)
+        await self._session.merge(row)
+        await self._session.flush()
+
+
+def _row_to_entity(row: ScheduleRow) -> Schedule:
+    """Map a ScheduleRow (with loaded ConfirmationRequestRows) to a domain Schedule."""
+    confirmation_requests = [
+        ConfirmationRequest(
+            id=ConfirmationRequestId.from_str(cr.id),
+            request_type=ConfirmationRequestType(cr.request_type),
+            requested_by=UserId.from_str(cr.requested_by),
+            proposed_at=cr.proposed_at,
+            _resolution=ConfirmationResolution(cr.resolution),
+            _resolved_by=UserId.from_str(cr.resolved_by) if cr.resolved_by else None,
+            created_at=cr.created_at,
+        )
+        for cr in row.confirmation_requests
+    ]
+
+    return Schedule(
+        id=ScheduleId.from_str(row.id),
+        organizer_id=UserId.from_str(row.organizer_id),
+        counterpart_id=UserId.from_str(row.counterpart_id),
+        _scheduled_at=row.scheduled_at,
+        _status=ScheduleStatus(row.status),
+        _confirmation_requests=confirmation_requests,
+        created_at=row.created_at,
+        _updated_at=row.updated_at,
+    )
+
+
+def _entity_to_row(schedule: Schedule) -> ScheduleRow:
+    """Map a domain Schedule to a ScheduleRow (with child rows)."""
+    row = ScheduleRow(
+        id=str(schedule.id.value),
+        organizer_id=str(schedule.organizer_id.value),
+        counterpart_id=str(schedule.counterpart_id.value),
+        scheduled_at=schedule.scheduled_at,
+        status=schedule.status.value,
+        created_at=schedule.created_at,
+        updated_at=schedule.updated_at,
+    )
+    row.confirmation_requests = [
+        ConfirmationRequestRow(
+            id=str(cr.id.value),
+            schedule_id=str(schedule.id.value),
+            request_type=cr.request_type.value,
+            requested_by=str(cr.requested_by.value),
+            proposed_at=cr.proposed_at,
+            resolution=cr.resolution.value,
+            resolved_by=str(cr.resolved_by.value) if cr.resolved_by else None,
+            created_at=cr.created_at,
+        )
+        for cr in schedule.confirmation_requests
+    ]
+    return row

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
@@ -38,6 +38,8 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
     async def save(self, schedule: Schedule) -> None:
         """Persist a Schedule (insert or update via merge)."""
         row = _entity_to_row(schedule)
+        # Note: merge does not delete orphaned children. This is safe because
+        # the domain model only adds ConfirmationRequests, never removes them.
         await self._session.merge(row)
         await self._session.flush()
 

--- a/backend/foundation/db/base.py
+++ b/backend/foundation/db/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy declarative base for all ORM models."""

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -5,14 +5,16 @@ from alembic import context
 from sqlalchemy import Connection, pool
 from sqlalchemy.ext.asyncio import create_async_engine
 
+import contexts.preparation.infrastructure.models  # noqa: F401
 from foundation.config.settings import settings
+from foundation.db.base import Base
 
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = None
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:

--- a/backend/migrations/versions/001_create_schedules_and_confirmation_requests.py
+++ b/backend/migrations/versions/001_create_schedules_and_confirmation_requests.py
@@ -22,14 +22,14 @@ def upgrade() -> None:
         sa.Column("id", sa.String(36), primary_key=True),
         sa.Column("organizer_id", sa.String(36), nullable=False, index=True),
         sa.Column("counterpart_id", sa.String(36), nullable=False, index=True),
-        sa.Column("scheduled_at", sa.DateTime, nullable=False),
+        sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column(
             "status",
             sa.Enum("requested", "confirmed", "cancelled", name="schedule_status"),
             nullable=False,
         ),
-        sa.Column("created_at", sa.DateTime, nullable=False),
-        sa.Column("updated_at", sa.DateTime, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
     )
 
     op.create_table(
@@ -48,7 +48,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("requested_by", sa.String(36), nullable=False),
-        sa.Column("proposed_at", sa.DateTime, nullable=False),
+        sa.Column("proposed_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column(
             "resolution",
             sa.Enum(
@@ -61,7 +61,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("resolved_by", sa.String(36), nullable=True),
-        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
     )
 
 

--- a/backend/migrations/versions/001_create_schedules_and_confirmation_requests.py
+++ b/backend/migrations/versions/001_create_schedules_and_confirmation_requests.py
@@ -1,0 +1,70 @@
+"""create schedules and confirmation_requests tables
+
+Revision ID: 001
+Revises:
+Create Date: 2026-03-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "schedules",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("organizer_id", sa.String(36), nullable=False, index=True),
+        sa.Column("counterpart_id", sa.String(36), nullable=False, index=True),
+        sa.Column("scheduled_at", sa.DateTime, nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("requested", "confirmed", "cancelled", name="schedule_status"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "confirmation_requests",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "schedule_id",
+            sa.String(36),
+            sa.ForeignKey("schedules.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "request_type",
+            sa.Enum("creation", "reschedule", name="confirmation_request_type"),
+            nullable=False,
+        ),
+        sa.Column("requested_by", sa.String(36), nullable=False),
+        sa.Column("proposed_at", sa.DateTime, nullable=False),
+        sa.Column(
+            "resolution",
+            sa.Enum(
+                "pending",
+                "approved",
+                "rejected",
+                "superseded",
+                name="confirmation_resolution",
+            ),
+            nullable=False,
+        ),
+        sa.Column("resolved_by", sa.String(36), nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("confirmation_requests")
+    op.drop_table("schedules")

--- a/backend/tests/contexts/preparation/infrastructure/test_schedule_mapping.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_schedule_mapping.py
@@ -1,0 +1,166 @@
+"""Tests for Schedule <-> ScheduleRow mapping functions.
+
+These tests verify that domain entities can be correctly converted to ORM rows
+and back without data loss. No database is required.
+"""
+
+from datetime import datetime
+
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.value_objects import (
+    ConfirmationResolution,
+    ScheduleStatus,
+)
+from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+    _entity_to_row,
+    _row_to_entity,
+)
+from shared.domain.value_objects import UserId
+
+_NOW = datetime(2026, 3, 20, 10, 0)
+_FUTURE = datetime(2026, 4, 1, 10, 0)
+_LATER = datetime(2026, 3, 20, 11, 0)
+
+
+def _make_schedule() -> Schedule:
+    """Create a simple requested schedule for mapping tests."""
+    org = UserId.generate()
+    cp = UserId.generate()
+    return Schedule.create(
+        organizer_id=org,
+        counterpart_id=cp,
+        scheduled_at=_FUTURE,
+        requested_by=org,
+        now=_NOW,
+    )
+
+
+def _make_confirmed_schedule() -> Schedule:
+    """Create a confirmed schedule for mapping tests."""
+    org = UserId.generate()
+    cp = UserId.generate()
+    schedule = Schedule.create(
+        organizer_id=org,
+        counterpart_id=cp,
+        scheduled_at=_FUTURE,
+        requested_by=org,
+        now=_NOW,
+    )
+    schedule.confirm(actor_id=cp, now=_LATER)
+    return schedule
+
+
+class TestEntityToRowMapping:
+    def test_schedule_fields_are_mapped(self) -> None:
+        schedule = _make_schedule()
+        row = _entity_to_row(schedule)
+
+        assert row.id == str(schedule.id.value)
+        assert row.organizer_id == str(schedule.organizer_id.value)
+        assert row.counterpart_id == str(schedule.counterpart_id.value)
+        assert row.scheduled_at == schedule.scheduled_at
+        assert row.status == schedule.status.value
+        assert row.created_at == schedule.created_at
+        assert row.updated_at == schedule.updated_at
+
+    def test_confirmation_requests_are_mapped(self) -> None:
+        schedule = _make_schedule()
+        row = _entity_to_row(schedule)
+
+        assert len(row.confirmation_requests) == 1
+        cr_row = row.confirmation_requests[0]
+        cr = schedule.confirmation_requests[0]
+        assert cr_row.id == str(cr.id.value)
+        assert cr_row.schedule_id == str(schedule.id.value)
+        assert cr_row.request_type == cr.request_type.value
+        assert cr_row.requested_by == str(cr.requested_by.value)
+        assert cr_row.proposed_at == cr.proposed_at
+        assert cr_row.resolution == cr.resolution.value
+        assert cr_row.resolved_by is None
+
+    def test_confirmed_schedule_maps_resolved_by(self) -> None:
+        schedule = _make_confirmed_schedule()
+        row = _entity_to_row(schedule)
+
+        approved = [
+            cr for cr in row.confirmation_requests if cr.resolution == "approved"
+        ]
+        assert len(approved) == 1
+        assert approved[0].resolved_by is not None
+
+
+class TestRowToEntityMapping:
+    def test_roundtrip_preserves_schedule_fields(self) -> None:
+        original = _make_schedule()
+        original.collect_events()  # clear events before roundtrip
+
+        row = _entity_to_row(original)
+        restored = _row_to_entity(row)
+
+        assert restored.id == original.id
+        assert restored.organizer_id == original.organizer_id
+        assert restored.counterpart_id == original.counterpart_id
+        assert restored.scheduled_at == original.scheduled_at
+        assert restored.status == original.status
+        assert restored.created_at == original.created_at
+        assert restored.updated_at == original.updated_at
+
+    def test_roundtrip_preserves_confirmation_requests(self) -> None:
+        original = _make_schedule()
+        original.collect_events()
+
+        row = _entity_to_row(original)
+        restored = _row_to_entity(row)
+
+        orig_count = len(original.confirmation_requests)
+        assert len(restored.confirmation_requests) == orig_count
+        orig_cr = original.confirmation_requests[0]
+        rest_cr = restored.confirmation_requests[0]
+        assert rest_cr.id == orig_cr.id
+        assert rest_cr.request_type == orig_cr.request_type
+        assert rest_cr.requested_by == orig_cr.requested_by
+        assert rest_cr.proposed_at == orig_cr.proposed_at
+        assert rest_cr.resolution == orig_cr.resolution
+        assert rest_cr.resolved_by == orig_cr.resolved_by
+
+    def test_roundtrip_confirmed_schedule(self) -> None:
+        original = _make_confirmed_schedule()
+        original.collect_events()
+
+        row = _entity_to_row(original)
+        restored = _row_to_entity(row)
+
+        assert restored.status == ScheduleStatus.CONFIRMED
+        assert len(restored.confirmation_requests) == 1
+        cr = restored.confirmation_requests[0]
+        assert cr.resolution == ConfirmationResolution.APPROVED
+
+    def test_roundtrip_with_multiple_confirmation_requests(self) -> None:
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = Schedule.create(
+            organizer_id=org,
+            counterpart_id=cp,
+            scheduled_at=_FUTURE,
+            requested_by=org,
+            now=_NOW,
+        )
+        schedule.confirm(actor_id=cp, now=_LATER)
+        new_time = datetime(2026, 5, 1, 10, 0)
+        schedule.reschedule(actor_id=org, new_proposed_at=new_time, now=_LATER)
+        schedule.collect_events()
+
+        row = _entity_to_row(schedule)
+        restored = _row_to_entity(row)
+
+        assert len(restored.confirmation_requests) == 2
+        assert restored.status == ScheduleStatus.REQUESTED
+
+    def test_restored_entity_has_no_events(self) -> None:
+        """Entities loaded from DB should have an empty events list."""
+        original = _make_schedule()
+        row = _entity_to_row(original)
+        restored = _row_to_entity(row)
+
+        events = restored.collect_events()
+        assert events == []


### PR DESCRIPTION
## Summary

Preparationコンテキストのリポジトリインターフェース・SQLAlchemy実装・Alembicマイグレーションを追加する。

### 変更内容

- **ScheduleRepository**: ドメイン層にリポジトリインターフェース（`find_by_id`, `save`）を追加
- **SQLAlchemy ORMモデル**: `ScheduleRow`, `ConfirmationRequestRow` を追加（`schedules`, `confirmation_requests` テーブル）
- **SqlAlchemyScheduleRepository**: リポジトリの SQLAlchemy 実装。ドメインエンティティとORMモデル間の双方向マッピングを含む
- **Alembicマイグレーション**: `schedules` と `confirmation_requests` テーブルの作成（001）
- **DeclarativeBase**: `foundation/db/base.py` にSQLAlchemy共通ベースクラスを追加
- **env.py更新**: `Base.metadata` をAlembicの `target_metadata` に設定し、ORMモデルのインポートを追加
- **マッピングテスト**: エンティティ→Row、Row→エンティティのラウンドトリップテストを追加

Closes #24

## Test plan

- [x] 既存の全ユニットテスト（118件）が通ること
- [x] マッピングのラウンドトリップテストでデータ損失がないこと
- [x] ruff lint / format チェック通過
- [x] pyright 型チェック通過
- [ ] integration テスト（テスト用MariaDBコンテナ）でのDB操作確認は別Issue