### PR TITLE
feat: add Preparation domain models (ScheduleGroup, Agenda, Template)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -76,6 +76,7 @@ git checkout -b feature/$ARGUMENTS-<説明>
 - **ドメイン層**: 純粋な Python で書く。FastAPI・SQLAlchemy 等のフレームワーク依存なし
 - **ドメイン例外**: ビジネスルール違反には `ValueError` / `PermissionError` ではなくドメイン固有の例外クラスを使う（例: `RecordAlreadyPublishedError`）。コンテキストの `domain/exceptions.py` に配置する
 - **フィールドのカプセル化**: 状態遷移や不変条件を持つフィールド、およびドメインメソッド経由でのみ変更すべきフィールドは `_` プレフィックス + read-only `@property` で公開し、直接代入を防ぐ
+- **値オブジェクトの配置**: ID型・Enumは `domain/value_objects.py` にまとめる。ドメイン固有のバリデーションを持つ値オブジェクト（`Topic`, `CommentBody` 等）は `domain/<vo_name>.py` として個別ファイルに切り出す
 - **ドメインイベント管理**: イベントは `_events` リストに蓄積し、`collect_events()` メソッドで取得＆クリアする
 - **datetime の扱い**: ファクトリメソッド（`create()`）では `now: datetime | None = None` で `datetime.now(UTC)` フォールバック可。操作メソッドでは `now: datetime` を必須引数にする
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -47,6 +47,7 @@ PR 本文に Issue リンクがある場合、`gh issue view` で Issue の完�
 - **ドメイン層**: 純粋な Python で書かれているか（FastAPI・SQLAlchemy 等のフレームワーク依存なし）
 - **ドメイン例外**: ビジネスルール違反に `ValueError` / `PermissionError` ではなくドメイン固有の例外を使っているか（`domain/exceptions.py` に配置）
 - **フィールドのカプセル化**: 状態遷移・不変条件を持つフィールドやドメインメソッド経由でのみ変更すべきフィールドが `_` プレフィックス + read-only `@property` で保護されているか（直接代入で不変条件を迂回できないこと）
+- **値オブジェクトの配置**: ID型・Enumは `domain/value_objects.py`、ドメイン固有のバリデーションを持つ値オブジェクト（`Topic`, `CommentBody` 等）は `domain/<vo_name>.py` として個別ファイルに配置されているか
 - **ドメインイベント管理**: イベントが `_events` + `collect_events()` パターンで管理されているか
 - **datetime の扱い**: ファクトリメソッドでは `now: datetime | None = None`（`datetime.now(UTC)` フォールバック可）、操作メソッドでは `now: datetime` 必須になっているか
 - **配置**: ファイルが適切なコンテキスト・レイヤーに配置されているか

--- a/backend/contexts/preparation/domain/agenda.py
+++ b/backend/contexts/preparation/domain/agenda.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from contexts.preparation.domain.comment import Comment
+from contexts.preparation.domain.topic import Topic
 from contexts.preparation.domain.value_objects import AgendaId, CommentId, ScheduleId
 from shared.domain.value_objects import UserId
 
@@ -24,7 +25,7 @@ class Agenda:
 
     _id: AgendaId
     _schedule_id: ScheduleId
-    _topic: str
+    _topic: Topic
     _added_by: UserId
     _comments: list[Comment]
     _created_at: datetime
@@ -39,7 +40,7 @@ class Agenda:
 
     @property
     def topic(self) -> str:
-        return self._topic
+        return self._topic.value
 
     @property
     def added_by(self) -> UserId:
@@ -61,12 +62,17 @@ class Agenda:
         added_by: UserId,
         now: datetime | None = None,
     ) -> Agenda:
-        """Factory method to create a new agenda item."""
+        """Factory method to create a new agenda item.
+
+        Raises:
+            InvalidTopicError: If topic is empty, contains newlines,
+                or exceeds max length.
+        """
         ts = now or datetime.now(UTC)
         return Agenda(
             _id=AgendaId.generate(),
             _schedule_id=schedule_id,
-            _topic=topic,
+            _topic=Topic(topic),
             _added_by=added_by,
             _comments=[],
             _created_at=ts,

--- a/backend/contexts/preparation/domain/agenda.py
+++ b/backend/contexts/preparation/domain/agenda.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.comment import Comment
+from contexts.preparation.domain.value_objects import AgendaId, CommentId, ScheduleId
+from shared.domain.value_objects import UserId
+
+
+@dataclass
+class Agenda:
+    """Entity: an agenda topic attached to a Schedule.
+
+    An agenda is a topic prepared before a 1-on-1 meeting.
+    It can have a comment thread (both organizer and counterpart can comment).
+
+    Agendas are created either:
+    - Via ScheduleGroup bulk operations (expanded from AgendaTemplate)
+    - Directly added to an individual Schedule
+
+    Post-hoc records (pattern C) do not have agendas.
+    """
+
+    id: AgendaId
+    schedule_id: ScheduleId
+    topic: str
+    added_by: UserId
+    _comments: list[Comment]
+    created_at: datetime
+
+    @property
+    def comments(self) -> list[Comment]:
+        return list(self._comments)
+
+    @staticmethod
+    def create(
+        *,
+        schedule_id: ScheduleId,
+        topic: str,
+        added_by: UserId,
+        now: datetime | None = None,
+    ) -> Agenda:
+        """Factory method to create a new agenda item."""
+        ts = now or datetime.now(UTC)
+        return Agenda(
+            id=AgendaId.generate(),
+            schedule_id=schedule_id,
+            topic=topic,
+            added_by=added_by,
+            _comments=[],
+            created_at=ts,
+        )
+
+    def add_comment(self, *, author_id: UserId, body: str, now: datetime) -> Comment:
+        """Add a comment to this agenda topic.
+
+        Both organizer and counterpart can comment (no restriction).
+        """
+        comment = Comment.create(
+            agenda_id=self.id,
+            author_id=author_id,
+            body=body,
+            now=now,
+        )
+        self._comments.append(comment)
+        return comment
+
+    def find_comment(self, comment_id: CommentId) -> Comment | None:
+        """Find a comment by its ID."""
+        for comment in self._comments:
+            if comment.id == comment_id:
+                return comment
+        return None

--- a/backend/contexts/preparation/domain/agenda.py
+++ b/backend/contexts/preparation/domain/agenda.py
@@ -39,8 +39,8 @@ class Agenda:
         return self._schedule_id
 
     @property
-    def topic(self) -> str:
-        return self._topic.value
+    def topic(self) -> Topic:
+        return self._topic
 
     @property
     def added_by(self) -> UserId:

--- a/backend/contexts/preparation/domain/agenda.py
+++ b/backend/contexts/preparation/domain/agenda.py
@@ -22,16 +22,36 @@ class Agenda:
     Post-hoc records (pattern C) do not have agendas.
     """
 
-    id: AgendaId
-    schedule_id: ScheduleId
-    topic: str
-    added_by: UserId
+    _id: AgendaId
+    _schedule_id: ScheduleId
+    _topic: str
+    _added_by: UserId
     _comments: list[Comment]
-    created_at: datetime
+    _created_at: datetime
+
+    @property
+    def id(self) -> AgendaId:
+        return self._id
+
+    @property
+    def schedule_id(self) -> ScheduleId:
+        return self._schedule_id
+
+    @property
+    def topic(self) -> str:
+        return self._topic
+
+    @property
+    def added_by(self) -> UserId:
+        return self._added_by
 
     @property
     def comments(self) -> list[Comment]:
         return list(self._comments)
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
 
     @staticmethod
     def create(
@@ -44,12 +64,12 @@ class Agenda:
         """Factory method to create a new agenda item."""
         ts = now or datetime.now(UTC)
         return Agenda(
-            id=AgendaId.generate(),
-            schedule_id=schedule_id,
-            topic=topic,
-            added_by=added_by,
+            _id=AgendaId.generate(),
+            _schedule_id=schedule_id,
+            _topic=topic,
+            _added_by=added_by,
             _comments=[],
-            created_at=ts,
+            _created_at=ts,
         )
 
     def add_comment(self, *, author_id: UserId, body: str, now: datetime) -> Comment:
@@ -58,7 +78,7 @@ class Agenda:
         Both organizer and counterpart can comment (no restriction).
         """
         comment = Comment.create(
-            agenda_id=self.id,
+            agenda_id=self._id,
             author_id=author_id,
             body=body,
             now=now,

--- a/backend/contexts/preparation/domain/agenda_template.py
+++ b/backend/contexts/preparation/domain/agenda_template.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from contexts.preparation.domain.exceptions import InvalidAgendaTopicError
-
-_AGENDA_TOPIC_MAX_LENGTH = 200
+from contexts.preparation.domain.topic import Topic
 
 
 @dataclass(frozen=True)
@@ -15,26 +13,13 @@ class AgendaTemplate:
     that will be expanded into Agenda entities when Schedules are created.
     Order is expressed by position in the containing list.
 
-    Invariants:
-    - Topic must not be empty (after stripping whitespace).
-    - Topic must not contain newlines.
-    - Max 200 characters.
-    - Leading/trailing whitespace is stripped.
+    Delegates topic validation to the Topic value object.
     """
 
-    topic: str
+    topic: Topic
 
     def __init__(self, topic: str) -> None:
-        stripped = topic.strip()
-        if not stripped:
-            raise InvalidAgendaTopicError("Agenda topic must not be empty.")
-        if "\n" in stripped or "\r" in stripped:
-            raise InvalidAgendaTopicError("Agenda topic must not contain newlines.")
-        if len(stripped) > _AGENDA_TOPIC_MAX_LENGTH:
-            raise InvalidAgendaTopicError(
-                f"Agenda topic must not exceed {_AGENDA_TOPIC_MAX_LENGTH} characters."
-            )
-        object.__setattr__(self, "topic", stripped)
+        object.__setattr__(self, "topic", Topic(topic))
 
     def __str__(self) -> str:
-        return self.topic
+        return str(self.topic)

--- a/backend/contexts/preparation/domain/agenda_template.py
+++ b/backend/contexts/preparation/domain/agenda_template.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contexts.preparation.domain.exceptions import InvalidAgendaTopicError
+
+_AGENDA_TOPIC_MAX_LENGTH = 200
+
+
+@dataclass(frozen=True)
+class AgendaTemplate:
+    """Value object: a topic name template for agenda items.
+
+    Used by both ScheduleGroup and Template to define agenda topics
+    that will be expanded into Agenda entities when Schedules are created.
+    Order is expressed by position in the containing list.
+
+    Invariants:
+    - Topic must not be empty (after stripping whitespace).
+    - Topic must not contain newlines.
+    - Max 200 characters.
+    - Leading/trailing whitespace is stripped.
+    """
+
+    topic: str
+
+    def __init__(self, topic: str) -> None:
+        stripped = topic.strip()
+        if not stripped:
+            raise InvalidAgendaTopicError("Agenda topic must not be empty.")
+        if "\n" in stripped or "\r" in stripped:
+            raise InvalidAgendaTopicError("Agenda topic must not contain newlines.")
+        if len(stripped) > _AGENDA_TOPIC_MAX_LENGTH:
+            raise InvalidAgendaTopicError(
+                f"Agenda topic must not exceed {_AGENDA_TOPIC_MAX_LENGTH} characters."
+            )
+        object.__setattr__(self, "topic", stripped)
+
+    def __str__(self) -> str:
+        return self.topic

--- a/backend/contexts/preparation/domain/comment.py
+++ b/backend/contexts/preparation/domain/comment.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from contexts.preparation.domain.exceptions import InvalidCommentBodyError
+from contexts.preparation.domain.comment_body import CommentBody
 from contexts.preparation.domain.value_objects import AgendaId, CommentId
 from shared.domain.value_objects import UserId
-
-_COMMENT_BODY_MAX_LENGTH = 2000
 
 
 @dataclass
@@ -21,7 +19,7 @@ class Comment:
     _id: CommentId
     _agenda_id: AgendaId
     _author_id: UserId
-    _body: str
+    _body: CommentBody
     _created_at: datetime
 
     @property
@@ -38,7 +36,7 @@ class Comment:
 
     @property
     def body(self) -> str:
-        return self._body
+        return self._body.value
 
     @property
     def created_at(self) -> datetime:
@@ -58,23 +56,10 @@ class Comment:
             InvalidCommentBodyError: If body is empty or exceeds max length.
         """
         ts = now or datetime.now(UTC)
-        validated_body = _validate_comment_body(body)
         return Comment(
             _id=CommentId.generate(),
             _agenda_id=agenda_id,
             _author_id=author_id,
-            _body=validated_body,
+            _body=CommentBody(body),
             _created_at=ts,
         )
-
-
-def _validate_comment_body(body: str) -> str:
-    """Validate and normalize a comment body."""
-    stripped = body.strip()
-    if not stripped:
-        raise InvalidCommentBodyError("Comment body must not be empty.")
-    if len(stripped) > _COMMENT_BODY_MAX_LENGTH:
-        raise InvalidCommentBodyError(
-            f"Comment body must not exceed {_COMMENT_BODY_MAX_LENGTH} characters."
-        )
-    return stripped

--- a/backend/contexts/preparation/domain/comment.py
+++ b/backend/contexts/preparation/domain/comment.py
@@ -35,8 +35,8 @@ class Comment:
         return self._author_id
 
     @property
-    def body(self) -> str:
-        return self._body.value
+    def body(self) -> CommentBody:
+        return self._body
 
     @property
     def created_at(self) -> datetime:

--- a/backend/contexts/preparation/domain/comment.py
+++ b/backend/contexts/preparation/domain/comment.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.value_objects import AgendaId, CommentId
+from shared.domain.value_objects import UserId
+
+
+@dataclass
+class Comment:
+    """Child entity of Agenda representing a comment on an agenda topic.
+
+    Both organizer and counterpart can add comments.
+    Comments are always public (no private comments).
+    """
+
+    id: CommentId
+    agenda_id: AgendaId
+    author_id: UserId
+    body: str
+    created_at: datetime
+
+    @staticmethod
+    def create(
+        *,
+        agenda_id: AgendaId,
+        author_id: UserId,
+        body: str,
+        now: datetime | None = None,
+    ) -> Comment:
+        """Factory method to create a new comment."""
+        ts = now or datetime.now(UTC)
+        return Comment(
+            id=CommentId.generate(),
+            agenda_id=agenda_id,
+            author_id=author_id,
+            body=body,
+            created_at=ts,
+        )

--- a/backend/contexts/preparation/domain/comment.py
+++ b/backend/contexts/preparation/domain/comment.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from contexts.preparation.domain.exceptions import InvalidCommentBodyError
 from contexts.preparation.domain.value_objects import AgendaId, CommentId
 from shared.domain.value_objects import UserId
+
+_COMMENT_BODY_MAX_LENGTH = 2000
 
 
 @dataclass
@@ -15,11 +18,31 @@ class Comment:
     Comments are always public (no private comments).
     """
 
-    id: CommentId
-    agenda_id: AgendaId
-    author_id: UserId
-    body: str
-    created_at: datetime
+    _id: CommentId
+    _agenda_id: AgendaId
+    _author_id: UserId
+    _body: str
+    _created_at: datetime
+
+    @property
+    def id(self) -> CommentId:
+        return self._id
+
+    @property
+    def agenda_id(self) -> AgendaId:
+        return self._agenda_id
+
+    @property
+    def author_id(self) -> UserId:
+        return self._author_id
+
+    @property
+    def body(self) -> str:
+        return self._body
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
 
     @staticmethod
     def create(
@@ -29,12 +52,29 @@ class Comment:
         body: str,
         now: datetime | None = None,
     ) -> Comment:
-        """Factory method to create a new comment."""
+        """Factory method to create a new comment.
+
+        Raises:
+            InvalidCommentBodyError: If body is empty or exceeds max length.
+        """
         ts = now or datetime.now(UTC)
+        validated_body = _validate_comment_body(body)
         return Comment(
-            id=CommentId.generate(),
-            agenda_id=agenda_id,
-            author_id=author_id,
-            body=body,
-            created_at=ts,
+            _id=CommentId.generate(),
+            _agenda_id=agenda_id,
+            _author_id=author_id,
+            _body=validated_body,
+            _created_at=ts,
         )
+
+
+def _validate_comment_body(body: str) -> str:
+    """Validate and normalize a comment body."""
+    stripped = body.strip()
+    if not stripped:
+        raise InvalidCommentBodyError("Comment body must not be empty.")
+    if len(stripped) > _COMMENT_BODY_MAX_LENGTH:
+        raise InvalidCommentBodyError(
+            f"Comment body must not exceed {_COMMENT_BODY_MAX_LENGTH} characters."
+        )
+    return stripped

--- a/backend/contexts/preparation/domain/comment_body.py
+++ b/backend/contexts/preparation/domain/comment_body.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contexts.preparation.domain.exceptions import InvalidCommentBodyError
+
+_COMMENT_BODY_MAX_LENGTH = 2000
+
+
+@dataclass(frozen=True)
+class CommentBody:
+    """Value object representing a comment body string.
+
+    Invariants:
+    - Must not be empty (after stripping whitespace).
+    - Max 2000 characters.
+    - Leading/trailing whitespace is stripped.
+    """
+
+    value: str
+
+    def __init__(self, value: str) -> None:
+        stripped = value.strip()
+        if not stripped:
+            raise InvalidCommentBodyError("Comment body must not be empty.")
+        if len(stripped) > _COMMENT_BODY_MAX_LENGTH:
+            raise InvalidCommentBodyError(
+                f"Comment body must not exceed {_COMMENT_BODY_MAX_LENGTH} characters."
+            )
+        object.__setattr__(self, "value", stripped)
+
+    def __str__(self) -> str:
+        return self.value

--- a/backend/contexts/preparation/domain/events.py
+++ b/backend/contexts/preparation/domain/events.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.preparation.domain.value_objects import (
+    AgendaId,
+    ScheduleGroupId,
+    ScheduleId,
+    TemplateId,
+)
 from shared.domain.value_objects import UserId
 
 
@@ -63,4 +68,54 @@ class ScheduleCancelled:
     organizer_id: UserId
     counterpart_id: UserId
     cancelled_by: UserId
+    occurred_at: datetime
+
+
+# ------------------------------------------------------------------
+# ScheduleGroup events
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScheduleGroupCreated:
+    """Raised when a new schedule group is created."""
+
+    schedule_group_id: ScheduleGroupId
+    organizer_id: UserId
+    template_id: TemplateId | None
+    occurred_at: datetime
+
+
+@dataclass(frozen=True)
+class AgendaAddedViaGroup:
+    """Raised when an agenda topic is added to all schedules via group."""
+
+    schedule_group_id: ScheduleGroupId
+    topic: str
+    target_schedule_ids: list[ScheduleId]
+    occurred_at: datetime
+
+
+@dataclass(frozen=True)
+class AgendaRemovedViaGroup:
+    """Raised when an agenda topic is removed from all schedules via group."""
+
+    schedule_group_id: ScheduleGroupId
+    topic: str
+    removed_agenda_ids: list[AgendaId]
+    occurred_at: datetime
+
+
+# ------------------------------------------------------------------
+# Template events
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TemplateSaved:
+    """Raised when a template is saved (created or updated)."""
+
+    template_id: TemplateId
+    name: str
+    organizer_id: UserId
     occurred_at: datetime

--- a/backend/contexts/preparation/domain/exceptions.py
+++ b/backend/contexts/preparation/domain/exceptions.py
@@ -59,3 +59,17 @@ class UnauthorizedScheduleGroupOperationError(Exception):
 
     def __init__(self, message: str = "Unauthorized schedule group operation.") -> None:
         super().__init__(message)
+
+
+class UnauthorizedTemplateOperationError(Exception):
+    """Raised when a user without permission attempts a Template operation."""
+
+    def __init__(self, message: str = "Unauthorized template operation.") -> None:
+        super().__init__(message)
+
+
+class InvalidCommentBodyError(Exception):
+    """Raised when a comment body fails validation."""
+
+    def __init__(self, message: str = "Invalid comment body.") -> None:
+        super().__init__(message)

--- a/backend/contexts/preparation/domain/exceptions.py
+++ b/backend/contexts/preparation/domain/exceptions.py
@@ -1,4 +1,4 @@
-"""Domain exceptions for the scheduling context."""
+"""Domain exceptions for the preparation context."""
 
 
 class ScheduleAlreadyCancelledError(Exception):
@@ -26,4 +26,36 @@ class NoPendingConfirmationRequestError(Exception):
     """Raised when confirm/reject is attempted without a pending request."""
 
     def __init__(self, message: str = "No pending confirmation request.") -> None:
+        super().__init__(message)
+
+
+class InvalidAgendaTopicError(Exception):
+    """Raised when an agenda topic fails validation."""
+
+    def __init__(self, message: str = "Invalid agenda topic.") -> None:
+        super().__init__(message)
+
+
+class InvalidTemplateNameError(Exception):
+    """Raised when a template name fails validation."""
+
+    def __init__(self, message: str = "Invalid template name.") -> None:
+        super().__init__(message)
+
+
+class AgendaEditNotAllowedError(Exception):
+    """Raised when attempting to edit an agenda topic via ScheduleGroup."""
+
+    def __init__(
+        self,
+        message: str = "Editing agenda topics via ScheduleGroup is not allowed. "
+        "Delete and re-add instead.",
+    ) -> None:
+        super().__init__(message)
+
+
+class UnauthorizedScheduleGroupOperationError(Exception):
+    """Raised when a user without permission attempts a ScheduleGroup operation."""
+
+    def __init__(self, message: str = "Unauthorized schedule group operation.") -> None:
         super().__init__(message)

--- a/backend/contexts/preparation/domain/exceptions.py
+++ b/backend/contexts/preparation/domain/exceptions.py
@@ -29,10 +29,10 @@ class NoPendingConfirmationRequestError(Exception):
         super().__init__(message)
 
 
-class InvalidAgendaTopicError(Exception):
-    """Raised when an agenda topic fails validation."""
+class InvalidTopicError(Exception):
+    """Raised when a topic value fails validation."""
 
-    def __init__(self, message: str = "Invalid agenda topic.") -> None:
+    def __init__(self, message: str = "Invalid topic.") -> None:
         super().__init__(message)
 
 

--- a/backend/contexts/preparation/domain/exceptions.py
+++ b/backend/contexts/preparation/domain/exceptions.py
@@ -54,6 +54,17 @@ class AgendaEditNotAllowedError(Exception):
         super().__init__(message)
 
 
+class InconsistentScheduleAgendasError(Exception):
+    """Raised when schedules_agendas dict is missing keys
+    for registered schedule IDs."""
+
+    def __init__(
+        self,
+        message: str = "schedules_agendas is missing registered schedule IDs.",
+    ) -> None:
+        super().__init__(message)
+
+
 class UnauthorizedScheduleGroupOperationError(Exception):
     """Raised when a user without permission attempts a ScheduleGroup operation."""
 

--- a/backend/contexts/preparation/domain/schedule.py
+++ b/backend/contexts/preparation/domain/schedule.py
@@ -20,6 +20,7 @@ from contexts.preparation.domain.exceptions import (
 from contexts.preparation.domain.value_objects import (
     ConfirmationRequestType,
     ConfirmationResolution,
+    ScheduleGroupId,
     ScheduleId,
     ScheduleStatus,
 )
@@ -52,6 +53,7 @@ class Schedule:
     id: ScheduleId
     organizer_id: UserId
     counterpart_id: UserId
+    schedule_group_id: ScheduleGroupId | None
     _scheduled_at: datetime
     _status: ScheduleStatus
     _confirmation_requests: list[ConfirmationRequest]
@@ -92,6 +94,7 @@ class Schedule:
         counterpart_id: UserId,
         scheduled_at: datetime,
         requested_by: UserId,
+        schedule_group_id: ScheduleGroupId | None = None,
         now: datetime | None = None,
     ) -> Schedule:
         """Create a new schedule in Requested status.
@@ -102,6 +105,8 @@ class Schedule:
             scheduled_at: Proposed datetime for the meeting.
             requested_by: The user creating the schedule (must be
                 organizer or counterpart).
+            schedule_group_id: Optional group ID if created via
+                ScheduleGroup.
             now: Current time (defaults to UTC now).
 
         Raises:
@@ -138,6 +143,7 @@ class Schedule:
             id=schedule_id,
             organizer_id=organizer_id,
             counterpart_id=counterpart_id,
+            schedule_group_id=schedule_group_id,
             _scheduled_at=scheduled_at,
             _status=ScheduleStatus.REQUESTED,
             _confirmation_requests=[creation_request],

--- a/backend/contexts/preparation/domain/schedule_group.py
+++ b/backend/contexts/preparation/domain/schedule_group.py
@@ -163,7 +163,7 @@ class ScheduleGroup:
         for schedule_id in self._schedule_ids:
             agenda = Agenda.create(
                 schedule_id=schedule_id,
-                topic=agenda_template.topic,
+                topic=agenda_template.topic.value,
                 added_by=actor_id,
                 now=now,
             )
@@ -174,7 +174,7 @@ class ScheduleGroup:
         self._events.append(
             AgendaAddedViaGroup(
                 schedule_group_id=self.id,
-                topic=agenda_template.topic,
+                topic=agenda_template.topic.value,
                 target_schedule_ids=list(self._schedule_ids),
                 occurred_at=now,
             )
@@ -213,7 +213,7 @@ class ScheduleGroup:
         # Remove first matching template; if none found, this is a no-op.
         found = False
         for i, tmpl in enumerate(self._agenda_templates):
-            if tmpl.topic == topic:
+            if tmpl.topic.value == topic:
                 self._agenda_templates.pop(i)
                 found = True
                 break

--- a/backend/contexts/preparation/domain/schedule_group.py
+++ b/backend/contexts/preparation/domain/schedule_group.py
@@ -230,7 +230,7 @@ class ScheduleGroup:
             agendas = schedules_agendas[schedule_id]
             to_remove: list[int] = []
             for idx, agenda in enumerate(agendas):
-                if agenda.topic == topic:
+                if str(agenda.topic) == topic:
                     removed_ids.append(agenda.id)
                     to_remove.append(idx)
                     break  # Remove one matching agenda per schedule

--- a/backend/contexts/preparation/domain/schedule_group.py
+++ b/backend/contexts/preparation/domain/schedule_group.py
@@ -117,8 +117,12 @@ class ScheduleGroup:
     # ------------------------------------------------------------------
 
     def register_schedule(self, schedule_id: ScheduleId) -> None:
-        """Register a schedule as belonging to this group."""
-        self._schedule_ids.append(schedule_id)
+        """Register a schedule as belonging to this group.
+
+        Duplicate registration of the same ScheduleId is silently ignored.
+        """
+        if schedule_id not in self._schedule_ids:
+            self._schedule_ids.append(schedule_id)
 
     def add_agenda_to_schedules(
         self,
@@ -137,7 +141,9 @@ class ScheduleGroup:
             topic: The agenda topic to add.
             actor_id: The user performing the operation (must be organizer).
             schedules_agendas: Mutable agenda lists keyed by schedule ID.
-                New agendas are appended to each list.
+                New agendas are appended to each list. Must contain keys
+                for all registered schedule IDs; missing keys are skipped
+                (new Agenda is still created but not appended to the dict).
             now: Current time.
 
         Returns:
@@ -204,11 +210,16 @@ class ScheduleGroup:
         """
         self._assert_organizer(actor_id)
 
-        # Remove first matching template
+        # Remove first matching template; if none found, this is a no-op.
+        found = False
         for i, tmpl in enumerate(self._agenda_templates):
             if tmpl.topic == topic:
                 self._agenda_templates.pop(i)
+                found = True
                 break
+
+        if not found:
+            return []
 
         self._updated_at = now
 

--- a/backend/contexts/preparation/domain/schedule_group.py
+++ b/backend/contexts/preparation/domain/schedule_group.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.events import (
+    AgendaAddedViaGroup,
+    AgendaRemovedViaGroup,
+    ScheduleGroupCreated,
+)
+from contexts.preparation.domain.exceptions import (
+    UnauthorizedScheduleGroupOperationError,
+)
+from contexts.preparation.domain.value_objects import (
+    AgendaId,
+    ScheduleGroupId,
+    ScheduleId,
+    TemplateId,
+)
+from shared.domain.value_objects import UserId
+
+type _ScheduleGroupEvent = (
+    ScheduleGroupCreated | AgendaAddedViaGroup | AgendaRemovedViaGroup
+)
+
+
+@dataclass
+class ScheduleGroup:
+    """Aggregate root: a batch management unit for 1-on-1 schedules.
+
+    Created by an organizer to register schedules for multiple counterparts
+    at once. Holds agenda templates that are expanded into Agenda entities
+    when individual Schedules are created.
+
+    Business rules:
+    - Only the organizer who created the group can operate on it.
+    - Agenda add/remove propagates to all associated Schedules.
+    - Agenda edit (topic change) is prohibited; use delete + re-add.
+    - Duplicate topics are allowed.
+    - Bulk operations with 0 targets succeed with no side effects.
+    - Failures during bulk operations roll back all changes
+      (synchronous transaction).
+    """
+
+    id: ScheduleGroupId
+    organizer_id: UserId
+    template_id: TemplateId | None
+    _agenda_templates: list[AgendaTemplate]
+    _schedule_ids: list[ScheduleId]
+    created_at: datetime
+    _updated_at: datetime
+    _events: list[_ScheduleGroupEvent] = field(default_factory=list, repr=False)
+
+    @property
+    def agenda_templates(self) -> list[AgendaTemplate]:
+        return list(self._agenda_templates)
+
+    @property
+    def schedule_ids(self) -> list[ScheduleId]:
+        return list(self._schedule_ids)
+
+    @property
+    def updated_at(self) -> datetime:
+        return self._updated_at
+
+    def collect_events(self) -> list[_ScheduleGroupEvent]:
+        """Return accumulated events and clear the internal list."""
+        events = list(self._events)
+        self._events.clear()
+        return events
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create(
+        *,
+        organizer_id: UserId,
+        agenda_templates: list[AgendaTemplate] | None = None,
+        template_id: TemplateId | None = None,
+        now: datetime | None = None,
+    ) -> ScheduleGroup:
+        """Create a new ScheduleGroup.
+
+        Args:
+            organizer_id: The organizer creating this group.
+            agenda_templates: Initial agenda templates (optional).
+            template_id: Source template ID if created from a template.
+            now: Current time (defaults to UTC now).
+        """
+        ts = now or datetime.now(UTC)
+        group_id = ScheduleGroupId.generate()
+        group = ScheduleGroup(
+            id=group_id,
+            organizer_id=organizer_id,
+            template_id=template_id,
+            _agenda_templates=list(agenda_templates) if agenda_templates else [],
+            _schedule_ids=[],
+            created_at=ts,
+            _updated_at=ts,
+        )
+        group._events.append(
+            ScheduleGroupCreated(
+                schedule_group_id=group_id,
+                organizer_id=organizer_id,
+                template_id=template_id,
+                occurred_at=ts,
+            )
+        )
+        return group
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+
+    def register_schedule(self, schedule_id: ScheduleId) -> None:
+        """Register a schedule as belonging to this group."""
+        self._schedule_ids.append(schedule_id)
+
+    def add_agenda_to_schedules(
+        self,
+        *,
+        topic: str,
+        actor_id: UserId,
+        schedules_agendas: dict[ScheduleId, list[Agenda]],
+        now: datetime,
+    ) -> list[Agenda]:
+        """Add an agenda topic to all associated schedules.
+
+        Creates a new AgendaTemplate and expands it into Agenda entities
+        for each schedule. Returns the newly created Agenda entities.
+
+        Args:
+            topic: The agenda topic to add.
+            actor_id: The user performing the operation (must be organizer).
+            schedules_agendas: Mutable agenda lists keyed by schedule ID.
+                New agendas are appended to each list.
+            now: Current time.
+
+        Returns:
+            List of newly created Agenda entities.
+
+        Raises:
+            UnauthorizedScheduleGroupOperationError: If actor is not the
+                organizer.
+        """
+        self._assert_organizer(actor_id)
+
+        agenda_template = AgendaTemplate(topic)
+        self._agenda_templates.append(agenda_template)
+        self._updated_at = now
+
+        new_agendas: list[Agenda] = []
+        for schedule_id in self._schedule_ids:
+            agenda = Agenda.create(
+                schedule_id=schedule_id,
+                topic=agenda_template.topic,
+                added_by=actor_id,
+                now=now,
+            )
+            new_agendas.append(agenda)
+            if schedule_id in schedules_agendas:
+                schedules_agendas[schedule_id].append(agenda)
+
+        self._events.append(
+            AgendaAddedViaGroup(
+                schedule_group_id=self.id,
+                topic=agenda_template.topic,
+                target_schedule_ids=list(self._schedule_ids),
+                occurred_at=now,
+            )
+        )
+        return new_agendas
+
+    def remove_agenda_from_schedules(
+        self,
+        *,
+        topic: str,
+        actor_id: UserId,
+        schedules_agendas: dict[ScheduleId, list[Agenda]],
+        now: datetime,
+    ) -> list[AgendaId]:
+        """Remove an agenda topic from all associated schedules.
+
+        Removes the first matching AgendaTemplate and physically deletes
+        all matching Agenda entities (including their comments).
+
+        Args:
+            topic: The agenda topic to remove.
+            actor_id: The user performing the operation (must be organizer).
+            schedules_agendas: Mutable agenda lists keyed by schedule ID.
+                Matching agendas are removed from each list.
+            now: Current time.
+
+        Returns:
+            List of removed Agenda IDs.
+
+        Raises:
+            UnauthorizedScheduleGroupOperationError: If actor is not the
+                organizer.
+        """
+        self._assert_organizer(actor_id)
+
+        # Remove first matching template
+        for i, tmpl in enumerate(self._agenda_templates):
+            if tmpl.topic == topic:
+                self._agenda_templates.pop(i)
+                break
+
+        self._updated_at = now
+
+        removed_ids: list[AgendaId] = []
+        for schedule_id in self._schedule_ids:
+            if schedule_id not in schedules_agendas:
+                continue
+            agendas = schedules_agendas[schedule_id]
+            to_remove: list[int] = []
+            for idx, agenda in enumerate(agendas):
+                if agenda.topic == topic:
+                    removed_ids.append(agenda.id)
+                    to_remove.append(idx)
+                    break  # Remove one matching agenda per schedule
+            for idx in reversed(to_remove):
+                agendas.pop(idx)
+
+        self._events.append(
+            AgendaRemovedViaGroup(
+                schedule_group_id=self.id,
+                topic=topic,
+                removed_agenda_ids=removed_ids,
+                occurred_at=now,
+            )
+        )
+        return removed_ids
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _assert_organizer(self, actor_id: UserId) -> None:
+        if actor_id != self.organizer_id:
+            raise UnauthorizedScheduleGroupOperationError(
+                "Only the organizer can operate on this schedule group."
+            )

--- a/backend/contexts/preparation/domain/schedule_group.py
+++ b/backend/contexts/preparation/domain/schedule_group.py
@@ -11,8 +11,10 @@ from contexts.preparation.domain.events import (
     ScheduleGroupCreated,
 )
 from contexts.preparation.domain.exceptions import (
+    InconsistentScheduleAgendasError,
     UnauthorizedScheduleGroupOperationError,
 )
+from contexts.preparation.domain.topic import Topic
 from contexts.preparation.domain.value_objects import (
     AgendaId,
     ScheduleGroupId,
@@ -142,8 +144,7 @@ class ScheduleGroup:
             actor_id: The user performing the operation (must be organizer).
             schedules_agendas: Mutable agenda lists keyed by schedule ID.
                 New agendas are appended to each list. Must contain keys
-                for all registered schedule IDs; missing keys are skipped
-                (new Agenda is still created but not appended to the dict).
+                for all registered schedule IDs.
             now: Current time.
 
         Returns:
@@ -152,8 +153,11 @@ class ScheduleGroup:
         Raises:
             UnauthorizedScheduleGroupOperationError: If actor is not the
                 organizer.
+            InconsistentScheduleAgendasError: If schedules_agendas is
+                missing keys for registered schedule IDs.
         """
         self._assert_organizer(actor_id)
+        self._assert_schedules_agendas_complete(schedules_agendas)
 
         agenda_template = AgendaTemplate(topic)
         self._agenda_templates.append(agenda_template)
@@ -168,8 +172,7 @@ class ScheduleGroup:
                 now=now,
             )
             new_agendas.append(agenda)
-            if schedule_id in schedules_agendas:
-                schedules_agendas[schedule_id].append(agenda)
+            schedules_agendas[schedule_id].append(agenda)
 
         self._events.append(
             AgendaAddedViaGroup(
@@ -207,13 +210,18 @@ class ScheduleGroup:
         Raises:
             UnauthorizedScheduleGroupOperationError: If actor is not the
                 organizer.
+            InconsistentScheduleAgendasError: If schedules_agendas is
+                missing keys for registered schedule IDs.
         """
         self._assert_organizer(actor_id)
+        self._assert_schedules_agendas_complete(schedules_agendas)
+
+        normalized_topic = Topic(topic).value
 
         # Remove first matching template; if none found, this is a no-op.
         found = False
         for i, tmpl in enumerate(self._agenda_templates):
-            if tmpl.topic.value == topic:
+            if tmpl.topic.value == normalized_topic:
                 self._agenda_templates.pop(i)
                 found = True
                 break
@@ -225,12 +233,10 @@ class ScheduleGroup:
 
         removed_ids: list[AgendaId] = []
         for schedule_id in self._schedule_ids:
-            if schedule_id not in schedules_agendas:
-                continue
             agendas = schedules_agendas[schedule_id]
             to_remove: list[int] = []
             for idx, agenda in enumerate(agendas):
-                if str(agenda.topic) == topic:
+                if agenda.topic.value == normalized_topic:
                     removed_ids.append(agenda.id)
                     to_remove.append(idx)
                     break  # Remove one matching agenda per schedule
@@ -240,7 +246,7 @@ class ScheduleGroup:
         self._events.append(
             AgendaRemovedViaGroup(
                 schedule_group_id=self.id,
-                topic=topic,
+                topic=normalized_topic,
                 removed_agenda_ids=removed_ids,
                 occurred_at=now,
             )
@@ -255,4 +261,14 @@ class ScheduleGroup:
         if actor_id != self.organizer_id:
             raise UnauthorizedScheduleGroupOperationError(
                 "Only the organizer can operate on this schedule group."
+            )
+
+    def _assert_schedules_agendas_complete(
+        self, schedules_agendas: dict[ScheduleId, list[Agenda]]
+    ) -> None:
+        """Verify schedules_agendas has keys for all schedule IDs."""
+        missing = set(self._schedule_ids) - schedules_agendas.keys()
+        if missing:
+            raise InconsistentScheduleAgendasError(
+                f"schedules_agendas is missing keys for schedule IDs: {missing}"
             )

--- a/backend/contexts/preparation/domain/template.py
+++ b/backend/contexts/preparation/domain/template.py
@@ -6,13 +6,11 @@ from datetime import UTC, datetime
 from contexts.preparation.domain.agenda_template import AgendaTemplate
 from contexts.preparation.domain.events import TemplateSaved
 from contexts.preparation.domain.exceptions import (
-    InvalidTemplateNameError,
     UnauthorizedTemplateOperationError,
 )
+from contexts.preparation.domain.template_name import TemplateName
 from contexts.preparation.domain.value_objects import TemplateId
 from shared.domain.value_objects import UserId
-
-_TEMPLATE_NAME_MAX_LENGTH = 100
 
 
 @dataclass
@@ -28,7 +26,7 @@ class Template:
 
     id: TemplateId
     organizer_id: UserId
-    _name: str
+    _name: TemplateName
     _default_counterparts: list[UserId]
     _agenda_templates: list[AgendaTemplate]
     created_at: datetime
@@ -36,7 +34,7 @@ class Template:
     _events: list[TemplateSaved] = field(default_factory=list, repr=False)
 
     @property
-    def name(self) -> str:
+    def name(self) -> TemplateName:
         return self._name
 
     @property
@@ -83,13 +81,13 @@ class Template:
             InvalidTemplateNameError: If name is empty or too long.
         """
         ts = now or datetime.now(UTC)
-        validated_name = _validate_template_name(name)
+        template_name = TemplateName(name)
         template_id = TemplateId.generate()
 
         template = Template(
             id=template_id,
             organizer_id=organizer_id,
-            _name=validated_name,
+            _name=template_name,
             _default_counterparts=list(default_counterparts)
             if default_counterparts
             else [],
@@ -100,7 +98,7 @@ class Template:
         template._events.append(
             TemplateSaved(
                 template_id=template_id,
-                name=validated_name,
+                name=str(template_name),
                 organizer_id=organizer_id,
                 occurred_at=ts,
             )
@@ -133,28 +131,16 @@ class Template:
             raise UnauthorizedTemplateOperationError(
                 "Only the organizer can update this template."
             )
-        validated_name = _validate_template_name(name)
-        self._name = validated_name
+        template_name = TemplateName(name)
+        self._name = template_name
         self._default_counterparts = list(default_counterparts)
         self._agenda_templates = list(agenda_templates)
         self._updated_at = now
         self._events.append(
             TemplateSaved(
                 template_id=self.id,
-                name=validated_name,
+                name=str(template_name),
                 organizer_id=self.organizer_id,
                 occurred_at=now,
             )
         )
-
-
-def _validate_template_name(name: str) -> str:
-    """Validate and normalize a template name."""
-    stripped = name.strip()
-    if not stripped:
-        raise InvalidTemplateNameError("Template name must not be empty.")
-    if len(stripped) > _TEMPLATE_NAME_MAX_LENGTH:
-        raise InvalidTemplateNameError(
-            f"Template name must not exceed {_TEMPLATE_NAME_MAX_LENGTH} characters."
-        )
-    return stripped

--- a/backend/contexts/preparation/domain/template.py
+++ b/backend/contexts/preparation/domain/template.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.events import TemplateSaved
+from contexts.preparation.domain.exceptions import (
+    InvalidTemplateNameError,
+    UnauthorizedScheduleGroupOperationError,
+)
+from contexts.preparation.domain.value_objects import TemplateId
+from shared.domain.value_objects import UserId
+
+_TEMPLATE_NAME_MAX_LENGTH = 100
+
+
+@dataclass
+class Template:
+    """Entity: a reusable preset for ScheduleGroup creation.
+
+    Templates are created from within the ScheduleGroup creation flow
+    ("save as template"). They hold default counterparts and agenda
+    templates that are copied into a new ScheduleGroup.
+
+    Domain logic is thin (master-data-like).
+    """
+
+    id: TemplateId
+    organizer_id: UserId
+    _name: str
+    _default_counterparts: list[UserId]
+    _agenda_templates: list[AgendaTemplate]
+    created_at: datetime
+    _updated_at: datetime
+    _events: list[TemplateSaved] = field(default_factory=list, repr=False)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def default_counterparts(self) -> list[UserId]:
+        return list(self._default_counterparts)
+
+    @property
+    def agenda_templates(self) -> list[AgendaTemplate]:
+        return list(self._agenda_templates)
+
+    @property
+    def updated_at(self) -> datetime:
+        return self._updated_at
+
+    def collect_events(self) -> list[TemplateSaved]:
+        """Return accumulated events and clear the internal list."""
+        events = list(self._events)
+        self._events.clear()
+        return events
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create(
+        *,
+        organizer_id: UserId,
+        name: str,
+        default_counterparts: list[UserId] | None = None,
+        agenda_templates: list[AgendaTemplate] | None = None,
+        now: datetime | None = None,
+    ) -> Template:
+        """Create a new template.
+
+        Args:
+            organizer_id: The organizer who owns this template.
+            name: Display name for the template.
+            default_counterparts: Default counterpart user IDs.
+            agenda_templates: Default agenda templates.
+            now: Current time (defaults to UTC now).
+
+        Raises:
+            InvalidTemplateNameError: If name is empty or too long.
+        """
+        ts = now or datetime.now(UTC)
+        validated_name = _validate_template_name(name)
+        template_id = TemplateId.generate()
+
+        template = Template(
+            id=template_id,
+            organizer_id=organizer_id,
+            _name=validated_name,
+            _default_counterparts=list(default_counterparts)
+            if default_counterparts
+            else [],
+            _agenda_templates=list(agenda_templates) if agenda_templates else [],
+            created_at=ts,
+            _updated_at=ts,
+        )
+        template._events.append(
+            TemplateSaved(
+                template_id=template_id,
+                name=validated_name,
+                organizer_id=organizer_id,
+                occurred_at=ts,
+            )
+        )
+        return template
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+
+    def update(
+        self,
+        *,
+        actor_id: UserId,
+        name: str,
+        default_counterparts: list[UserId],
+        agenda_templates: list[AgendaTemplate],
+        now: datetime,
+    ) -> None:
+        """Update template contents.
+
+        Only the owning organizer can update.
+
+        Raises:
+            UnauthorizedScheduleGroupOperationError: If actor is not the
+                organizer.
+            InvalidTemplateNameError: If name is empty or too long.
+        """
+        if actor_id != self.organizer_id:
+            raise UnauthorizedScheduleGroupOperationError(
+                "Only the organizer can update this template."
+            )
+        validated_name = _validate_template_name(name)
+        self._name = validated_name
+        self._default_counterparts = list(default_counterparts)
+        self._agenda_templates = list(agenda_templates)
+        self._updated_at = now
+        self._events.append(
+            TemplateSaved(
+                template_id=self.id,
+                name=validated_name,
+                organizer_id=self.organizer_id,
+                occurred_at=now,
+            )
+        )
+
+
+def _validate_template_name(name: str) -> str:
+    """Validate and normalize a template name."""
+    stripped = name.strip()
+    if not stripped:
+        raise InvalidTemplateNameError("Template name must not be empty.")
+    if len(stripped) > _TEMPLATE_NAME_MAX_LENGTH:
+        raise InvalidTemplateNameError(
+            f"Template name must not exceed {_TEMPLATE_NAME_MAX_LENGTH} characters."
+        )
+    return stripped

--- a/backend/contexts/preparation/domain/template.py
+++ b/backend/contexts/preparation/domain/template.py
@@ -7,7 +7,7 @@ from contexts.preparation.domain.agenda_template import AgendaTemplate
 from contexts.preparation.domain.events import TemplateSaved
 from contexts.preparation.domain.exceptions import (
     InvalidTemplateNameError,
-    UnauthorizedScheduleGroupOperationError,
+    UnauthorizedTemplateOperationError,
 )
 from contexts.preparation.domain.value_objects import TemplateId
 from shared.domain.value_objects import UserId
@@ -125,12 +125,12 @@ class Template:
         Only the owning organizer can update.
 
         Raises:
-            UnauthorizedScheduleGroupOperationError: If actor is not the
+            UnauthorizedTemplateOperationError: If actor is not the
                 organizer.
             InvalidTemplateNameError: If name is empty or too long.
         """
         if actor_id != self.organizer_id:
-            raise UnauthorizedScheduleGroupOperationError(
+            raise UnauthorizedTemplateOperationError(
                 "Only the organizer can update this template."
             )
         validated_name = _validate_template_name(name)

--- a/backend/contexts/preparation/domain/template_name.py
+++ b/backend/contexts/preparation/domain/template_name.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contexts.preparation.domain.exceptions import InvalidTemplateNameError
+
+_TEMPLATE_NAME_MAX_LENGTH = 100
+
+
+@dataclass(frozen=True)
+class TemplateName:
+    """Value object representing a template name string.
+
+    Invariants:
+    - Must not be empty (after stripping whitespace).
+    - Max 100 characters.
+    - Leading/trailing whitespace is stripped.
+    """
+
+    value: str
+
+    def __init__(self, value: str) -> None:
+        stripped = value.strip()
+        if not stripped:
+            raise InvalidTemplateNameError("Template name must not be empty.")
+        if len(stripped) > _TEMPLATE_NAME_MAX_LENGTH:
+            raise InvalidTemplateNameError(
+                f"Template name must not exceed {_TEMPLATE_NAME_MAX_LENGTH} characters."
+            )
+        object.__setattr__(self, "value", stripped)
+
+    def __str__(self) -> str:
+        return self.value

--- a/backend/contexts/preparation/domain/topic.py
+++ b/backend/contexts/preparation/domain/topic.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contexts.preparation.domain.exceptions import InvalidTopicError
+
+_TOPIC_MAX_LENGTH = 200
+
+
+@dataclass(frozen=True)
+class Topic:
+    """Value object representing an agenda topic string.
+
+    Invariants:
+    - Must not be empty (after stripping whitespace).
+    - Must not contain newlines.
+    - Max 200 characters.
+    - Leading/trailing whitespace is stripped.
+    """
+
+    value: str
+
+    def __init__(self, value: str) -> None:
+        stripped = value.strip()
+        if not stripped:
+            raise InvalidTopicError("Topic must not be empty.")
+        if "\n" in stripped or "\r" in stripped:
+            raise InvalidTopicError("Topic must not contain newlines.")
+        if len(stripped) > _TOPIC_MAX_LENGTH:
+            raise InvalidTopicError(
+                f"Topic must not exceed {_TOPIC_MAX_LENGTH} characters."
+            )
+        object.__setattr__(self, "value", stripped)
+
+    def __str__(self) -> str:
+        return self.value

--- a/backend/contexts/preparation/domain/value_objects.py
+++ b/backend/contexts/preparation/domain/value_objects.py
@@ -57,3 +57,63 @@ class ConfirmationResolution(Enum):
     APPROVED = "approved"
     REJECTED = "rejected"
     SUPERSEDED = "superseded"
+
+
+@dataclass(frozen=True)
+class ScheduleGroupId:
+    """ScheduleGroup identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> ScheduleGroupId:
+        return ScheduleGroupId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> ScheduleGroupId:
+        return ScheduleGroupId(value=uuid.UUID(raw))
+
+
+@dataclass(frozen=True)
+class AgendaId:
+    """Agenda identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> AgendaId:
+        return AgendaId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> AgendaId:
+        return AgendaId(value=uuid.UUID(raw))
+
+
+@dataclass(frozen=True)
+class TemplateId:
+    """Template identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> TemplateId:
+        return TemplateId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> TemplateId:
+        return TemplateId(value=uuid.UUID(raw))
+
+
+@dataclass(frozen=True)
+class CommentId:
+    """Agenda comment identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> CommentId:
+        return CommentId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> CommentId:
+        return CommentId(value=uuid.UUID(raw))

--- a/backend/tests/contexts/preparation/domain/test_agenda.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.value_objects import ScheduleId
+from shared.domain.value_objects import UserId
+
+_NOW = datetime(2026, 3, 20, 10, 0)
+_LATER = datetime(2026, 3, 20, 11, 0)
+
+
+def _make_agenda(
+    *,
+    schedule_id: ScheduleId | None = None,
+    topic: str = "Discuss project status",
+    added_by: UserId | None = None,
+    now: datetime = _NOW,
+) -> Agenda:
+    return Agenda.create(
+        schedule_id=schedule_id or ScheduleId.generate(),
+        topic=topic,
+        added_by=added_by or UserId.generate(),
+        now=now,
+    )
+
+
+class TestAgendaCreate:
+    def test_creates_with_defaults(self) -> None:
+        agenda = _make_agenda()
+        assert agenda.topic == "Discuss project status"
+        assert agenda.comments == []
+        assert agenda.created_at == _NOW
+
+    def test_assigns_unique_id(self) -> None:
+        a1 = _make_agenda()
+        a2 = _make_agenda()
+        assert a1.id != a2.id
+
+
+class TestAgendaComment:
+    def test_add_comment(self) -> None:
+        agenda = _make_agenda()
+        author = UserId.generate()
+
+        comment = agenda.add_comment(
+            author_id=author,
+            body="Let's focus on timeline",
+            now=_LATER,
+        )
+
+        assert len(agenda.comments) == 1
+        assert comment.author_id == author
+        assert comment.body == "Let's focus on timeline"
+        assert comment.agenda_id == agenda.id
+
+    def test_multiple_comments(self) -> None:
+        agenda = _make_agenda()
+        user1 = UserId.generate()
+        user2 = UserId.generate()
+
+        agenda.add_comment(author_id=user1, body="Comment 1", now=_LATER)
+        agenda.add_comment(author_id=user2, body="Comment 2", now=_LATER)
+
+        assert len(agenda.comments) == 2
+
+    def test_find_comment(self) -> None:
+        agenda = _make_agenda()
+        author = UserId.generate()
+        comment = agenda.add_comment(author_id=author, body="Some comment", now=_LATER)
+
+        found = agenda.find_comment(comment.id)
+        assert found is not None
+        assert found.id == comment.id
+
+    def test_find_comment_not_found(self) -> None:
+        from contexts.preparation.domain.value_objects import CommentId
+
+        agenda = _make_agenda()
+        found = agenda.find_comment(CommentId.generate())
+        assert found is None
+
+    def test_comments_returns_copy(self) -> None:
+        agenda = _make_agenda()
+        comments = agenda.comments
+        assert comments is not agenda.comments  # different list instances

--- a/backend/tests/contexts/preparation/domain/test_agenda.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda.py
@@ -3,7 +3,10 @@ from datetime import datetime
 import pytest
 
 from contexts.preparation.domain.agenda import Agenda
-from contexts.preparation.domain.exceptions import InvalidCommentBodyError
+from contexts.preparation.domain.exceptions import (
+    InvalidCommentBodyError,
+    InvalidTopicError,
+)
 from contexts.preparation.domain.value_objects import ScheduleId
 from shared.domain.value_objects import UserId
 
@@ -37,6 +40,26 @@ class TestAgendaCreate:
         a1 = _make_agenda()
         a2 = _make_agenda()
         assert a1.id != a2.id
+
+    def test_empty_topic_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not be empty"):
+            _make_agenda(topic="")
+
+    def test_whitespace_only_topic_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not be empty"):
+            _make_agenda(topic="   ")
+
+    def test_newline_topic_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not contain newlines"):
+            _make_agenda(topic="line1\nline2")
+
+    def test_topic_exceeds_max_length_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not exceed"):
+            _make_agenda(topic="a" * 201)
+
+    def test_topic_strips_whitespace(self) -> None:
+        agenda = _make_agenda(topic="  padded  ")
+        assert agenda.topic == "padded"
 
 
 class TestAgendaComment:

--- a/backend/tests/contexts/preparation/domain/test_agenda.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
+import pytest
+
 from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.exceptions import InvalidCommentBodyError
 from contexts.preparation.domain.value_objects import ScheduleId
 from shared.domain.value_objects import UserId
 
@@ -82,3 +85,32 @@ class TestAgendaComment:
         agenda = _make_agenda()
         comments = agenda.comments
         assert comments is not agenda.comments  # different list instances
+
+    def test_empty_comment_body_raises(self) -> None:
+        agenda = _make_agenda()
+        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
+            agenda.add_comment(author_id=UserId.generate(), body="", now=_LATER)
+
+    def test_whitespace_only_comment_body_raises(self) -> None:
+        agenda = _make_agenda()
+        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
+            agenda.add_comment(author_id=UserId.generate(), body="   ", now=_LATER)
+
+    def test_comment_body_exceeds_max_length_raises(self) -> None:
+        agenda = _make_agenda()
+        with pytest.raises(InvalidCommentBodyError, match="must not exceed"):
+            agenda.add_comment(author_id=UserId.generate(), body="a" * 2001, now=_LATER)
+
+    def test_comment_body_at_max_length_is_valid(self) -> None:
+        agenda = _make_agenda()
+        comment = agenda.add_comment(
+            author_id=UserId.generate(), body="a" * 2000, now=_LATER
+        )
+        assert len(comment.body) == 2000
+
+    def test_comment_body_strips_whitespace(self) -> None:
+        agenda = _make_agenda()
+        comment = agenda.add_comment(
+            author_id=UserId.generate(), body="  hello  ", now=_LATER
+        )
+        assert comment.body == "hello"

--- a/backend/tests/contexts/preparation/domain/test_agenda.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda.py
@@ -3,10 +3,12 @@ from datetime import datetime
 import pytest
 
 from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.comment_body import CommentBody
 from contexts.preparation.domain.exceptions import (
     InvalidCommentBodyError,
     InvalidTopicError,
 )
+from contexts.preparation.domain.topic import Topic
 from contexts.preparation.domain.value_objects import ScheduleId
 from shared.domain.value_objects import UserId
 
@@ -32,7 +34,7 @@ def _make_agenda(
 class TestAgendaCreate:
     def test_creates_with_defaults(self) -> None:
         agenda = _make_agenda()
-        assert agenda.topic == "Discuss project status"
+        assert agenda.topic == Topic("Discuss project status")
         assert agenda.comments == []
         assert agenda.created_at == _NOW
 
@@ -59,7 +61,7 @@ class TestAgendaCreate:
 
     def test_topic_strips_whitespace(self) -> None:
         agenda = _make_agenda(topic="  padded  ")
-        assert agenda.topic == "padded"
+        assert agenda.topic == Topic("padded")
 
 
 class TestAgendaComment:
@@ -75,7 +77,7 @@ class TestAgendaComment:
 
         assert len(agenda.comments) == 1
         assert comment.author_id == author
-        assert comment.body == "Let's focus on timeline"
+        assert comment.body == CommentBody("Let's focus on timeline")
         assert comment.agenda_id == agenda.id
 
     def test_multiple_comments(self) -> None:
@@ -129,11 +131,11 @@ class TestAgendaComment:
         comment = agenda.add_comment(
             author_id=UserId.generate(), body="a" * 2000, now=_LATER
         )
-        assert len(comment.body) == 2000
+        assert len(str(comment.body)) == 2000
 
     def test_comment_body_strips_whitespace(self) -> None:
         agenda = _make_agenda()
         comment = agenda.add_comment(
             author_id=UserId.generate(), body="  hello  ", now=_LATER
         )
-        assert comment.body == "hello"
+        assert comment.body == CommentBody("hello")

--- a/backend/tests/contexts/preparation/domain/test_agenda_template.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda_template.py
@@ -1,0 +1,58 @@
+import pytest
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.exceptions import InvalidAgendaTopicError
+
+
+class TestAgendaTemplate:
+    def test_creates_with_valid_topic(self) -> None:
+        tmpl = AgendaTemplate("Weekly check-in")
+        assert tmpl.topic == "Weekly check-in"
+
+    def test_strips_whitespace(self) -> None:
+        tmpl = AgendaTemplate("  padded topic  ")
+        assert tmpl.topic == "padded topic"
+
+    def test_empty_topic_raises(self) -> None:
+        with pytest.raises(InvalidAgendaTopicError, match="must not be empty"):
+            AgendaTemplate("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(InvalidAgendaTopicError, match="must not be empty"):
+            AgendaTemplate("   ")
+
+    def test_newline_raises(self) -> None:
+        with pytest.raises(InvalidAgendaTopicError, match="must not contain newlines"):
+            AgendaTemplate("line1\nline2")
+
+    def test_carriage_return_raises(self) -> None:
+        with pytest.raises(InvalidAgendaTopicError, match="must not contain newlines"):
+            AgendaTemplate("line1\rline2")
+
+    def test_exceeds_max_length_raises(self) -> None:
+        with pytest.raises(InvalidAgendaTopicError, match="must not exceed"):
+            AgendaTemplate("a" * 201)
+
+    def test_exactly_max_length_is_valid(self) -> None:
+        tmpl = AgendaTemplate("a" * 200)
+        assert len(tmpl.topic) == 200
+
+    def test_frozen(self) -> None:
+        tmpl = AgendaTemplate("topic")
+        with pytest.raises(AttributeError):
+            tmpl.topic = "changed"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        assert AgendaTemplate("topic") == AgendaTemplate("topic")
+
+    def test_inequality(self) -> None:
+        assert AgendaTemplate("topic A") != AgendaTemplate("topic B")
+
+    def test_str(self) -> None:
+        tmpl = AgendaTemplate("My topic")
+        assert str(tmpl) == "My topic"
+
+    def test_usable_as_dict_key(self) -> None:
+        tmpl = AgendaTemplate("topic")
+        d = {tmpl: "value"}
+        assert d[tmpl] == "value"

--- a/backend/tests/contexts/preparation/domain/test_agenda_template.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda_template.py
@@ -1,41 +1,42 @@
 import pytest
 
 from contexts.preparation.domain.agenda_template import AgendaTemplate
-from contexts.preparation.domain.exceptions import InvalidAgendaTopicError
+from contexts.preparation.domain.exceptions import InvalidTopicError
+from contexts.preparation.domain.topic import Topic
 
 
 class TestAgendaTemplate:
     def test_creates_with_valid_topic(self) -> None:
         tmpl = AgendaTemplate("Weekly check-in")
-        assert tmpl.topic == "Weekly check-in"
+        assert tmpl.topic == Topic("Weekly check-in")
 
     def test_strips_whitespace(self) -> None:
         tmpl = AgendaTemplate("  padded topic  ")
-        assert tmpl.topic == "padded topic"
+        assert tmpl.topic.value == "padded topic"
 
     def test_empty_topic_raises(self) -> None:
-        with pytest.raises(InvalidAgendaTopicError, match="must not be empty"):
+        with pytest.raises(InvalidTopicError, match="must not be empty"):
             AgendaTemplate("")
 
     def test_whitespace_only_raises(self) -> None:
-        with pytest.raises(InvalidAgendaTopicError, match="must not be empty"):
+        with pytest.raises(InvalidTopicError, match="must not be empty"):
             AgendaTemplate("   ")
 
     def test_newline_raises(self) -> None:
-        with pytest.raises(InvalidAgendaTopicError, match="must not contain newlines"):
+        with pytest.raises(InvalidTopicError, match="must not contain newlines"):
             AgendaTemplate("line1\nline2")
 
     def test_carriage_return_raises(self) -> None:
-        with pytest.raises(InvalidAgendaTopicError, match="must not contain newlines"):
+        with pytest.raises(InvalidTopicError, match="must not contain newlines"):
             AgendaTemplate("line1\rline2")
 
     def test_exceeds_max_length_raises(self) -> None:
-        with pytest.raises(InvalidAgendaTopicError, match="must not exceed"):
+        with pytest.raises(InvalidTopicError, match="must not exceed"):
             AgendaTemplate("a" * 201)
 
     def test_exactly_max_length_is_valid(self) -> None:
         tmpl = AgendaTemplate("a" * 200)
-        assert len(tmpl.topic) == 200
+        assert len(tmpl.topic.value) == 200
 
     def test_frozen(self) -> None:
         tmpl = AgendaTemplate("topic")

--- a/backend/tests/contexts/preparation/domain/test_comment_body.py
+++ b/backend/tests/contexts/preparation/domain/test_comment_body.py
@@ -1,0 +1,50 @@
+import pytest
+
+from contexts.preparation.domain.comment_body import CommentBody
+from contexts.preparation.domain.exceptions import InvalidCommentBodyError
+
+
+class TestCommentBody:
+    def test_creates_with_valid_value(self) -> None:
+        body = CommentBody("Hello, world!")
+        assert body.value == "Hello, world!"
+
+    def test_strips_whitespace(self) -> None:
+        body = CommentBody("  padded body  ")
+        assert body.value == "padded body"
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
+            CommentBody("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
+            CommentBody("   ")
+
+    def test_exceeds_max_length_raises(self) -> None:
+        with pytest.raises(InvalidCommentBodyError, match="must not exceed"):
+            CommentBody("a" * 2001)
+
+    def test_exactly_max_length_is_valid(self) -> None:
+        body = CommentBody("a" * 2000)
+        assert len(body.value) == 2000
+
+    def test_frozen(self) -> None:
+        body = CommentBody("body")
+        with pytest.raises(AttributeError):
+            body.value = "changed"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        assert CommentBody("body") == CommentBody("body")
+
+    def test_inequality(self) -> None:
+        assert CommentBody("body A") != CommentBody("body B")
+
+    def test_str(self) -> None:
+        body = CommentBody("My body")
+        assert str(body) == "My body"
+
+    def test_usable_as_dict_key(self) -> None:
+        body = CommentBody("body")
+        d = {body: "value"}
+        assert d[body] == "value"

--- a/backend/tests/contexts/preparation/domain/test_schedule.py
+++ b/backend/tests/contexts/preparation/domain/test_schedule.py
@@ -192,6 +192,26 @@ class TestScheduleCreate:
         assert len(events) == 1
         assert schedule.collect_events() == []
 
+    def test_schedule_group_id_defaults_to_none(self) -> None:
+        schedule = _make_schedule()
+        assert schedule.schedule_group_id is None
+
+    def test_schedule_group_id_set_when_provided(self) -> None:
+        from contexts.preparation.domain.value_objects import ScheduleGroupId
+
+        group_id = ScheduleGroupId.generate()
+        org = UserId.generate()
+        cp = UserId.generate()
+        schedule = Schedule.create(
+            organizer_id=org,
+            counterpart_id=cp,
+            scheduled_at=_FUTURE,
+            requested_by=org,
+            schedule_group_id=group_id,
+            now=_NOW,
+        )
+        assert schedule.schedule_group_id == group_id
+
 
 # ===========================================================================
 # Confirm

--- a/backend/tests/contexts/preparation/domain/test_schedule_group.py
+++ b/backend/tests/contexts/preparation/domain/test_schedule_group.py
@@ -1,0 +1,392 @@
+from datetime import datetime
+
+import pytest
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.events import (
+    AgendaAddedViaGroup,
+    AgendaRemovedViaGroup,
+    ScheduleGroupCreated,
+)
+from contexts.preparation.domain.exceptions import (
+    UnauthorizedScheduleGroupOperationError,
+)
+from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.value_objects import ScheduleId, TemplateId
+from shared.domain.value_objects import UserId
+
+_NOW = datetime(2026, 3, 20, 10, 0)
+_LATER = datetime(2026, 3, 20, 11, 0)
+
+
+def _make_group(
+    *,
+    organizer_id: UserId | None = None,
+    agenda_templates: list[AgendaTemplate] | None = None,
+    template_id: TemplateId | None = None,
+    now: datetime = _NOW,
+) -> ScheduleGroup:
+    return ScheduleGroup.create(
+        organizer_id=organizer_id or UserId.generate(),
+        agenda_templates=agenda_templates,
+        template_id=template_id,
+        now=now,
+    )
+
+
+def _make_group_with_schedules(
+    *,
+    organizer_id: UserId | None = None,
+    schedule_count: int = 3,
+    now: datetime = _NOW,
+) -> tuple[ScheduleGroup, list[ScheduleId]]:
+    """Create a group with registered schedules."""
+    org = organizer_id or UserId.generate()
+    group = _make_group(organizer_id=org, now=now)
+    schedule_ids = [ScheduleId.generate() for _ in range(schedule_count)]
+    for sid in schedule_ids:
+        group.register_schedule(sid)
+    return group, schedule_ids
+
+
+class TestScheduleGroupCreate:
+    def test_creates_with_defaults(self) -> None:
+        group = _make_group()
+        assert group.agenda_templates == []
+        assert group.schedule_ids == []
+        assert group.template_id is None
+        assert group.created_at == _NOW
+        assert group.updated_at == _NOW
+
+    def test_creates_with_agenda_templates(self) -> None:
+        templates = [AgendaTemplate("Topic A"), AgendaTemplate("Topic B")]
+        group = _make_group(agenda_templates=templates)
+        assert group.agenda_templates == templates
+
+    def test_creates_with_template_id(self) -> None:
+        tid = TemplateId.generate()
+        group = _make_group(template_id=tid)
+        assert group.template_id == tid
+
+    def test_emits_created_event(self) -> None:
+        group = _make_group()
+        events = group.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, ScheduleGroupCreated)
+        assert event.schedule_group_id == group.id
+        assert event.organizer_id == group.organizer_id
+
+    def test_collect_events_clears_list(self) -> None:
+        group = _make_group()
+        group.collect_events()
+        assert group.collect_events() == []
+
+
+class TestScheduleGroupRegisterSchedule:
+    def test_register_schedule(self) -> None:
+        group = _make_group()
+        sid = ScheduleId.generate()
+        group.register_schedule(sid)
+        assert sid in group.schedule_ids
+
+    def test_register_multiple_schedules(self) -> None:
+        group = _make_group()
+        sids = [ScheduleId.generate() for _ in range(3)]
+        for sid in sids:
+            group.register_schedule(sid)
+        assert group.schedule_ids == sids
+
+
+class TestScheduleGroupAddAgenda:
+    def test_add_agenda_to_all_schedules(self) -> None:
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+
+        new_agendas = group.add_agenda_to_schedules(
+            topic="New topic",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        assert len(new_agendas) == 3
+        for sid in schedule_ids:
+            assert len(schedules_agendas[sid]) == 1
+            assert schedules_agendas[sid][0].topic == "New topic"
+        # Template also updated
+        assert AgendaTemplate("New topic") in group.agenda_templates
+
+    def test_add_agenda_updates_timestamp(self) -> None:
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+
+        group.add_agenda_to_schedules(
+            topic="Topic",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        assert group.updated_at == _LATER
+
+    def test_add_agenda_emits_event(self) -> None:
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        group.collect_events()  # clear creation event
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+
+        group.add_agenda_to_schedules(
+            topic="Topic",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        events = group.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, AgendaAddedViaGroup)
+        assert event.topic == "Topic"
+        assert set(event.target_schedule_ids) == set(schedule_ids)
+
+    def test_non_organizer_cannot_add_agenda(self) -> None:
+        organizer = UserId.generate()
+        other = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+
+        with pytest.raises(
+            UnauthorizedScheduleGroupOperationError, match="Only the organizer"
+        ):
+            group.add_agenda_to_schedules(
+                topic="Topic",
+                actor_id=other,
+                schedules_agendas=schedules_agendas,
+                now=_LATER,
+            )
+
+    def test_add_agenda_with_zero_schedules(self) -> None:
+        """0 targets: normal completion with no side effects."""
+        organizer = UserId.generate()
+        group = _make_group(organizer_id=organizer)
+
+        new_agendas = group.add_agenda_to_schedules(
+            topic="Topic",
+            actor_id=organizer,
+            schedules_agendas={},
+            now=_LATER,
+        )
+
+        assert new_agendas == []
+        # Template still added even with no schedules
+        assert AgendaTemplate("Topic") in group.agenda_templates
+
+    def test_duplicate_topic_allowed(self) -> None:
+        """Duplicate agenda topics are permitted."""
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+
+        group.add_agenda_to_schedules(
+            topic="Same topic",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+        group.add_agenda_to_schedules(
+            topic="Same topic",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        for sid in schedule_ids:
+            assert len(schedules_agendas[sid]) == 2
+        assert group.agenda_templates.count(AgendaTemplate("Same topic")) == 2
+
+
+class TestScheduleGroupRemoveAgenda:
+    def test_remove_agenda_from_all_schedules(self) -> None:
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        # First add agendas
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+        group.add_agenda_to_schedules(
+            topic="To remove",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+        group.collect_events()  # clear
+
+        removed_ids = group.remove_agenda_from_schedules(
+            topic="To remove",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        assert len(removed_ids) == 3
+        for sid in schedule_ids:
+            assert len(schedules_agendas[sid]) == 0
+        assert AgendaTemplate("To remove") not in group.agenda_templates
+
+    def test_remove_agenda_emits_event(self) -> None:
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+        group.add_agenda_to_schedules(
+            topic="Topic",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+        group.collect_events()  # clear
+
+        group.remove_agenda_from_schedules(
+            topic="Topic",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        events = group.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, AgendaRemovedViaGroup)
+        assert event.topic == "Topic"
+        assert len(event.removed_agenda_ids) == 3
+
+    def test_non_organizer_cannot_remove_agenda(self) -> None:
+        organizer = UserId.generate()
+        other = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+
+        with pytest.raises(
+            UnauthorizedScheduleGroupOperationError, match="Only the organizer"
+        ):
+            group.remove_agenda_from_schedules(
+                topic="Topic",
+                actor_id=other,
+                schedules_agendas=schedules_agendas,
+                now=_LATER,
+            )
+
+    def test_remove_agenda_with_zero_schedules(self) -> None:
+        """0 targets: normal completion with no side effects."""
+        organizer = UserId.generate()
+        group = _make_group(
+            organizer_id=organizer,
+            agenda_templates=[AgendaTemplate("Topic")],
+        )
+
+        removed_ids = group.remove_agenda_from_schedules(
+            topic="Topic",
+            actor_id=organizer,
+            schedules_agendas={},
+            now=_LATER,
+        )
+
+        assert removed_ids == []
+        assert AgendaTemplate("Topic") not in group.agenda_templates
+
+    def test_remove_with_comments_deletes_all(self) -> None:
+        """Removing agenda also deletes associated comments."""
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(
+            organizer_id=organizer, schedule_count=1
+        )
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+        group.add_agenda_to_schedules(
+            topic="With comments",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+        # Add comment to the agenda
+        agenda = schedules_agendas[schedule_ids[0]][0]
+        agenda.add_comment(author_id=UserId.generate(), body="A comment", now=_LATER)
+        assert len(agenda.comments) == 1
+
+        removed_ids = group.remove_agenda_from_schedules(
+            topic="With comments",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        # Agenda is removed (including its comments)
+        assert len(removed_ids) == 1
+        assert len(schedules_agendas[schedule_ids[0]]) == 0
+
+    def test_remove_duplicate_removes_one_per_schedule(self) -> None:
+        """When duplicate topics exist, remove only removes one per schedule."""
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(
+            organizer_id=organizer, schedule_count=1
+        )
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+        # Add same topic twice
+        group.add_agenda_to_schedules(
+            topic="Dup",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+        group.add_agenda_to_schedules(
+            topic="Dup",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+        assert len(schedules_agendas[schedule_ids[0]]) == 2
+
+        group.remove_agenda_from_schedules(
+            topic="Dup",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        # One removed, one remains
+        assert len(schedules_agendas[schedule_ids[0]]) == 1
+        assert group.agenda_templates.count(AgendaTemplate("Dup")) == 1
+
+
+class TestScheduleGroupProperties:
+    def test_agenda_templates_returns_copy(self) -> None:
+        templates = [AgendaTemplate("A")]
+        group = _make_group(agenda_templates=templates)
+        returned = group.agenda_templates
+        assert returned is not group.agenda_templates
+
+    def test_schedule_ids_returns_copy(self) -> None:
+        group = _make_group()
+        group.register_schedule(ScheduleId.generate())
+        returned = group.schedule_ids
+        assert returned is not group.schedule_ids

--- a/backend/tests/contexts/preparation/domain/test_schedule_group.py
+++ b/backend/tests/contexts/preparation/domain/test_schedule_group.py
@@ -98,6 +98,13 @@ class TestScheduleGroupRegisterSchedule:
             group.register_schedule(sid)
         assert group.schedule_ids == sids
 
+    def test_register_duplicate_schedule_is_ignored(self) -> None:
+        group = _make_group()
+        sid = ScheduleId.generate()
+        group.register_schedule(sid)
+        group.register_schedule(sid)
+        assert group.schedule_ids == [sid]
+
 
 class TestScheduleGroupAddAgenda:
     def test_add_agenda_to_all_schedules(self) -> None:
@@ -341,6 +348,23 @@ class TestScheduleGroupRemoveAgenda:
         # Agenda is removed (including its comments)
         assert len(removed_ids) == 1
         assert len(schedules_agendas[schedule_ids[0]]) == 0
+
+    def test_remove_nonexistent_topic_is_noop(self) -> None:
+        """Removing a topic that has no matching template is a no-op."""
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(organizer_id=organizer)
+        group.collect_events()  # clear
+
+        removed_ids = group.remove_agenda_from_schedules(
+            topic="Nonexistent",
+            actor_id=organizer,
+            schedules_agendas={sid: [] for sid in schedule_ids},
+            now=_LATER,
+        )
+
+        assert removed_ids == []
+        assert group.updated_at == _NOW  # timestamp not updated
+        assert group.collect_events() == []  # no events emitted
 
     def test_remove_duplicate_removes_one_per_schedule(self) -> None:
         """When duplicate topics exist, remove only removes one per schedule."""

--- a/backend/tests/contexts/preparation/domain/test_schedule_group.py
+++ b/backend/tests/contexts/preparation/domain/test_schedule_group.py
@@ -13,6 +13,7 @@ from contexts.preparation.domain.exceptions import (
     UnauthorizedScheduleGroupOperationError,
 )
 from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.topic import Topic
 from contexts.preparation.domain.value_objects import ScheduleId, TemplateId
 from shared.domain.value_objects import UserId
 
@@ -124,7 +125,7 @@ class TestScheduleGroupAddAgenda:
         assert len(new_agendas) == 3
         for sid in schedule_ids:
             assert len(schedules_agendas[sid]) == 1
-            assert schedules_agendas[sid][0].topic == "New topic"
+            assert schedules_agendas[sid][0].topic == Topic("New topic")
         # Template also updated
         assert AgendaTemplate("New topic") in group.agenda_templates
 

--- a/backend/tests/contexts/preparation/domain/test_schedule_group.py
+++ b/backend/tests/contexts/preparation/domain/test_schedule_group.py
@@ -10,6 +10,7 @@ from contexts.preparation.domain.events import (
     ScheduleGroupCreated,
 )
 from contexts.preparation.domain.exceptions import (
+    InconsistentScheduleAgendasError,
     UnauthorizedScheduleGroupOperationError,
 )
 from contexts.preparation.domain.schedule_group import ScheduleGroup
@@ -201,6 +202,30 @@ class TestScheduleGroupAddAgenda:
         # Template still added even with no schedules
         assert AgendaTemplate("Topic") in group.agenda_templates
 
+    def test_add_agenda_fails_when_schedules_agendas_missing_keys(self) -> None:
+        """Adding fails if schedules_agendas misses schedule IDs."""
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(
+            organizer_id=organizer, schedule_count=3
+        )
+        # Only provide 2 of 3 schedule IDs
+        partial_agendas: dict[ScheduleId, list[Agenda]] = {
+            schedule_ids[0]: [],
+            schedule_ids[1]: [],
+        }
+
+        with pytest.raises(InconsistentScheduleAgendasError, match="missing keys"):
+            group.add_agenda_to_schedules(
+                topic="Topic",
+                actor_id=organizer,
+                schedules_agendas=partial_agendas,
+                now=_LATER,
+            )
+
+        # Verify no partial mutation: no template added, timestamp unchanged
+        assert group.agenda_templates == []
+        assert group.updated_at == _NOW
+
     def test_duplicate_topic_allowed(self) -> None:
         """Duplicate agenda topics are permitted."""
         organizer = UserId.generate()
@@ -349,6 +374,59 @@ class TestScheduleGroupRemoveAgenda:
         # Agenda is removed (including its comments)
         assert len(removed_ids) == 1
         assert len(schedules_agendas[schedule_ids[0]]) == 0
+
+    def test_remove_agenda_normalizes_topic(self) -> None:
+        """Removing with whitespace-padded topic matches the normalized stored topic."""
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(
+            organizer_id=organizer, schedule_count=1
+        )
+        schedules_agendas: dict[ScheduleId, list[Agenda]] = {
+            sid: [] for sid in schedule_ids
+        }
+        group.add_agenda_to_schedules(
+            topic="  目標確認  ",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+        assert len(schedules_agendas[schedule_ids[0]]) == 1
+
+        # Remove with different whitespace
+        removed_ids = group.remove_agenda_from_schedules(
+            topic="  目標確認  ",
+            actor_id=organizer,
+            schedules_agendas=schedules_agendas,
+            now=_LATER,
+        )
+
+        assert len(removed_ids) == 1
+        assert len(schedules_agendas[schedule_ids[0]]) == 0
+        assert group.agenda_templates == []
+
+    def test_remove_agenda_fails_when_schedules_agendas_missing_keys(self) -> None:
+        """Removing fails if schedules_agendas misses schedule IDs."""
+        organizer = UserId.generate()
+        group, schedule_ids = _make_group_with_schedules(
+            organizer_id=organizer, schedule_count=2
+        )
+        group = _make_group(
+            organizer_id=organizer,
+            agenda_templates=[AgendaTemplate("Topic")],
+        )
+        sid1 = ScheduleId.generate()
+        sid2 = ScheduleId.generate()
+        group.register_schedule(sid1)
+        group.register_schedule(sid2)
+
+        # Only provide one of two schedule IDs
+        with pytest.raises(InconsistentScheduleAgendasError, match="missing keys"):
+            group.remove_agenda_from_schedules(
+                topic="Topic",
+                actor_id=organizer,
+                schedules_agendas={sid1: []},
+                now=_LATER,
+            )
 
     def test_remove_nonexistent_topic_is_noop(self) -> None:
         """Removing a topic that has no matching template is a no-op."""

--- a/backend/tests/contexts/preparation/domain/test_template.py
+++ b/backend/tests/contexts/preparation/domain/test_template.py
@@ -9,6 +9,7 @@ from contexts.preparation.domain.exceptions import (
     UnauthorizedTemplateOperationError,
 )
 from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_name import TemplateName
 from shared.domain.value_objects import UserId
 
 _NOW = datetime(2026, 3, 20, 10, 0)
@@ -35,7 +36,7 @@ def _make_template(
 class TestTemplateCreate:
     def test_creates_with_defaults(self) -> None:
         tmpl = _make_template()
-        assert tmpl.name == "Monthly 1on1"
+        assert tmpl.name == TemplateName("Monthly 1on1")
         assert tmpl.default_counterparts == []
         assert tmpl.agenda_templates == []
         assert tmpl.created_at == _NOW
@@ -49,7 +50,7 @@ class TestTemplateCreate:
 
     def test_name_strips_whitespace(self) -> None:
         tmpl = _make_template(name="  Padded Name  ")
-        assert tmpl.name == "Padded Name"
+        assert tmpl.name == TemplateName("Padded Name")
 
     def test_empty_name_raises(self) -> None:
         with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
@@ -65,7 +66,7 @@ class TestTemplateCreate:
 
     def test_name_exactly_max_length_is_valid(self) -> None:
         tmpl = _make_template(name="a" * 100)
-        assert len(tmpl.name) == 100
+        assert len(tmpl.name.value) == 100
 
     def test_emits_template_saved_event(self) -> None:
         tmpl = _make_template()
@@ -97,7 +98,7 @@ class TestTemplateUpdate:
             now=_LATER,
         )
 
-        assert tmpl.name == "Updated Name"
+        assert tmpl.name == TemplateName("Updated Name")
         assert tmpl.default_counterparts == new_cps
         assert tmpl.agenda_templates == new_ats
         assert tmpl.updated_at == _LATER

--- a/backend/tests/contexts/preparation/domain/test_template.py
+++ b/backend/tests/contexts/preparation/domain/test_template.py
@@ -1,0 +1,165 @@
+from datetime import datetime
+
+import pytest
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.events import TemplateSaved
+from contexts.preparation.domain.exceptions import (
+    InvalidTemplateNameError,
+    UnauthorizedScheduleGroupOperationError,
+)
+from contexts.preparation.domain.template import Template
+from shared.domain.value_objects import UserId
+
+_NOW = datetime(2026, 3, 20, 10, 0)
+_LATER = datetime(2026, 3, 20, 11, 0)
+
+
+def _make_template(
+    *,
+    organizer_id: UserId | None = None,
+    name: str = "Monthly 1on1",
+    default_counterparts: list[UserId] | None = None,
+    agenda_templates: list[AgendaTemplate] | None = None,
+    now: datetime = _NOW,
+) -> Template:
+    return Template.create(
+        organizer_id=organizer_id or UserId.generate(),
+        name=name,
+        default_counterparts=default_counterparts,
+        agenda_templates=agenda_templates,
+        now=now,
+    )
+
+
+class TestTemplateCreate:
+    def test_creates_with_defaults(self) -> None:
+        tmpl = _make_template()
+        assert tmpl.name == "Monthly 1on1"
+        assert tmpl.default_counterparts == []
+        assert tmpl.agenda_templates == []
+        assert tmpl.created_at == _NOW
+
+    def test_creates_with_counterparts_and_agenda_templates(self) -> None:
+        cps = [UserId.generate(), UserId.generate()]
+        ats = [AgendaTemplate("Topic A"), AgendaTemplate("Topic B")]
+        tmpl = _make_template(default_counterparts=cps, agenda_templates=ats)
+        assert tmpl.default_counterparts == cps
+        assert tmpl.agenda_templates == ats
+
+    def test_name_strips_whitespace(self) -> None:
+        tmpl = _make_template(name="  Padded Name  ")
+        assert tmpl.name == "Padded Name"
+
+    def test_empty_name_raises(self) -> None:
+        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
+            _make_template(name="")
+
+    def test_whitespace_only_name_raises(self) -> None:
+        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
+            _make_template(name="   ")
+
+    def test_name_exceeds_max_length_raises(self) -> None:
+        with pytest.raises(InvalidTemplateNameError, match="must not exceed"):
+            _make_template(name="a" * 101)
+
+    def test_name_exactly_max_length_is_valid(self) -> None:
+        tmpl = _make_template(name="a" * 100)
+        assert len(tmpl.name) == 100
+
+    def test_emits_template_saved_event(self) -> None:
+        tmpl = _make_template()
+        events = tmpl.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, TemplateSaved)
+        assert event.template_id == tmpl.id
+        assert event.name == "Monthly 1on1"
+
+    def test_collect_events_clears_list(self) -> None:
+        tmpl = _make_template()
+        tmpl.collect_events()
+        assert tmpl.collect_events() == []
+
+
+class TestTemplateUpdate:
+    def test_update_all_fields(self) -> None:
+        organizer = UserId.generate()
+        tmpl = _make_template(organizer_id=organizer)
+        new_cps = [UserId.generate()]
+        new_ats = [AgendaTemplate("New topic")]
+
+        tmpl.update(
+            actor_id=organizer,
+            name="Updated Name",
+            default_counterparts=new_cps,
+            agenda_templates=new_ats,
+            now=_LATER,
+        )
+
+        assert tmpl.name == "Updated Name"
+        assert tmpl.default_counterparts == new_cps
+        assert tmpl.agenda_templates == new_ats
+        assert tmpl.updated_at == _LATER
+
+    def test_update_emits_event(self) -> None:
+        organizer = UserId.generate()
+        tmpl = _make_template(organizer_id=organizer)
+        tmpl.collect_events()  # clear
+
+        tmpl.update(
+            actor_id=organizer,
+            name="New Name",
+            default_counterparts=[],
+            agenda_templates=[],
+            now=_LATER,
+        )
+
+        events = tmpl.collect_events()
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, TemplateSaved)
+        assert event.name == "New Name"
+
+    def test_non_organizer_cannot_update(self) -> None:
+        organizer = UserId.generate()
+        other = UserId.generate()
+        tmpl = _make_template(organizer_id=organizer)
+
+        with pytest.raises(
+            UnauthorizedScheduleGroupOperationError, match="Only the organizer"
+        ):
+            tmpl.update(
+                actor_id=other,
+                name="New Name",
+                default_counterparts=[],
+                agenda_templates=[],
+                now=_LATER,
+            )
+
+    def test_update_with_invalid_name_raises(self) -> None:
+        organizer = UserId.generate()
+        tmpl = _make_template(organizer_id=organizer)
+
+        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
+            tmpl.update(
+                actor_id=organizer,
+                name="",
+                default_counterparts=[],
+                agenda_templates=[],
+                now=_LATER,
+            )
+
+
+class TestTemplateProperties:
+    def test_default_counterparts_returns_copy(self) -> None:
+        cps = [UserId.generate()]
+        tmpl = _make_template(default_counterparts=cps)
+        returned = tmpl.default_counterparts
+        assert returned is not tmpl.default_counterparts
+
+    def test_agenda_templates_returns_copy(self) -> None:
+        ats = [AgendaTemplate("A")]
+        tmpl = _make_template(agenda_templates=ats)
+        returned = tmpl.agenda_templates
+        assert returned is not tmpl.agenda_templates

--- a/backend/tests/contexts/preparation/domain/test_template.py
+++ b/backend/tests/contexts/preparation/domain/test_template.py
@@ -6,7 +6,7 @@ from contexts.preparation.domain.agenda_template import AgendaTemplate
 from contexts.preparation.domain.events import TemplateSaved
 from contexts.preparation.domain.exceptions import (
     InvalidTemplateNameError,
-    UnauthorizedScheduleGroupOperationError,
+    UnauthorizedTemplateOperationError,
 )
 from contexts.preparation.domain.template import Template
 from shared.domain.value_objects import UserId
@@ -127,7 +127,7 @@ class TestTemplateUpdate:
         tmpl = _make_template(organizer_id=organizer)
 
         with pytest.raises(
-            UnauthorizedScheduleGroupOperationError, match="Only the organizer"
+            UnauthorizedTemplateOperationError, match="Only the organizer"
         ):
             tmpl.update(
                 actor_id=other,

--- a/backend/tests/contexts/preparation/domain/test_template_name.py
+++ b/backend/tests/contexts/preparation/domain/test_template_name.py
@@ -1,0 +1,50 @@
+import pytest
+
+from contexts.preparation.domain.exceptions import InvalidTemplateNameError
+from contexts.preparation.domain.template_name import TemplateName
+
+
+class TestTemplateName:
+    def test_creates_with_valid_value(self) -> None:
+        name = TemplateName("Monthly 1on1")
+        assert name.value == "Monthly 1on1"
+
+    def test_strips_whitespace(self) -> None:
+        name = TemplateName("  padded name  ")
+        assert name.value == "padded name"
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
+            TemplateName("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
+            TemplateName("   ")
+
+    def test_exceeds_max_length_raises(self) -> None:
+        with pytest.raises(InvalidTemplateNameError, match="must not exceed"):
+            TemplateName("a" * 101)
+
+    def test_exactly_max_length_is_valid(self) -> None:
+        name = TemplateName("a" * 100)
+        assert len(name.value) == 100
+
+    def test_frozen(self) -> None:
+        name = TemplateName("name")
+        with pytest.raises(AttributeError):
+            name.value = "changed"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        assert TemplateName("name") == TemplateName("name")
+
+    def test_inequality(self) -> None:
+        assert TemplateName("name A") != TemplateName("name B")
+
+    def test_str(self) -> None:
+        name = TemplateName("My template")
+        assert str(name) == "My template"
+
+    def test_usable_as_dict_key(self) -> None:
+        name = TemplateName("name")
+        d = {name: "value"}
+        assert d[name] == "value"

--- a/backend/tests/contexts/preparation/domain/test_topic.py
+++ b/backend/tests/contexts/preparation/domain/test_topic.py
@@ -1,0 +1,58 @@
+import pytest
+
+from contexts.preparation.domain.exceptions import InvalidTopicError
+from contexts.preparation.domain.topic import Topic
+
+
+class TestTopic:
+    def test_creates_with_valid_value(self) -> None:
+        topic = Topic("Weekly check-in")
+        assert topic.value == "Weekly check-in"
+
+    def test_strips_whitespace(self) -> None:
+        topic = Topic("  padded topic  ")
+        assert topic.value == "padded topic"
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not be empty"):
+            Topic("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not be empty"):
+            Topic("   ")
+
+    def test_newline_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not contain newlines"):
+            Topic("line1\nline2")
+
+    def test_carriage_return_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not contain newlines"):
+            Topic("line1\rline2")
+
+    def test_exceeds_max_length_raises(self) -> None:
+        with pytest.raises(InvalidTopicError, match="must not exceed"):
+            Topic("a" * 201)
+
+    def test_exactly_max_length_is_valid(self) -> None:
+        topic = Topic("a" * 200)
+        assert len(topic.value) == 200
+
+    def test_frozen(self) -> None:
+        topic = Topic("topic")
+        with pytest.raises(AttributeError):
+            topic.value = "changed"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        assert Topic("topic") == Topic("topic")
+
+    def test_inequality(self) -> None:
+        assert Topic("topic A") != Topic("topic B")
+
+    def test_str(self) -> None:
+        topic = Topic("My topic")
+        assert str(topic) == "My topic"
+
+    def test_usable_as_dict_key(self) -> None:
+        topic = Topic("topic")
+        d = {topic: "value"}
+        assert d[topic] == "value"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,6 +112,18 @@ class Record:
         return events
 ```
 
+### 値オブジェクトの配置
+
+値オブジェクトは性質に応じて配置先を分ける。
+
+| 種類 | 配置先 | 例 |
+|---|---|---|
+| ID型（UUID ラッパー）、Enum | `domain/value_objects.py` | `ScheduleId`, `RecordStatus` |
+| ドメイン固有のバリデーションを持つ値オブジェクト | `domain/<vo_name>.py`（個別ファイル） | `Topic`, `CommentBody`, `TemplateName` |
+
+- ID型・Enum はバリデーションロジックが薄く（UUID パース程度）、数が多いため `value_objects.py` にまとめる
+- ドメイン固有の不変条件を持つ値オブジェクト（空禁止、最大長、改行禁止等）は関心が独立しているため個別ファイルに切り出す
+
 ### datetime の扱い
 
 - **ファクトリメソッド（`create()`）**: `now: datetime | None = None` で受け取り、省略時は `datetime.now(UTC)` をフォールバックとして使用する


### PR DESCRIPTION
## Summary

- Preparationコンテキストに新しいドメインモデルを追加: ScheduleGroup（集約ルート）、Agenda（エンティティ）、Template（エンティティ）、AgendaTemplate（値オブジェクト）、Comment（子エンティティ）
- ScheduleGroupからの一括アジェンダ追加・削除の伝播ロジックを実装（アジェンダ編集は禁止、削除→再追加で対応）
- 境界条件（対象0件で正常終了、重複トピック許可、権限チェック）をカバーするユニットテストを追加
- 新しい値オブジェクト（ScheduleGroupId, AgendaId, TemplateId, CommentId）とドメインイベント（ScheduleGroupCreated, AgendaAddedViaGroup, AgendaRemovedViaGroup, TemplateSaved）を追加

## 実装詳細

### 新規ファイル
- `backend/contexts/preparation/domain/agenda_template.py` - AgendaTemplate値オブジェクト（トピック名のバリデーション付き）
- `backend/contexts/preparation/domain/agenda.py` - Agendaエンティティ（コメントスレッド付き）
- `backend/contexts/preparation/domain/comment.py` - Comment子エンティティ
- `backend/contexts/preparation/domain/schedule_group.py` - ScheduleGroup集約ルート（一括操作ロジック）
- `backend/contexts/preparation/domain/template.py` - Templateエンティティ（プリセット管理）

### 変更ファイル
- `backend/contexts/preparation/domain/value_objects.py` - 新ID型追加
- `backend/contexts/preparation/domain/events.py` - 新ドメインイベント追加
- `backend/contexts/preparation/domain/exceptions.py` - 新例外クラス追加

### 受け入れ基準の対応
- 一括伝播: 同期・トランザクション制御を前提とした設計
- アジェンダ削除: 物理削除（コメントごと削除）
- ID型配置: Preparationコンテキストのvalue_objects.pyに定義
- 境界条件: 対象0件→正常終了、重複追加→許可、権限チェック→例外

## テスト

- 166件のユニットテストがすべてパス（`pytest -m 'not integration'`）
- ruff check / ruff format / pyright すべてパス

Closes #47

## Test plan
- [x] `uv run pytest -m 'not integration'` で全テストがパスすることを確認
- [x] `uv run ruff check .` でリントエラーがないことを確認
- [x] `uv run ruff format --check .` でフォーマットが正しいことを確認
- [x] `uv run pyright` で型エラーがないことを確認

:robot: Generated with [Claude Code](https://claude.com/claude-code)