### PR TITLE
Record: ドメインモデル（公開先・コメント）の実装

### DIFF
--- a/backend/contexts/record/domain/comment.py
+++ b/backend/contexts/record/domain/comment.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from contexts.record.domain.comment_body import CommentBody
+from contexts.record.domain.events import CommentAdded
+from contexts.record.domain.value_objects import CommentId, RecordId
+from shared.domain.value_objects import UserId
+
+type _CommentEvent = CommentAdded
+
+
+@dataclass
+class Comment:
+    """Aggregate root: a comment on a published record.
+
+    Comments can be made by organizer, counterpart, or viewers.
+    Authorization (whether the actor is allowed to comment) is
+    the responsibility of the application layer, not the domain.
+    """
+
+    id: CommentId
+    record_id: RecordId
+    author_id: UserId
+    body: CommentBody
+    created_at: datetime
+    _events: list[_CommentEvent] = field(default_factory=list, repr=False)
+
+    @staticmethod
+    def create(
+        *,
+        record_id: RecordId,
+        author_id: UserId,
+        body: str,
+        now: datetime | None = None,
+    ) -> Comment:
+        """Create a new comment.
+
+        Raises:
+            InvalidCommentBodyError: If body is empty or exceeds max length.
+        """
+        comment_id = CommentId.generate()
+        ts = now or datetime.now(UTC)
+        comment = Comment(
+            id=comment_id,
+            record_id=record_id,
+            author_id=author_id,
+            body=CommentBody(body),
+            created_at=ts,
+        )
+        comment._events.append(
+            CommentAdded(
+                comment_id=comment_id,
+                record_id=record_id,
+                author_id=author_id,
+                created_at=ts,
+            )
+        )
+        return comment
+
+    def collect_events(self) -> list[_CommentEvent]:
+        """Return accumulated events and clear the internal list."""
+        events = list(self._events)
+        self._events.clear()
+        return events

--- a/backend/contexts/record/domain/comment_body.py
+++ b/backend/contexts/record/domain/comment_body.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contexts.record.domain.exceptions import InvalidCommentBodyError
+
+_COMMENT_BODY_MAX_LENGTH = 2000
+
+
+@dataclass(frozen=True)
+class CommentBody:
+    """Value object representing a comment body string.
+
+    Invariants:
+    - Must not be empty (after stripping whitespace).
+    - Max 2000 characters.
+    - Leading/trailing whitespace is stripped.
+    """
+
+    value: str
+
+    def __init__(self, value: str) -> None:
+        stripped = value.strip()
+        if not stripped:
+            raise InvalidCommentBodyError("Comment body must not be empty.")
+        if len(stripped) > _COMMENT_BODY_MAX_LENGTH:
+            raise InvalidCommentBodyError(
+                f"Comment body must not exceed {_COMMENT_BODY_MAX_LENGTH} characters."
+            )
+        object.__setattr__(self, "value", stripped)
+
+    def __str__(self) -> str:
+        return self.value

--- a/backend/contexts/record/domain/events.py
+++ b/backend/contexts/record/domain/events.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from contexts.preparation.domain.value_objects import ScheduleId
-from contexts.record.domain.value_objects import ActionItemId, RecordId
+from contexts.record.domain.value_objects import ActionItemId, CommentId, RecordId
 from shared.domain.value_objects import UserId
 
 
@@ -45,6 +45,26 @@ class RecordPublished:
     record_id: RecordId
     organizer_id: UserId
     published_at: datetime
+
+
+@dataclass(frozen=True)
+class ViewersChanged:
+    """Raised when the viewers list of a record is changed."""
+
+    record_id: RecordId
+    organizer_id: UserId
+    viewer_ids: tuple[UserId, ...]
+    changed_at: datetime
+
+
+@dataclass(frozen=True)
+class CommentAdded:
+    """Raised when a comment is added to a record."""
+
+    comment_id: CommentId
+    record_id: RecordId
+    author_id: UserId
+    created_at: datetime
 
 
 @dataclass(frozen=True)

--- a/backend/contexts/record/domain/exceptions.py
+++ b/backend/contexts/record/domain/exceptions.py
@@ -27,3 +27,10 @@ class InvalidActionItemTitleError(Exception):
 
     def __init__(self, message: str = "Invalid action item title.") -> None:
         super().__init__(message)
+
+
+class InvalidCommentBodyError(Exception):
+    """Raised when a comment body fails validation."""
+
+    def __init__(self, message: str = "Invalid comment body.") -> None:
+        super().__init__(message)

--- a/backend/contexts/record/domain/record.py
+++ b/backend/contexts/record/domain/record.py
@@ -9,6 +9,7 @@ from contexts.record.domain.events import (
     RecordCreated,
     RecordDraftSaved,
     RecordPublished,
+    ViewersChanged,
 )
 from contexts.record.domain.exceptions import (
     RecordAlreadyPublishedError,
@@ -17,7 +18,9 @@ from contexts.record.domain.exceptions import (
 from contexts.record.domain.value_objects import RecordId, RecordStatus
 from shared.domain.value_objects import UserId
 
-type _RecordEvent = RecordCreated | MemoUpdated | RecordDraftSaved | RecordPublished
+type _RecordEvent = (
+    RecordCreated | MemoUpdated | RecordDraftSaved | RecordPublished | ViewersChanged
+)
 
 
 @dataclass
@@ -37,6 +40,7 @@ class Record:
     schedule_id: ScheduleId | None
     _memo: str
     _status: RecordStatus
+    _viewers: list[UserId]
     conducted_at: datetime
     created_at: datetime
     _updated_at: datetime
@@ -49,6 +53,10 @@ class Record:
     @property
     def status(self) -> RecordStatus:
         return self._status
+
+    @property
+    def viewers(self) -> list[UserId]:
+        return list(self._viewers)
 
     @property
     def updated_at(self) -> datetime:
@@ -73,6 +81,7 @@ class Record:
             schedule_id=schedule_id,
             _memo="",
             _status=RecordStatus.DRAFT,
+            _viewers=[],
             conducted_at=conducted_at,
             created_at=ts,
             _updated_at=ts,
@@ -133,15 +142,46 @@ class Record:
             )
         )
 
+    def set_viewers(
+        self, *, viewer_ids: list[UserId], actor_id: UserId, now: datetime
+    ) -> None:
+        """Set the viewers list. Only the organizer may change viewers.
+
+        organizer_id and counterpart_id are implicitly included and will be
+        excluded from the explicit viewers list. Duplicates are removed.
+        """
+        self._assert_organizer(actor_id)
+        implicit = {self.organizer_id, self.counterpart_id}
+        seen: set[UserId] = set()
+        deduplicated: list[UserId] = []
+        for vid in viewer_ids:
+            if vid not in implicit and vid not in seen:
+                seen.add(vid)
+                deduplicated.append(vid)
+        self._viewers = deduplicated
+        self._updated_at = now
+        self._events.append(
+            ViewersChanged(
+                record_id=self.id,
+                organizer_id=self.organizer_id,
+                viewer_ids=tuple(deduplicated),
+                changed_at=now,
+            )
+        )
+
     def is_visible_to(self, user_id: UserId) -> bool:
         """Check if the record is visible to a given user.
 
         Draft records are only visible to the organizer.
-        Published records visibility is managed by the Publishing context.
+        Published records are visible to organizer, counterpart, and viewers.
         """
         if self._status == RecordStatus.DRAFT:
             return user_id == self.organizer_id
-        return True
+        return (
+            user_id == self.organizer_id
+            or user_id == self.counterpart_id
+            or user_id in self._viewers
+        )
 
     def collect_events(self) -> list[_RecordEvent]:
         """Return accumulated events and clear the internal list."""

--- a/backend/contexts/record/domain/value_objects.py
+++ b/backend/contexts/record/domain/value_objects.py
@@ -71,6 +71,21 @@ class ActionItemId:
         return ActionItemId(value=uuid.UUID(raw))
 
 
+@dataclass(frozen=True)
+class CommentId:
+    """Comment identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> CommentId:
+        return CommentId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> CommentId:
+        return CommentId(value=uuid.UUID(raw))
+
+
 class RecordStatus(Enum):
     """Record status: Draft -> Published (one-way transition)."""
 

--- a/backend/tests/contexts/record/domain/test_comment.py
+++ b/backend/tests/contexts/record/domain/test_comment.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+
+import pytest
+
+from contexts.record.domain.comment import Comment
+from contexts.record.domain.comment_body import CommentBody
+from contexts.record.domain.events import CommentAdded
+from contexts.record.domain.exceptions import InvalidCommentBodyError
+from contexts.record.domain.value_objects import RecordId
+from shared.domain.value_objects import UserId
+
+
+def _make_comment(
+    *,
+    record_id: RecordId | None = None,
+    author_id: UserId | None = None,
+    body: str = "Great discussion today!",
+    now: datetime | None = None,
+) -> Comment:
+    """Helper to create a comment with sensible defaults."""
+    return Comment.create(
+        record_id=record_id or RecordId.generate(),
+        author_id=author_id or UserId.generate(),
+        body=body,
+        now=now or datetime(2026, 3, 20, 11, 0),
+    )
+
+
+class TestCommentCreate:
+    def test_creates_with_defaults(self) -> None:
+        comment = _make_comment()
+        assert comment.body == CommentBody("Great discussion today!")
+
+    def test_sets_record_id_and_author_id(self) -> None:
+        record_id = RecordId.generate()
+        author_id = UserId.generate()
+        comment = _make_comment(record_id=record_id, author_id=author_id)
+
+        assert comment.record_id == record_id
+        assert comment.author_id == author_id
+
+    def test_sets_timestamp(self) -> None:
+        now = datetime(2026, 3, 20, 11, 0)
+        comment = _make_comment(now=now)
+        assert comment.created_at == now
+
+    def test_body_must_not_be_empty(self) -> None:
+        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
+            _make_comment(body="   ")
+
+    def test_body_must_not_exceed_max_length(self) -> None:
+        with pytest.raises(InvalidCommentBodyError, match="must not exceed"):
+            _make_comment(body="a" * 2001)
+
+    def test_body_strips_whitespace(self) -> None:
+        comment = _make_comment(body="  some comment  ")
+        assert comment.body.value == "some comment"
+
+    def test_emits_comment_added_event(self) -> None:
+        now = datetime(2026, 3, 20, 11, 0)
+        comment = _make_comment(now=now)
+        events = comment.collect_events()
+
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, CommentAdded)
+        assert event.comment_id == comment.id
+        assert event.record_id == comment.record_id
+        assert event.author_id == comment.author_id
+        assert event.created_at == now
+
+    def test_collect_events_clears_list(self) -> None:
+        comment = _make_comment()
+        events = comment.collect_events()
+        assert len(events) == 1
+        assert comment.collect_events() == []

--- a/backend/tests/contexts/record/domain/test_record.py
+++ b/backend/tests/contexts/record/domain/test_record.py
@@ -8,6 +8,7 @@ from contexts.record.domain.events import (
     RecordCreated,
     RecordDraftSaved,
     RecordPublished,
+    ViewersChanged,
 )
 from contexts.record.domain.exceptions import (
     RecordAlreadyPublishedError,
@@ -221,10 +222,145 @@ class TestRecordVisibility:
 
         assert record.is_visible_to(other) is False
 
-    def test_published_visible_to_anyone(self) -> None:
+    def test_published_visible_to_organizer(self) -> None:
         organizer = UserId.generate()
         record = _make_record(organizer_id=organizer)
         record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 10, 45))
+
+        assert record.is_visible_to(organizer) is True
+
+    def test_published_visible_to_counterpart(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 10, 45))
+
+        assert record.is_visible_to(counterpart) is True
+
+    def test_published_visible_to_viewer(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        viewer = UserId.generate()
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        record.set_viewers(
+            viewer_ids=[viewer],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 10, 40),
+        )
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 10, 45))
+
+        assert record.is_visible_to(viewer) is True
+
+    def test_published_not_visible_to_non_viewer(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 10, 45))
         other = UserId.generate()
 
-        assert record.is_visible_to(other) is True
+        assert record.is_visible_to(other) is False
+
+
+class TestRecordViewers:
+    def test_organizer_can_set_viewers(self) -> None:
+        organizer = UserId.generate()
+        viewer1 = UserId.generate()
+        viewer2 = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.set_viewers(viewer_ids=[viewer1, viewer2], actor_id=organizer, now=now)
+
+        assert viewer1 in record.viewers
+        assert viewer2 in record.viewers
+        assert len(record.viewers) == 2
+
+    def test_non_organizer_cannot_set_viewers(self) -> None:
+        organizer = UserId.generate()
+        other = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+
+        with pytest.raises(UnauthorizedOperationError, match="Only the organizer"):
+            record.set_viewers(
+                viewer_ids=[UserId.generate()],
+                actor_id=other,
+                now=datetime(2026, 3, 20, 11, 0),
+            )
+
+    def test_excludes_organizer_from_viewers(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+
+        record.set_viewers(
+            viewer_ids=[organizer],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+
+        assert record.viewers == []
+
+    def test_excludes_counterpart_from_viewers(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+
+        record.set_viewers(
+            viewer_ids=[counterpart],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+
+        assert record.viewers == []
+
+    def test_deduplicates_viewers(self) -> None:
+        organizer = UserId.generate()
+        viewer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+
+        record.set_viewers(
+            viewer_ids=[viewer, viewer, viewer],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+
+        assert record.viewers == [viewer]
+
+    def test_emits_viewers_changed_event(self) -> None:
+        organizer = UserId.generate()
+        viewer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        record.collect_events()  # clear creation event
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.set_viewers(viewer_ids=[viewer], actor_id=organizer, now=now)
+
+        events = record.collect_events()
+        viewer_events = [e for e in events if isinstance(e, ViewersChanged)]
+        assert len(viewer_events) == 1
+        assert viewer_events[0].record_id == record.id
+        assert viewer_events[0].viewer_ids == (viewer,)
+        assert viewer_events[0].changed_at == now
+
+    def test_updates_timestamp(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.set_viewers(viewer_ids=[], actor_id=organizer, now=now)
+
+        assert record.updated_at == now
+
+    def test_viewers_property_returns_copy(self) -> None:
+        organizer = UserId.generate()
+        viewer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        record.set_viewers(
+            viewer_ids=[viewer],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+
+        returned = record.viewers
+        returned.append(UserId.generate())
+
+        assert len(record.viewers) == 1

--- a/backend/tests/contexts/record/domain/test_value_objects.py
+++ b/backend/tests/contexts/record/domain/test_value_objects.py
@@ -2,6 +2,7 @@ import uuid
 
 from contexts.record.domain.value_objects import (
     ActionItemId,
+    CommentId,
     RecordId,
     RecordStatus,
 )
@@ -55,6 +56,30 @@ class TestActionItemId:
         action_item_id = ActionItemId.generate()
         try:
             action_item_id.value = uuid.uuid4()  # type: ignore[misc]
+            raise AssertionError("Expected FrozenInstanceError")  # noqa: TRY301
+        except AttributeError:
+            pass
+
+
+class TestCommentId:
+    def test_generate_creates_unique_ids(self) -> None:
+        id1 = CommentId.generate()
+        id2 = CommentId.generate()
+        assert id1 != id2
+
+    def test_from_str_roundtrip(self) -> None:
+        raw = "770e8400-e29b-41d4-a716-446655440000"
+        comment_id = CommentId.from_str(raw)
+        assert str(comment_id.value) == raw
+
+    def test_equality_same_uuid(self) -> None:
+        raw = uuid.UUID("770e8400-e29b-41d4-a716-446655440000")
+        assert CommentId(value=raw) == CommentId(value=raw)
+
+    def test_frozen(self) -> None:
+        comment_id = CommentId.generate()
+        try:
+            comment_id.value = uuid.uuid4()  # type: ignore[misc]
             raise AssertionError("Expected FrozenInstanceError")  # noqa: TRY301
         except AttributeError:
             pass

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -327,5 +327,6 @@ Slack通知（リンク）
 
 ### イベントストーミング図（Figma / FigJam）
 
+- v18（公開先・コメント・フォローアップ追加）: https://www.figma.com/board/TwUYCgisIjpwzTRvAOx5jI/v18
 - v17（FollowUp・Session を Record に統合）: https://www.figma.com/board/TwUYCgisIjpwzTRvAOx5jI
 - v16（4フェーズ再定義）: https://www.figma.com/board/stNxBFtqJyjMW0zAzdStgN/1on1-%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%82%B9%E3%83%88%E3%83%BC%E3%83%9F%E3%83%B3%E3%82%B0-v16%EF%BC%884%E3%83%95%E3%82%A7%E3%83%BC%E3%82%BA%E5%86%8D%E5%AE%9A%E7%BE%A9%EF%BC%89?node-id=0-1&p=f&t=TjPlsLJAjfkUKTfO-0


### PR DESCRIPTION
## Summary
- Record 集約に Viewer（公開先）管理を追加し、`is_visible_to()` を Viewer リストベースの判定に変更
- Comment 別集約を ActionItem パターンに倣って新規作成（CommentBody VO、CommentId VO 含む）
- ViewersChanged / CommentAdded ドメインイベントを追加
- 既存の TestRecordVisibility を Viewer ベースに更新、TestRecordViewers / TestCommentCreate / TestCommentId テストを追加
- system_design.md にイベントストーミング v18 の Figma リンクを追加

## 対象ファイル

| ファイル | 変更種別 |
|---|---|
| `backend/contexts/record/domain/record.py` | 変更（Viewer 管理追加、is_visible_to 変更） |
| `backend/contexts/record/domain/comment.py` | 新規 |
| `backend/contexts/record/domain/comment_body.py` | 新規 |
| `backend/contexts/record/domain/value_objects.py` | 変更（CommentId 追加） |
| `backend/contexts/record/domain/events.py` | 変更（ViewersChanged, CommentAdded 追加） |
| `backend/contexts/record/domain/exceptions.py` | 変更（InvalidCommentBodyError 追加） |
| `backend/tests/contexts/record/domain/test_record.py` | 変更（Viewer テスト追加、Visibility テスト更新） |
| `backend/tests/contexts/record/domain/test_comment.py` | 新規 |
| `backend/tests/contexts/record/domain/test_value_objects.py` | 変更（CommentId テスト追加） |
| `docs/system_design.md` | 変更（Figma リンク追加） |

## Test plan
- [x] `ruff check` / `ruff format --check` パス
- [x] `pyright` 型チェック 0 errors
- [x] `pytest -m 'not integration'` 全 241 テストパス（新規テスト含む）

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)