### PR TITLE
ドメイン層のファクトリ/コマンドメソッドで値オブジェクトを受け取るように統一

### DIFF
--- a/backend/contexts/preparation/domain/agenda.py
+++ b/backend/contexts/preparation/domain/agenda.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from contexts.preparation.domain.comment import Comment
+from contexts.preparation.domain.comment_body import CommentBody
 from contexts.preparation.domain.topic import Topic
 from contexts.preparation.domain.value_objects import AgendaId, CommentId, ScheduleId
 from shared.domain.value_objects import UserId
@@ -58,27 +59,24 @@ class Agenda:
     def create(
         *,
         schedule_id: ScheduleId,
-        topic: str,
+        topic: Topic,
         added_by: UserId,
         now: datetime | None = None,
     ) -> Agenda:
-        """Factory method to create a new agenda item.
-
-        Raises:
-            InvalidTopicError: If topic is empty, contains newlines,
-                or exceeds max length.
-        """
+        """Factory method to create a new agenda item."""
         ts = now or datetime.now(UTC)
         return Agenda(
             _id=AgendaId.generate(),
             _schedule_id=schedule_id,
-            _topic=Topic(topic),
+            _topic=topic,
             _added_by=added_by,
             _comments=[],
             _created_at=ts,
         )
 
-    def add_comment(self, *, author_id: UserId, body: str, now: datetime) -> Comment:
+    def add_comment(
+        self, *, author_id: UserId, body: CommentBody, now: datetime
+    ) -> Comment:
         """Add a comment to this agenda topic.
 
         Both organizer and counterpart can comment (no restriction).

--- a/backend/contexts/preparation/domain/comment.py
+++ b/backend/contexts/preparation/domain/comment.py
@@ -47,19 +47,15 @@ class Comment:
         *,
         agenda_id: AgendaId,
         author_id: UserId,
-        body: str,
+        body: CommentBody,
         now: datetime | None = None,
     ) -> Comment:
-        """Factory method to create a new comment.
-
-        Raises:
-            InvalidCommentBodyError: If body is empty or exceeds max length.
-        """
+        """Factory method to create a new comment."""
         ts = now or datetime.now(UTC)
         return Comment(
             _id=CommentId.generate(),
             _agenda_id=agenda_id,
             _author_id=author_id,
-            _body=CommentBody(body),
+            _body=body,
             _created_at=ts,
         )

--- a/backend/contexts/preparation/domain/schedule_group.py
+++ b/backend/contexts/preparation/domain/schedule_group.py
@@ -236,7 +236,7 @@ class ScheduleGroup:
         for schedule_id in self._schedule_ids:
             agenda = Agenda.create(
                 schedule_id=schedule_id,
-                topic=agenda_template.topic.value,
+                topic=agenda_template.topic,
                 added_by=actor_id,
                 now=now,
             )

--- a/backend/contexts/preparation/domain/template.py
+++ b/backend/contexts/preparation/domain/template.py
@@ -63,7 +63,7 @@ class Template:
     def create(
         *,
         organizer_id: UserId,
-        name: str,
+        name: TemplateName,
         default_counterparts: list[UserId] | None = None,
         agenda_templates: list[AgendaTemplate] | None = None,
         now: datetime | None = None,
@@ -76,18 +76,14 @@ class Template:
             default_counterparts: Default counterpart user IDs.
             agenda_templates: Default agenda templates.
             now: Current time (defaults to UTC now).
-
-        Raises:
-            InvalidTemplateNameError: If name is empty or too long.
         """
         ts = now or datetime.now(UTC)
-        template_name = TemplateName(name)
         template_id = TemplateId.generate()
 
         template = Template(
             id=template_id,
             organizer_id=organizer_id,
-            _name=template_name,
+            _name=name,
             _default_counterparts=list(default_counterparts)
             if default_counterparts
             else [],
@@ -98,7 +94,7 @@ class Template:
         template._events.append(
             TemplateSaved(
                 template_id=template_id,
-                name=str(template_name),
+                name=str(name),
                 organizer_id=organizer_id,
                 occurred_at=ts,
             )
@@ -113,7 +109,7 @@ class Template:
         self,
         *,
         actor_id: UserId,
-        name: str,
+        name: TemplateName,
         default_counterparts: list[UserId],
         agenda_templates: list[AgendaTemplate],
         now: datetime,
@@ -125,21 +121,19 @@ class Template:
         Raises:
             UnauthorizedTemplateOperationError: If actor is not the
                 organizer.
-            InvalidTemplateNameError: If name is empty or too long.
         """
         if actor_id != self.organizer_id:
             raise UnauthorizedTemplateOperationError(
                 "Only the organizer can update this template."
             )
-        template_name = TemplateName(name)
-        self._name = template_name
+        self._name = name
         self._default_counterparts = list(default_counterparts)
         self._agenda_templates = list(agenda_templates)
         self._updated_at = now
         self._events.append(
             TemplateSaved(
                 template_id=self.id,
-                name=str(template_name),
+                name=str(name),
                 organizer_id=self.organizer_id,
                 occurred_at=now,
             )

--- a/backend/contexts/record/domain/action_item.py
+++ b/backend/contexts/record/domain/action_item.py
@@ -47,7 +47,7 @@ class ActionItem:
         *,
         counterpart_id: UserId,
         record_id: RecordId,
-        title: str,
+        title: ActionItemTitle,
         actor_id: UserId,
         organizer_id: UserId,
         now: datetime | None = None,
@@ -55,14 +55,13 @@ class ActionItem:
         """Create a new action item. Only the organizer may add."""
         if actor_id != organizer_id:
             raise UnauthorizedOperationError("Only the organizer can add action items.")
-        action_item_title = ActionItemTitle(title)
         action_item_id = ActionItemId.generate()
         ts = now or datetime.now(UTC)
         action_item = ActionItem(
             id=action_item_id,
             counterpart_id=counterpart_id,
             record_id=record_id,
-            title=action_item_title,
+            title=title,
             _is_completed=False,
             created_at=ts,
         )
@@ -71,7 +70,7 @@ class ActionItem:
                 action_item_id=action_item_id,
                 counterpart_id=counterpart_id,
                 record_id=record_id,
-                title=action_item_title.value,
+                title=title.value,
                 created_at=ts,
             )
         )

--- a/backend/contexts/record/domain/comment.py
+++ b/backend/contexts/record/domain/comment.py
@@ -32,21 +32,17 @@ class Comment:
         *,
         record_id: RecordId,
         author_id: UserId,
-        body: str,
+        body: CommentBody,
         now: datetime | None = None,
     ) -> Comment:
-        """Create a new comment.
-
-        Raises:
-            InvalidCommentBodyError: If body is empty or exceeds max length.
-        """
+        """Create a new comment."""
         comment_id = CommentId.generate()
         ts = now or datetime.now(UTC)
         comment = Comment(
             id=comment_id,
             record_id=record_id,
             author_id=author_id,
-            body=CommentBody(body),
+            body=body,
             created_at=ts,
         )
         comment._events.append(

--- a/backend/contexts/record/domain/exceptions.py
+++ b/backend/contexts/record/domain/exceptions.py
@@ -34,3 +34,10 @@ class InvalidCommentBodyError(Exception):
 
     def __init__(self, message: str = "Invalid comment body.") -> None:
         super().__init__(message)
+
+
+class InvalidMemoError(Exception):
+    """Raised when a memo fails validation."""
+
+    def __init__(self, message: str = "Invalid memo.") -> None:
+        super().__init__(message)

--- a/backend/contexts/record/domain/memo.py
+++ b/backend/contexts/record/domain/memo.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contexts.record.domain.exceptions import InvalidMemoError
+
+_MEMO_MAX_LENGTH = 10_000
+
+
+@dataclass(frozen=True)
+class Memo:
+    """Value object representing a record memo.
+
+    Invariants:
+    - Empty string is allowed.
+    - Newlines are allowed.
+    - Max 10,000 characters.
+    - Leading/trailing whitespace is stripped.
+    """
+
+    value: str
+
+    def __init__(self, raw: str) -> None:
+        stripped = raw.strip()
+        if len(stripped) > _MEMO_MAX_LENGTH:
+            raise InvalidMemoError(
+                f"Memo must not exceed {_MEMO_MAX_LENGTH} characters."
+            )
+        object.__setattr__(self, "value", stripped)
+
+    def __str__(self) -> str:
+        return self.value

--- a/backend/contexts/record/domain/record.py
+++ b/backend/contexts/record/domain/record.py
@@ -15,6 +15,7 @@ from contexts.record.domain.exceptions import (
     RecordAlreadyPublishedError,
     UnauthorizedOperationError,
 )
+from contexts.record.domain.memo import Memo
 from contexts.record.domain.value_objects import RecordId, RecordStatus
 from shared.domain.value_objects import UserId
 
@@ -98,11 +99,11 @@ class Record:
         )
         return record
 
-    def update_memo(self, *, memo: str, actor_id: UserId, now: datetime) -> None:
+    def update_memo(self, *, memo: Memo, actor_id: UserId, now: datetime) -> None:
         """Update memo content. Only the organizer may edit."""
         self._assert_organizer(actor_id)
         self._assert_draft()
-        self._memo = memo
+        self._memo = memo.value
         self._updated_at = now
         self._events.append(
             MemoUpdated(

--- a/backend/contexts/record/domain/record.py
+++ b/backend/contexts/record/domain/record.py
@@ -39,7 +39,7 @@ class Record:
     organizer_id: UserId
     counterpart_id: UserId
     schedule_id: ScheduleId | None
-    _memo: str
+    _memo: Memo
     _status: RecordStatus
     _viewers: list[UserId]
     conducted_at: datetime
@@ -48,7 +48,7 @@ class Record:
     _events: list[_RecordEvent] = field(default_factory=list, repr=False)
 
     @property
-    def memo(self) -> str:
+    def memo(self) -> Memo:
         return self._memo
 
     @property
@@ -80,7 +80,7 @@ class Record:
             organizer_id=organizer_id,
             counterpart_id=counterpart_id,
             schedule_id=schedule_id,
-            _memo="",
+            _memo=Memo(""),
             _status=RecordStatus.DRAFT,
             _viewers=[],
             conducted_at=conducted_at,
@@ -103,7 +103,7 @@ class Record:
         """Update memo content. Only the organizer may edit."""
         self._assert_organizer(actor_id)
         self._assert_draft()
-        self._memo = memo.value
+        self._memo = memo
         self._updated_at = now
         self._events.append(
             MemoUpdated(

--- a/backend/tests/contexts/preparation/domain/test_agenda.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda.py
@@ -1,25 +1,20 @@
 from datetime import datetime
 
-import pytest
-
 from contexts.preparation.domain.agenda import Agenda
 from contexts.preparation.domain.comment_body import CommentBody
-from contexts.preparation.domain.exceptions import (
-    InvalidCommentBodyError,
-    InvalidTopicError,
-)
 from contexts.preparation.domain.topic import Topic
 from contexts.preparation.domain.value_objects import ScheduleId
 from shared.domain.value_objects import UserId
 
 _NOW = datetime(2026, 3, 20, 10, 0)
 _LATER = datetime(2026, 3, 20, 11, 0)
+_DEFAULT_TOPIC = Topic("Discuss project status")
 
 
 def _make_agenda(
     *,
     schedule_id: ScheduleId | None = None,
-    topic: str = "Discuss project status",
+    topic: Topic = _DEFAULT_TOPIC,
     added_by: UserId | None = None,
     now: datetime = _NOW,
 ) -> Agenda:
@@ -43,24 +38,8 @@ class TestAgendaCreate:
         a2 = _make_agenda()
         assert a1.id != a2.id
 
-    def test_empty_topic_raises(self) -> None:
-        with pytest.raises(InvalidTopicError, match="must not be empty"):
-            _make_agenda(topic="")
-
-    def test_whitespace_only_topic_raises(self) -> None:
-        with pytest.raises(InvalidTopicError, match="must not be empty"):
-            _make_agenda(topic="   ")
-
-    def test_newline_topic_raises(self) -> None:
-        with pytest.raises(InvalidTopicError, match="must not contain newlines"):
-            _make_agenda(topic="line1\nline2")
-
-    def test_topic_exceeds_max_length_raises(self) -> None:
-        with pytest.raises(InvalidTopicError, match="must not exceed"):
-            _make_agenda(topic="a" * 201)
-
-    def test_topic_strips_whitespace(self) -> None:
-        agenda = _make_agenda(topic="  padded  ")
+    def test_topic_is_stored_as_given(self) -> None:
+        agenda = _make_agenda(topic=Topic("padded"))
         assert agenda.topic == Topic("padded")
 
 
@@ -71,7 +50,7 @@ class TestAgendaComment:
 
         comment = agenda.add_comment(
             author_id=author,
-            body="Let's focus on timeline",
+            body=CommentBody("Let's focus on timeline"),
             now=_LATER,
         )
 
@@ -85,15 +64,17 @@ class TestAgendaComment:
         user1 = UserId.generate()
         user2 = UserId.generate()
 
-        agenda.add_comment(author_id=user1, body="Comment 1", now=_LATER)
-        agenda.add_comment(author_id=user2, body="Comment 2", now=_LATER)
+        agenda.add_comment(author_id=user1, body=CommentBody("Comment 1"), now=_LATER)
+        agenda.add_comment(author_id=user2, body=CommentBody("Comment 2"), now=_LATER)
 
         assert len(agenda.comments) == 2
 
     def test_find_comment(self) -> None:
         agenda = _make_agenda()
         author = UserId.generate()
-        comment = agenda.add_comment(author_id=author, body="Some comment", now=_LATER)
+        comment = agenda.add_comment(
+            author_id=author, body=CommentBody("Some comment"), now=_LATER
+        )
 
         found = agenda.find_comment(comment.id)
         assert found is not None
@@ -111,31 +92,11 @@ class TestAgendaComment:
         comments = agenda.comments
         assert comments is not agenda.comments  # different list instances
 
-    def test_empty_comment_body_raises(self) -> None:
-        agenda = _make_agenda()
-        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
-            agenda.add_comment(author_id=UserId.generate(), body="", now=_LATER)
-
-    def test_whitespace_only_comment_body_raises(self) -> None:
-        agenda = _make_agenda()
-        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
-            agenda.add_comment(author_id=UserId.generate(), body="   ", now=_LATER)
-
-    def test_comment_body_exceeds_max_length_raises(self) -> None:
-        agenda = _make_agenda()
-        with pytest.raises(InvalidCommentBodyError, match="must not exceed"):
-            agenda.add_comment(author_id=UserId.generate(), body="a" * 2001, now=_LATER)
-
-    def test_comment_body_at_max_length_is_valid(self) -> None:
+    def test_comment_body_is_stored_as_given(self) -> None:
         agenda = _make_agenda()
         comment = agenda.add_comment(
-            author_id=UserId.generate(), body="a" * 2000, now=_LATER
-        )
-        assert len(str(comment.body)) == 2000
-
-    def test_comment_body_strips_whitespace(self) -> None:
-        agenda = _make_agenda()
-        comment = agenda.add_comment(
-            author_id=UserId.generate(), body="  hello  ", now=_LATER
+            author_id=UserId.generate(),
+            body=CommentBody("hello"),
+            now=_LATER,
         )
         assert comment.body == CommentBody("hello")

--- a/backend/tests/contexts/preparation/domain/test_schedule_group.py
+++ b/backend/tests/contexts/preparation/domain/test_schedule_group.py
@@ -4,6 +4,7 @@ import pytest
 
 from contexts.preparation.domain.agenda import Agenda
 from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.comment_body import CommentBody
 from contexts.preparation.domain.events import (
     AgendaAddedViaGroup,
     AgendaRemovedViaGroup,
@@ -369,8 +370,6 @@ class TestScheduleGroupRemoveAgenda:
         )
         # Add comment to the agenda
         agenda = schedules_agendas[schedule_ids[0]][0]
-        from contexts.preparation.domain.comment_body import CommentBody
-
         agenda.add_comment(
             author_id=UserId.generate(), body=CommentBody("A comment"), now=_LATER
         )

--- a/backend/tests/contexts/preparation/domain/test_schedule_group.py
+++ b/backend/tests/contexts/preparation/domain/test_schedule_group.py
@@ -369,7 +369,11 @@ class TestScheduleGroupRemoveAgenda:
         )
         # Add comment to the agenda
         agenda = schedules_agendas[schedule_ids[0]][0]
-        agenda.add_comment(author_id=UserId.generate(), body="A comment", now=_LATER)
+        from contexts.preparation.domain.comment_body import CommentBody
+
+        agenda.add_comment(
+            author_id=UserId.generate(), body=CommentBody("A comment"), now=_LATER
+        )
         assert len(agenda.comments) == 1
 
         removed_ids = group.remove_agenda_from_schedules(

--- a/backend/tests/contexts/preparation/domain/test_template.py
+++ b/backend/tests/contexts/preparation/domain/test_template.py
@@ -5,7 +5,6 @@ import pytest
 from contexts.preparation.domain.agenda_template import AgendaTemplate
 from contexts.preparation.domain.events import TemplateSaved
 from contexts.preparation.domain.exceptions import (
-    InvalidTemplateNameError,
     UnauthorizedTemplateOperationError,
 )
 from contexts.preparation.domain.template import Template
@@ -14,12 +13,13 @@ from shared.domain.value_objects import UserId
 
 _NOW = datetime(2026, 3, 20, 10, 0)
 _LATER = datetime(2026, 3, 20, 11, 0)
+_DEFAULT_TEMPLATE_NAME = TemplateName("Monthly 1on1")
 
 
 def _make_template(
     *,
     organizer_id: UserId | None = None,
-    name: str = "Monthly 1on1",
+    name: TemplateName = _DEFAULT_TEMPLATE_NAME,
     default_counterparts: list[UserId] | None = None,
     agenda_templates: list[AgendaTemplate] | None = None,
     now: datetime = _NOW,
@@ -48,25 +48,9 @@ class TestTemplateCreate:
         assert tmpl.default_counterparts == cps
         assert tmpl.agenda_templates == ats
 
-    def test_name_strips_whitespace(self) -> None:
-        tmpl = _make_template(name="  Padded Name  ")
-        assert tmpl.name == TemplateName("Padded Name")
-
-    def test_empty_name_raises(self) -> None:
-        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
-            _make_template(name="")
-
-    def test_whitespace_only_name_raises(self) -> None:
-        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
-            _make_template(name="   ")
-
-    def test_name_exceeds_max_length_raises(self) -> None:
-        with pytest.raises(InvalidTemplateNameError, match="must not exceed"):
-            _make_template(name="a" * 101)
-
-    def test_name_exactly_max_length_is_valid(self) -> None:
-        tmpl = _make_template(name="a" * 100)
-        assert len(tmpl.name.value) == 100
+    def test_name_is_stored_as_given(self) -> None:
+        tmpl = _make_template(name=TemplateName("Custom Name"))
+        assert tmpl.name == TemplateName("Custom Name")
 
     def test_emits_template_saved_event(self) -> None:
         tmpl = _make_template()
@@ -92,7 +76,7 @@ class TestTemplateUpdate:
 
         tmpl.update(
             actor_id=organizer,
-            name="Updated Name",
+            name=TemplateName("Updated Name"),
             default_counterparts=new_cps,
             agenda_templates=new_ats,
             now=_LATER,
@@ -110,7 +94,7 @@ class TestTemplateUpdate:
 
         tmpl.update(
             actor_id=organizer,
-            name="New Name",
+            name=TemplateName("New Name"),
             default_counterparts=[],
             agenda_templates=[],
             now=_LATER,
@@ -132,20 +116,7 @@ class TestTemplateUpdate:
         ):
             tmpl.update(
                 actor_id=other,
-                name="New Name",
-                default_counterparts=[],
-                agenda_templates=[],
-                now=_LATER,
-            )
-
-    def test_update_with_invalid_name_raises(self) -> None:
-        organizer = UserId.generate()
-        tmpl = _make_template(organizer_id=organizer)
-
-        with pytest.raises(InvalidTemplateNameError, match="must not be empty"):
-            tmpl.update(
-                actor_id=organizer,
-                name="",
+                name=TemplateName("New Name"),
                 default_counterparts=[],
                 agenda_templates=[],
                 now=_LATER,

--- a/backend/tests/contexts/record/domain/test_action_item.py
+++ b/backend/tests/contexts/record/domain/test_action_item.py
@@ -6,11 +6,12 @@ from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.events import ActionItemAdded, ActionItemCompleted
 from contexts.record.domain.exceptions import (
     ActionItemAlreadyCompletedError,
-    InvalidActionItemTitleError,
     UnauthorizedOperationError,
 )
 from contexts.record.domain.value_objects import ActionItemTitle, RecordId
 from shared.domain.value_objects import UserId
+
+_DEFAULT_TITLE = ActionItemTitle("Follow up on project status")
 
 
 def _make_action_item(
@@ -18,7 +19,7 @@ def _make_action_item(
     organizer_id: UserId | None = None,
     counterpart_id: UserId | None = None,
     record_id: RecordId | None = None,
-    title: str = "Follow up on project status",
+    title: ActionItemTitle = _DEFAULT_TITLE,
     now: datetime | None = None,
 ) -> ActionItem:
     """Helper to create an action item with sensible defaults."""
@@ -47,52 +48,14 @@ class TestActionItemCreate:
             ActionItem.create(
                 counterpart_id=UserId.generate(),
                 record_id=RecordId.generate(),
-                title="Task",
+                title=ActionItemTitle("Task"),
                 actor_id=other,
                 organizer_id=organizer,
             )
 
-    def test_title_must_not_be_empty(self) -> None:
-        organizer = UserId.generate()
-
-        with pytest.raises(InvalidActionItemTitleError, match="must not be empty"):
-            ActionItem.create(
-                counterpart_id=UserId.generate(),
-                record_id=RecordId.generate(),
-                title="   ",
-                actor_id=organizer,
-                organizer_id=organizer,
-            )
-
-    def test_title_must_not_contain_newlines(self) -> None:
-        organizer = UserId.generate()
-
-        with pytest.raises(
-            InvalidActionItemTitleError, match="must not contain newlines"
-        ):
-            ActionItem.create(
-                counterpart_id=UserId.generate(),
-                record_id=RecordId.generate(),
-                title="line1\nline2",
-                actor_id=organizer,
-                organizer_id=organizer,
-            )
-
-    def test_title_must_not_exceed_max_length(self) -> None:
-        organizer = UserId.generate()
-
-        with pytest.raises(InvalidActionItemTitleError, match="must not exceed"):
-            ActionItem.create(
-                counterpart_id=UserId.generate(),
-                record_id=RecordId.generate(),
-                title="a" * 201,
-                actor_id=organizer,
-                organizer_id=organizer,
-            )
-
-    def test_title_strips_whitespace(self) -> None:
-        item = _make_action_item(title="  some task  ")
-        assert item.title.value == "some task"
+    def test_title_is_stored_as_given(self) -> None:
+        item = _make_action_item(title=ActionItemTitle("some task"))
+        assert item.title == ActionItemTitle("some task")
 
     def test_emits_action_item_added_event(self) -> None:
         item = _make_action_item()

--- a/backend/tests/contexts/record/domain/test_comment.py
+++ b/backend/tests/contexts/record/domain/test_comment.py
@@ -1,20 +1,19 @@
 from datetime import datetime
 
-import pytest
-
 from contexts.record.domain.comment import Comment
 from contexts.record.domain.comment_body import CommentBody
 from contexts.record.domain.events import CommentAdded
-from contexts.record.domain.exceptions import InvalidCommentBodyError
 from contexts.record.domain.value_objects import RecordId
 from shared.domain.value_objects import UserId
+
+_DEFAULT_BODY = CommentBody("Great discussion today!")
 
 
 def _make_comment(
     *,
     record_id: RecordId | None = None,
     author_id: UserId | None = None,
-    body: str = "Great discussion today!",
+    body: CommentBody = _DEFAULT_BODY,
     now: datetime | None = None,
 ) -> Comment:
     """Helper to create a comment with sensible defaults."""
@@ -44,17 +43,9 @@ class TestCommentCreate:
         comment = _make_comment(now=now)
         assert comment.created_at == now
 
-    def test_body_must_not_be_empty(self) -> None:
-        with pytest.raises(InvalidCommentBodyError, match="must not be empty"):
-            _make_comment(body="   ")
-
-    def test_body_must_not_exceed_max_length(self) -> None:
-        with pytest.raises(InvalidCommentBodyError, match="must not exceed"):
-            _make_comment(body="a" * 2001)
-
-    def test_body_strips_whitespace(self) -> None:
-        comment = _make_comment(body="  some comment  ")
-        assert comment.body.value == "some comment"
+    def test_body_is_stored_as_given(self) -> None:
+        comment = _make_comment(body=CommentBody("some comment"))
+        assert comment.body == CommentBody("some comment")
 
     def test_emits_comment_added_event(self) -> None:
         now = datetime(2026, 3, 20, 11, 0)

--- a/backend/tests/contexts/record/domain/test_memo.py
+++ b/backend/tests/contexts/record/domain/test_memo.py
@@ -1,0 +1,45 @@
+import pytest
+
+from contexts.record.domain.exceptions import InvalidMemoError
+from contexts.record.domain.memo import Memo
+
+
+class TestMemo:
+    def test_empty_string_is_allowed(self) -> None:
+        memo = Memo("")
+        assert memo.value == ""
+
+    def test_strips_whitespace(self) -> None:
+        memo = Memo("  hello  ")
+        assert memo.value == "hello"
+
+    def test_whitespace_only_becomes_empty(self) -> None:
+        memo = Memo("   ")
+        assert memo.value == ""
+
+    def test_newlines_are_allowed(self) -> None:
+        memo = Memo("line1\nline2\nline3")
+        assert memo.value == "line1\nline2\nline3"
+
+    def test_max_length_is_valid(self) -> None:
+        memo = Memo("a" * 10_000)
+        assert len(memo.value) == 10_000
+
+    def test_exceeds_max_length_raises(self) -> None:
+        with pytest.raises(InvalidMemoError, match="must not exceed"):
+            Memo("a" * 10_001)
+
+    def test_str_returns_value(self) -> None:
+        memo = Memo("some memo")
+        assert str(memo) == "some memo"
+
+    def test_equality(self) -> None:
+        assert Memo("hello") == Memo("hello")
+
+    def test_frozen(self) -> None:
+        memo = Memo("hello")
+        try:
+            memo.value = "changed"  # type: ignore[misc]
+            raise AssertionError("Expected FrozenInstanceError")  # noqa: TRY301
+        except AttributeError:
+            pass

--- a/backend/tests/contexts/record/domain/test_memo.py
+++ b/backend/tests/contexts/record/domain/test_memo.py
@@ -38,8 +38,5 @@ class TestMemo:
 
     def test_frozen(self) -> None:
         memo = Memo("hello")
-        try:
+        with pytest.raises(AttributeError):
             memo.value = "changed"  # type: ignore[misc]
-            raise AssertionError("Expected FrozenInstanceError")  # noqa: TRY301
-        except AttributeError:
-            pass

--- a/backend/tests/contexts/record/domain/test_record.py
+++ b/backend/tests/contexts/record/domain/test_record.py
@@ -14,6 +14,7 @@ from contexts.record.domain.exceptions import (
     RecordAlreadyPublishedError,
     UnauthorizedOperationError,
 )
+from contexts.record.domain.memo import Memo
 from contexts.record.domain.record import Record
 from contexts.record.domain.value_objects import RecordStatus
 from shared.domain.value_objects import UserId
@@ -79,7 +80,7 @@ class TestRecordUpdateMemo:
         record = _make_record(organizer_id=organizer)
         now = datetime(2026, 3, 20, 11, 0)
 
-        record.update_memo(memo="Discussion notes", actor_id=organizer, now=now)
+        record.update_memo(memo=Memo("Discussion notes"), actor_id=organizer, now=now)
 
         assert record.memo == "Discussion notes"
         assert record.updated_at == now
@@ -91,7 +92,7 @@ class TestRecordUpdateMemo:
 
         with pytest.raises(UnauthorizedOperationError, match="Only the organizer"):
             record.update_memo(
-                memo="hack", actor_id=other, now=datetime(2026, 3, 20, 11, 0)
+                memo=Memo("hack"), actor_id=other, now=datetime(2026, 3, 20, 11, 0)
             )
 
     def test_cannot_update_memo_when_published(self) -> None:
@@ -101,7 +102,7 @@ class TestRecordUpdateMemo:
 
         with pytest.raises(RecordAlreadyPublishedError):
             record.update_memo(
-                memo="late edit",
+                memo=Memo("late edit"),
                 actor_id=organizer,
                 now=datetime(2026, 3, 20, 11, 0),
             )
@@ -112,7 +113,7 @@ class TestRecordUpdateMemo:
         record.collect_events()  # clear creation event
         now = datetime(2026, 3, 20, 11, 0)
 
-        record.update_memo(memo="Updated", actor_id=organizer, now=now)
+        record.update_memo(memo=Memo("Updated"), actor_id=organizer, now=now)
 
         events = record.collect_events()
         memo_events = [e for e in events if isinstance(e, MemoUpdated)]

--- a/backend/tests/contexts/record/domain/test_record.py
+++ b/backend/tests/contexts/record/domain/test_record.py
@@ -41,7 +41,7 @@ class TestRecordCreate:
     def test_creates_draft_with_empty_memo(self) -> None:
         record = _make_record()
         assert record.status == RecordStatus.DRAFT
-        assert record.memo == ""
+        assert record.memo == Memo("")
 
     def test_creates_without_schedule_id(self) -> None:
         record = _make_record()
@@ -82,7 +82,7 @@ class TestRecordUpdateMemo:
 
         record.update_memo(memo=Memo("Discussion notes"), actor_id=organizer, now=now)
 
-        assert record.memo == "Discussion notes"
+        assert record.memo == Memo("Discussion notes")
         assert record.updated_at == now
 
     def test_non_organizer_cannot_update_memo(self) -> None:


### PR DESCRIPTION
## Summary

- Preparation コンテキストの 5 メソッド（Agenda.create, Agenda.add_comment, Comment.create, Template.create, Template.update）の引数を str から値オブジェクト（Topic, CommentBody, TemplateName）に変更
- Record コンテキストの 3 メソッド（ActionItem.create, Comment.create, Record.update_memo）の引数を str から値オブジェクト（ActionItemTitle, CommentBody, Memo）に変更
- Memo 値オブジェクトを新規作成（空文字許可、最大 10,000 文字、改行許可、前後空白ストリップ）
- 内部での VO 変換処理を削除し、呼び出し側が VO を構築する責務を明確化
- ScheduleGroup 内の Agenda.create 呼び出しも VO を直接渡すように修正

## 変更ファイル

### ドメイン層
- `backend/contexts/preparation/domain/agenda.py` - create(), add_comment() の引数型変更
- `backend/contexts/preparation/domain/comment.py` - create() の引数型変更
- `backend/contexts/preparation/domain/template.py` - create(), update() の引数型変更
- `backend/contexts/preparation/domain/schedule_group.py` - Agenda.create 呼び出しの修正
- `backend/contexts/record/domain/action_item.py` - create() の引数型変更
- `backend/contexts/record/domain/comment.py` - create() の引数型変更
- `backend/contexts/record/domain/record.py` - update_memo() の引数型変更
- `backend/contexts/record/domain/memo.py` - **新規** Memo 値オブジェクト
- `backend/contexts/record/domain/exceptions.py` - InvalidMemoError 追加

### テスト
- 全テストを VO を渡す形に更新
- `backend/tests/contexts/record/domain/test_memo.py` - **新規** Memo のユニットテスト

## Test plan

- [x] `ruff check .` / `ruff format --check .` パス
- [x] `pyright` エラーなし
- [x] `pytest -m "not integration"` 全 314 テストパス

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)