### PR TITLE
リポジトリ・マイグレーション共通基盤の整備

### DIFF
--- a/backend/foundation/db/base.py
+++ b/backend/foundation/db/base.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, func, text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class TimestampMixin:
+    """Mixin that adds created_at / updated_at columns to all tables."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+        onupdate=func.now(),
+    )
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy declarative base for all ORM models."""

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -1,0 +1,9 @@
+"""Aggregation module for all ORM table definitions.
+
+Import all table models here so that Alembic's autogenerate can detect them
+via Base.metadata. When adding a new table, add an explicit import below.
+"""
+
+from shared.infrastructure.tables import UserTable  # noqa: F401
+
+__all__ = ["UserTable"]

--- a/backend/foundation/db/session.py
+++ b/backend/foundation/db/session.py
@@ -12,6 +12,7 @@ engine = create_async_engine(
     settings.database_url,
     echo=settings.debug,
     pool_pre_ping=True,
+    connect_args={"init_command": "SET time_zone='+00:00'"},
 )
 
 async_session_factory = async_sessionmaker(

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -5,14 +5,16 @@ from alembic import context
 from sqlalchemy import Connection, pool
 from sqlalchemy.ext.asyncio import create_async_engine
 
+import foundation.db.models  # noqa: F401
 from foundation.config.settings import settings
+from foundation.db.base import Base
 
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = None
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:
@@ -41,6 +43,7 @@ async def run_async_migrations() -> None:
     connectable = create_async_engine(
         settings.database_url,
         poolclass=pool.NullPool,
+        connect_args={"init_command": "SET time_zone='+00:00'"},
     )
 
     async with connectable.connect() as connection:

--- a/backend/migrations/versions/0001_create_users_table.py
+++ b/backend/migrations/versions/0001_create_users_table.py
@@ -1,0 +1,40 @@
+"""create users table
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-03-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("users")

--- a/backend/shared/infrastructure/tables.py
+++ b/backend/shared/infrastructure/tables.py
@@ -1,0 +1,12 @@
+from sqlalchemy import CHAR
+from sqlalchemy.orm import Mapped, mapped_column
+
+from foundation.db.base import Base, TimestampMixin
+
+
+class UserTable(Base, TimestampMixin):
+    """ORM model for the users table (minimal: id only)."""
+
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,3 +171,23 @@ Workspace コンテキストは組織・グループの階層と所属を管理�
 - コンテキスト間はドメインイベントで連携する（例：「記録が公開された」→ notification が Slack通知を送信）
 - 他コンテキストのエンティティを直接importしない。参照が必要な場合はIDで参照する
 - オーガナイザー・カウンターパートの概念は各コンテキストが必要に応じてIDで参照する（専用のidentityコンテキストは設けない）
+
+## インフラ層の設計規約
+
+### ORM テーブル定義
+
+- テーブル定義は各コンテキスト（または shared）の `infrastructure/tables.py` に配置し、`foundation/db/base.py` の `Base` を継承する
+- 全テーブルに `TimestampMixin` を適用する（`created_at` / `updated_at` を自動付与）
+- 新規テーブル追加時は `foundation/db/models.py` に明示 import を追加する（Alembic 自動検出の漏れ防止）
+
+### datetime の扱い（インフラ層）
+
+- DB セッションは `connect_args={"init_command": "SET time_zone='+00:00'"}` で UTC 固定
+- `NOW()` / `CURRENT_TIMESTAMP` は常に UTC を返す
+- アプリ層で datetime を生成する場合は `datetime.now(UTC)` を使用する
+- 表示層で各ユーザーのタイムゾーンに変換する
+
+### リポジトリ
+
+- リポジトリインターフェースは `domain/` に ABC で定義する
+- SQLAlchemy 実装は `infrastructure/` に配置する（依存性逆転）


### PR DESCRIPTION
## 概要
Issue #66 の実装。Preparation (#24) / Record (#28) のリポジトリ・DBマイグレーション実装に先立ち、両コンテキストが共通で利用するインフラ基盤を整備する。

## 変更内容
- `foundation/db/base.py`: `DeclarativeBase` ベースの `Base` クラスと `TimestampMixin`（created_at / updated_at）を定義
- `foundation/db/session.py`: `connect_args` で DB セッションの timezone を UTC に強制
- `migrations/env.py`: `target_metadata` を `Base.metadata` に設定、timezone UTC 強制、モデル集約モジュールの import
- `foundation/db/models.py`: 全 ORM テーブル定義の集約モジュール（Alembic 自動検出用）
- `shared/infrastructure/tables.py`: users テーブルの ORM モデル定義（id: CHAR(36) PK + TimestampMixin）
- `migrations/versions/0001_create_users_table.py`: 初回マイグレーション（ON UPDATE CURRENT_TIMESTAMP を含む手書き）
- `docs/architecture.md`: インフラ層の設計規約を追記

## テスト計画
- [x] ruff check / ruff format --check 通過
- [x] pyright 型チェック通過
- [x] pytest -m "not integration" 全 314 テスト通過（既存テスト破壊なし）
- [ ] DB 接続環境で `alembic upgrade head` / `alembic downgrade -1` の動作確認

Closes #66

Generated with [Claude Code](https://claude.com/claude-code)