### PR TITLE
Preparation: リポジトリ + DBマイグレーション（Schedule / ScheduleGroup / Template）

### DIFF
--- a/backend/contexts/preparation/domain/schedule_group_repository.py
+++ b/backend/contexts/preparation/domain/schedule_group_repository.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.value_objects import ScheduleGroupId
+from foundation.domain.base_repository import BaseRepository
+
+
+class ScheduleGroupRepository(BaseRepository[ScheduleGroup, ScheduleGroupId]):
+    """Repository interface for ScheduleGroup aggregates."""
+
+    pass

--- a/backend/contexts/preparation/domain/schedule_repository.py
+++ b/backend/contexts/preparation/domain/schedule_repository.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.value_objects import ScheduleId
+from foundation.domain.base_repository import BaseRepository
+
+
+class ScheduleRepository(BaseRepository[Schedule, ScheduleId]):
+    """Repository interface for Schedule aggregates."""
+
+    pass

--- a/backend/contexts/preparation/domain/template_repository.py
+++ b/backend/contexts/preparation/domain/template_repository.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.value_objects import TemplateId
+from foundation.domain.base_repository import BaseRepository
+
+
+class TemplateRepository(BaseRepository[Template, TemplateId]):
+    """Repository interface for Template aggregates."""
+
+    pass

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_group_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_group_repository.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.schedule_group_repository import (
+    ScheduleGroupRepository,
+)
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import (
+    ScheduleGroupId,
+    ScheduleId,
+    TemplateId,
+)
+from contexts.preparation.infrastructure.tables import (
+    ScheduleGroupAgendaTemplateTable,
+    ScheduleGroupTable,
+    ScheduleTable,
+)
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyScheduleGroupRepository(ScheduleGroupRepository):
+    """SQLAlchemy-based implementation of ScheduleGroupRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: ScheduleGroupId) -> ScheduleGroup | None:
+        stmt = select(ScheduleGroupTable).where(
+            ScheduleGroupTable.id == str(entity_id.value)
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+
+        # Restore schedule_ids from the schedules table
+        schedule_ids = await self._load_schedule_ids(entity_id)
+
+        return self._to_entity(row, schedule_ids)
+
+    async def save(self, entity: ScheduleGroup) -> None:
+        existing = await self._session.get(ScheduleGroupTable, str(entity.id.value))
+        if existing is None:
+            await self._insert(entity)
+        else:
+            await self._update(entity, existing)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _load_schedule_ids(self, group_id: ScheduleGroupId) -> list[ScheduleId]:
+        """Load schedule IDs belonging to this group.
+
+        Ordered by created_at ASC, id ASC.
+        """
+        stmt = (
+            select(ScheduleTable.id)
+            .where(ScheduleTable.schedule_group_id == str(group_id.value))
+            .order_by(ScheduleTable.created_at.asc(), ScheduleTable.id.asc())
+        )
+        result = await self._session.execute(stmt)
+        return [ScheduleId.from_str(row[0]) for row in result.fetchall()]
+
+    async def _insert(self, entity: ScheduleGroup) -> None:
+        group_row = ScheduleGroupTable(
+            id=str(entity.id.value),
+            organizer_id=str(entity.organizer_id.value),
+            template_id=(str(entity.template_id.value) if entity.template_id else None),
+            title=entity.title.value,
+            created_at=entity.created_at,
+            updated_at=entity.updated_at,
+        )
+        for position, at in enumerate(entity.agenda_templates):
+            at_row = ScheduleGroupAgendaTemplateTable(
+                id=str(uuid.uuid4()),
+                schedule_group_id=str(entity.id.value),
+                topic=at.topic.value,
+                position=position,
+                created_at=entity.created_at,
+                updated_at=entity.created_at,
+            )
+            group_row.agenda_templates.append(at_row)
+        self._session.add(group_row)
+        await self._session.flush()
+
+    async def _update(
+        self, entity: ScheduleGroup, existing: ScheduleGroupTable
+    ) -> None:
+        now = datetime.now(UTC)
+
+        existing.organizer_id = str(entity.organizer_id.value)
+        existing.template_id = (
+            str(entity.template_id.value) if entity.template_id else None
+        )
+        existing.title = entity.title.value
+        existing.updated_at = now
+
+        # AgendaTemplates: full delete + re-insert
+        # (position-ordered list, IDs have no meaning)
+        existing.agenda_templates.clear()
+        await self._session.flush()
+
+        for position, at in enumerate(entity.agenda_templates):
+            new_row = ScheduleGroupAgendaTemplateTable(
+                id=str(uuid.uuid4()),
+                schedule_group_id=str(entity.id.value),
+                topic=at.topic.value,
+                position=position,
+                created_at=now,
+                updated_at=now,
+            )
+            existing.agenda_templates.append(new_row)
+
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(
+        row: ScheduleGroupTable, schedule_ids: list[ScheduleId]
+    ) -> ScheduleGroup:
+        sorted_ats = sorted(row.agenda_templates, key=lambda x: x.position)
+        agenda_templates = [AgendaTemplate(at.topic) for at in sorted_ats]
+
+        return ScheduleGroup(
+            id=ScheduleGroupId.from_str(row.id),
+            organizer_id=UserId.from_str(row.organizer_id),
+            template_id=(
+                TemplateId.from_str(row.template_id) if row.template_id else None
+            ),
+            _title=ScheduleTitle(row.title),
+            _agenda_templates=agenda_templates,
+            _schedule_ids=schedule_ids,
+            created_at=row.created_at,
+            _updated_at=row.updated_at,
+        )

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.confirmation_request import ConfirmationRequest
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import (
+    ConfirmationRequestId,
+    ConfirmationRequestType,
+    ConfirmationResolution,
+    ScheduleGroupId,
+    ScheduleId,
+    ScheduleStatus,
+)
+from contexts.preparation.infrastructure.tables import (
+    ConfirmationRequestTable,
+    ScheduleTable,
+)
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyScheduleRepository(ScheduleRepository):
+    """SQLAlchemy-based implementation of ScheduleRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: ScheduleId) -> Schedule | None:
+        stmt = select(ScheduleTable).where(ScheduleTable.id == str(entity_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def save(self, entity: Schedule) -> None:
+        existing = await self._session.get(ScheduleTable, str(entity.id.value))
+        if existing is None:
+            await self._insert(entity)
+        else:
+            await self._update(entity, existing)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _insert(self, entity: Schedule) -> None:
+        schedule_row = ScheduleTable(
+            id=str(entity.id.value),
+            organizer_id=str(entity.organizer_id.value),
+            counterpart_id=str(entity.counterpart_id.value),
+            schedule_group_id=(
+                str(entity.schedule_group_id.value)
+                if entity.schedule_group_id
+                else None
+            ),
+            title=entity.title.value,
+            scheduled_at=entity.scheduled_at,
+            status=entity.status.value,
+            created_at=entity.created_at,
+            updated_at=entity.updated_at,
+        )
+        for cr in entity.confirmation_requests:
+            cr_row = ConfirmationRequestTable(
+                id=str(cr.id.value),
+                schedule_id=str(entity.id.value),
+                request_type=cr.request_type.value,
+                requested_by=str(cr.requested_by.value),
+                proposed_at=cr.proposed_at,
+                resolution=cr.resolution.value,
+                resolved_by=str(cr.resolved_by.value) if cr.resolved_by else None,
+                created_at=cr.created_at,
+                updated_at=entity.created_at,
+            )
+            schedule_row.confirmation_requests.append(cr_row)
+        self._session.add(schedule_row)
+        await self._session.flush()
+
+    async def _update(self, entity: Schedule, existing: ScheduleTable) -> None:
+        now = datetime.now(UTC)
+
+        existing.organizer_id = str(entity.organizer_id.value)
+        existing.counterpart_id = str(entity.counterpart_id.value)
+        existing.schedule_group_id = (
+            str(entity.schedule_group_id.value) if entity.schedule_group_id else None
+        )
+        existing.title = entity.title.value
+        existing.scheduled_at = entity.scheduled_at
+        existing.status = entity.status.value
+        existing.updated_at = now
+
+        # Reconcile confirmation requests
+        existing_cr_map: dict[str, ConfirmationRequestTable] = {
+            cr.id: cr for cr in existing.confirmation_requests
+        }
+        entity_cr_ids: set[str] = set()
+
+        for cr in entity.confirmation_requests:
+            cr_id = str(cr.id.value)
+            entity_cr_ids.add(cr_id)
+            if cr_id in existing_cr_map:
+                db_cr = existing_cr_map[cr_id]
+                db_cr.request_type = cr.request_type.value
+                db_cr.requested_by = str(cr.requested_by.value)
+                db_cr.proposed_at = cr.proposed_at
+                db_cr.resolution = cr.resolution.value
+                db_cr.resolved_by = (
+                    str(cr.resolved_by.value) if cr.resolved_by else None
+                )
+                db_cr.updated_at = now
+            else:
+                new_cr = ConfirmationRequestTable(
+                    id=cr_id,
+                    schedule_id=str(entity.id.value),
+                    request_type=cr.request_type.value,
+                    requested_by=str(cr.requested_by.value),
+                    proposed_at=cr.proposed_at,
+                    resolution=cr.resolution.value,
+                    resolved_by=(str(cr.resolved_by.value) if cr.resolved_by else None),
+                    created_at=now,
+                    updated_at=now,
+                )
+                existing.confirmation_requests.append(new_cr)
+
+        for cr_id, db_cr in existing_cr_map.items():
+            if cr_id not in entity_cr_ids:
+                existing.confirmation_requests.remove(db_cr)
+
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: ScheduleTable) -> Schedule:
+        confirmation_requests = [
+            ConfirmationRequest(
+                id=ConfirmationRequestId.from_str(cr.id),
+                request_type=ConfirmationRequestType(cr.request_type),
+                requested_by=UserId.from_str(cr.requested_by),
+                proposed_at=cr.proposed_at,
+                _resolution=ConfirmationResolution(cr.resolution),
+                _resolved_by=(
+                    UserId.from_str(cr.resolved_by) if cr.resolved_by else None
+                ),
+                created_at=cr.created_at,
+            )
+            for cr in row.confirmation_requests
+        ]
+        return Schedule(
+            id=ScheduleId.from_str(row.id),
+            organizer_id=UserId.from_str(row.organizer_id),
+            counterpart_id=UserId.from_str(row.counterpart_id),
+            schedule_group_id=(
+                ScheduleGroupId.from_str(row.schedule_group_id)
+                if row.schedule_group_id
+                else None
+            ),
+            _title=ScheduleTitle(row.title),
+            _scheduled_at=row.scheduled_at,
+            _status=ScheduleStatus(row.status),
+            _confirmation_requests=confirmation_requests,
+            created_at=row.created_at,
+            _updated_at=row.updated_at,
+        )

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
@@ -122,8 +122,8 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
                     proposed_at=cr.proposed_at,
                     resolution=cr.resolution.value,
                     resolved_by=(str(cr.resolved_by.value) if cr.resolved_by else None),
-                    created_at=now,
-                    updated_at=now,
+                    created_at=cr.created_at,
+                    updated_at=cr.created_at,
                 )
                 existing.confirmation_requests.append(new_cr)
 

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_template_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_template_repository.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_name import TemplateName
+from contexts.preparation.domain.template_repository import TemplateRepository
+from contexts.preparation.domain.value_objects import TemplateId
+from contexts.preparation.infrastructure.tables import (
+    TemplateAgendaTemplateTable,
+    TemplateDefaultCounterpartTable,
+    TemplateTable,
+)
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyTemplateRepository(TemplateRepository):
+    """SQLAlchemy-based implementation of TemplateRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: TemplateId) -> Template | None:
+        stmt = select(TemplateTable).where(TemplateTable.id == str(entity_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def save(self, entity: Template) -> None:
+        existing = await self._session.get(TemplateTable, str(entity.id.value))
+        if existing is None:
+            await self._insert(entity)
+        else:
+            await self._update(entity, existing)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _insert(self, entity: Template) -> None:
+        template_row = TemplateTable(
+            id=str(entity.id.value),
+            organizer_id=str(entity.organizer_id.value),
+            name=entity.name.value,
+            created_at=entity.created_at,
+            updated_at=entity.updated_at,
+        )
+        for position, user_id in enumerate(entity.default_counterparts):
+            dc_row = TemplateDefaultCounterpartTable(
+                id=str(uuid.uuid4()),
+                template_id=str(entity.id.value),
+                user_id=str(user_id.value),
+                position=position,
+                created_at=entity.created_at,
+                updated_at=entity.created_at,
+            )
+            template_row.default_counterparts.append(dc_row)
+        for position, at in enumerate(entity.agenda_templates):
+            at_row = TemplateAgendaTemplateTable(
+                id=str(uuid.uuid4()),
+                template_id=str(entity.id.value),
+                topic=at.topic.value,
+                position=position,
+                created_at=entity.created_at,
+                updated_at=entity.created_at,
+            )
+            template_row.agenda_templates.append(at_row)
+        self._session.add(template_row)
+        await self._session.flush()
+
+    async def _update(self, entity: Template, existing: TemplateTable) -> None:
+        now = datetime.now(UTC)
+
+        existing.organizer_id = str(entity.organizer_id.value)
+        existing.name = entity.name.value
+        existing.updated_at = now
+
+        # DefaultCounterparts: full delete + re-insert
+        existing.default_counterparts.clear()
+        await self._session.flush()
+
+        for position, user_id in enumerate(entity.default_counterparts):
+            new_dc = TemplateDefaultCounterpartTable(
+                id=str(uuid.uuid4()),
+                template_id=str(entity.id.value),
+                user_id=str(user_id.value),
+                position=position,
+                created_at=now,
+                updated_at=now,
+            )
+            existing.default_counterparts.append(new_dc)
+
+        # AgendaTemplates: full delete + re-insert
+        existing.agenda_templates.clear()
+        await self._session.flush()
+
+        for position, at in enumerate(entity.agenda_templates):
+            new_at = TemplateAgendaTemplateTable(
+                id=str(uuid.uuid4()),
+                template_id=str(entity.id.value),
+                topic=at.topic.value,
+                position=position,
+                created_at=now,
+                updated_at=now,
+            )
+            existing.agenda_templates.append(new_at)
+
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: TemplateTable) -> Template:
+        sorted_dcs = sorted(row.default_counterparts, key=lambda x: x.position)
+        default_counterparts = [UserId.from_str(dc.user_id) for dc in sorted_dcs]
+
+        sorted_ats = sorted(row.agenda_templates, key=lambda x: x.position)
+        agenda_templates = [AgendaTemplate(at.topic) for at in sorted_ats]
+
+        return Template(
+            id=TemplateId.from_str(row.id),
+            organizer_id=UserId.from_str(row.organizer_id),
+            _name=TemplateName(row.name),
+            _default_counterparts=default_counterparts,
+            _agenda_templates=agenda_templates,
+            created_at=row.created_at,
+            _updated_at=row.updated_at,
+        )

--- a/backend/contexts/preparation/infrastructure/tables.py
+++ b/backend/contexts/preparation/infrastructure/tables.py
@@ -1,0 +1,257 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    CHAR,
+    INTEGER,
+    VARCHAR,
+    ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.mysql import DATETIME
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from foundation.db.base import Base, TimestampMixin
+
+# ------------------------------------------------------------------
+# Template
+# ------------------------------------------------------------------
+
+
+class TemplateTable(Base, TimestampMixin):
+    """ORM model for the templates table."""
+
+    __tablename__ = "templates"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    organizer_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey("users.id", name="fk_templates_organizer_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(VARCHAR(100), nullable=False)
+
+    default_counterparts: Mapped[list["TemplateDefaultCounterpartTable"]] = (
+        relationship(
+            back_populates="template",
+            lazy="selectin",
+            cascade="all, delete-orphan",
+        )
+    )
+    agenda_templates: Mapped[list["TemplateAgendaTemplateTable"]] = relationship(
+        back_populates="template",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
+
+
+class TemplateDefaultCounterpartTable(Base, TimestampMixin):
+    """ORM model for the template_default_counterparts table."""
+
+    __tablename__ = "template_default_counterparts"
+    __table_args__ = (
+        UniqueConstraint(
+            "template_id",
+            "user_id",
+            name="uq_template_default_counterparts_template_user",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    template_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "templates.id",
+            name="fk_template_default_counterparts_template_id",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    user_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_template_default_counterparts_user_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    position: Mapped[int] = mapped_column(INTEGER, nullable=False)
+
+    template: Mapped["TemplateTable"] = relationship(
+        back_populates="default_counterparts",
+    )
+
+
+class TemplateAgendaTemplateTable(Base, TimestampMixin):
+    """ORM model for the template_agenda_templates table."""
+
+    __tablename__ = "template_agenda_templates"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    template_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "templates.id",
+            name="fk_template_agenda_templates_template_id",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    topic: Mapped[str] = mapped_column(VARCHAR(200), nullable=False)
+    position: Mapped[int] = mapped_column(INTEGER, nullable=False)
+
+    template: Mapped["TemplateTable"] = relationship(
+        back_populates="agenda_templates",
+    )
+
+
+# ------------------------------------------------------------------
+# ScheduleGroup
+# ------------------------------------------------------------------
+
+
+class ScheduleGroupTable(Base, TimestampMixin):
+    """ORM model for the schedule_groups table."""
+
+    __tablename__ = "schedule_groups"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    organizer_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_schedule_groups_organizer_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    template_id: Mapped[str | None] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "templates.id",
+            name="fk_schedule_groups_template_id",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    title: Mapped[str] = mapped_column(VARCHAR(100), nullable=False)
+
+    agenda_templates: Mapped[list["ScheduleGroupAgendaTemplateTable"]] = relationship(
+        back_populates="schedule_group",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
+
+
+class ScheduleGroupAgendaTemplateTable(Base, TimestampMixin):
+    """ORM model for the schedule_group_agenda_templates table."""
+
+    __tablename__ = "schedule_group_agenda_templates"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    schedule_group_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "schedule_groups.id",
+            name="fk_schedule_group_agenda_templates_schedule_group_id",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    topic: Mapped[str] = mapped_column(VARCHAR(200), nullable=False)
+    position: Mapped[int] = mapped_column(INTEGER, nullable=False)
+
+    schedule_group: Mapped["ScheduleGroupTable"] = relationship(
+        back_populates="agenda_templates",
+    )
+
+
+# ------------------------------------------------------------------
+# Schedule
+# ------------------------------------------------------------------
+
+
+class ScheduleTable(Base, TimestampMixin):
+    """ORM model for the schedules table."""
+
+    __tablename__ = "schedules"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    organizer_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_schedules_organizer_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    counterpart_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_schedules_counterpart_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    schedule_group_id: Mapped[str | None] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "schedule_groups.id",
+            name="fk_schedules_schedule_group_id",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    title: Mapped[str] = mapped_column(VARCHAR(100), nullable=False)
+    scheduled_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
+    status: Mapped[str] = mapped_column(VARCHAR(20), nullable=False)
+
+    confirmation_requests: Mapped[list["ConfirmationRequestTable"]] = relationship(
+        back_populates="schedule",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
+
+
+class ConfirmationRequestTable(Base, TimestampMixin):
+    """ORM model for the confirmation_requests table."""
+
+    __tablename__ = "confirmation_requests"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    schedule_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "schedules.id",
+            name="fk_confirmation_requests_schedule_id",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    request_type: Mapped[str] = mapped_column(VARCHAR(20), nullable=False)
+    requested_by: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_confirmation_requests_requested_by",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    proposed_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
+    resolution: Mapped[str] = mapped_column(VARCHAR(20), nullable=False)
+    resolved_by: Mapped[str | None] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_confirmation_requests_resolved_by",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+    )
+
+    schedule: Mapped["ScheduleTable"] = relationship(
+        back_populates="confirmation_requests",
+    )

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -4,10 +4,30 @@ Import all table models here so that Alembic's autogenerate can detect them
 via Base.metadata. When adding a new table, add an explicit import below.
 """
 
+from contexts.preparation.infrastructure.tables import (
+    ConfirmationRequestTable,  # noqa: F401
+    ScheduleGroupAgendaTemplateTable,  # noqa: F401
+    ScheduleGroupTable,  # noqa: F401
+    ScheduleTable,  # noqa: F401
+    TemplateAgendaTemplateTable,  # noqa: F401
+    TemplateDefaultCounterpartTable,  # noqa: F401
+    TemplateTable,  # noqa: F401
+)
 from contexts.workspace.infrastructure.tables import (
     MembershipTable,  # noqa: F401
     WorkspaceTable,  # noqa: F401
 )
 from shared.infrastructure.tables import UserTable  # noqa: F401
 
-__all__ = ["MembershipTable", "UserTable", "WorkspaceTable"]
+__all__ = [
+    "ConfirmationRequestTable",
+    "MembershipTable",
+    "ScheduleGroupAgendaTemplateTable",
+    "ScheduleGroupTable",
+    "ScheduleTable",
+    "TemplateAgendaTemplateTable",
+    "TemplateDefaultCounterpartTable",
+    "TemplateTable",
+    "UserTable",
+    "WorkspaceTable",
+]

--- a/backend/migrations/versions/0003_create_preparation_tables.py
+++ b/backend/migrations/versions/0003_create_preparation_tables.py
@@ -1,0 +1,271 @@
+"""create preparation tables
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import DATETIME as MYSQL_DATETIME
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- templates ---
+    op.create_table(
+        "templates",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("organizer_id", sa.CHAR(36), nullable=False),
+        sa.Column("name", sa.VARCHAR(100), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["organizer_id"],
+            ["users.id"],
+            name="fk_templates_organizer_id",
+            ondelete="RESTRICT",
+        ),
+    )
+
+    # --- template_default_counterparts ---
+    op.create_table(
+        "template_default_counterparts",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("template_id", sa.CHAR(36), nullable=False),
+        sa.Column("user_id", sa.CHAR(36), nullable=False),
+        sa.Column("position", sa.INTEGER(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["template_id"],
+            ["templates.id"],
+            name="fk_template_default_counterparts_template_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_template_default_counterparts_user_id",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint(
+            "template_id",
+            "user_id",
+            name="uq_template_default_counterparts_template_user",
+        ),
+    )
+
+    # --- template_agenda_templates ---
+    op.create_table(
+        "template_agenda_templates",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("template_id", sa.CHAR(36), nullable=False),
+        sa.Column("topic", sa.VARCHAR(200), nullable=False),
+        sa.Column("position", sa.INTEGER(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["template_id"],
+            ["templates.id"],
+            name="fk_template_agenda_templates_template_id",
+            ondelete="CASCADE",
+        ),
+    )
+
+    # --- schedule_groups ---
+    op.create_table(
+        "schedule_groups",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("organizer_id", sa.CHAR(36), nullable=False),
+        sa.Column("template_id", sa.CHAR(36), nullable=True),
+        sa.Column("title", sa.VARCHAR(100), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["organizer_id"],
+            ["users.id"],
+            name="fk_schedule_groups_organizer_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["template_id"],
+            ["templates.id"],
+            name="fk_schedule_groups_template_id",
+            ondelete="SET NULL",
+        ),
+    )
+
+    # --- schedule_group_agenda_templates ---
+    op.create_table(
+        "schedule_group_agenda_templates",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("schedule_group_id", sa.CHAR(36), nullable=False),
+        sa.Column("topic", sa.VARCHAR(200), nullable=False),
+        sa.Column("position", sa.INTEGER(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["schedule_group_id"],
+            ["schedule_groups.id"],
+            name="fk_schedule_group_agenda_templates_schedule_group_id",
+            ondelete="CASCADE",
+        ),
+    )
+
+    # --- schedules ---
+    op.create_table(
+        "schedules",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("organizer_id", sa.CHAR(36), nullable=False),
+        sa.Column("counterpart_id", sa.CHAR(36), nullable=False),
+        sa.Column("schedule_group_id", sa.CHAR(36), nullable=True),
+        sa.Column("title", sa.VARCHAR(100), nullable=False),
+        sa.Column("scheduled_at", MYSQL_DATETIME(fsp=6), nullable=False),
+        sa.Column("status", sa.VARCHAR(20), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["organizer_id"],
+            ["users.id"],
+            name="fk_schedules_organizer_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["counterpart_id"],
+            ["users.id"],
+            name="fk_schedules_counterpart_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["schedule_group_id"],
+            ["schedule_groups.id"],
+            name="fk_schedules_schedule_group_id",
+            ondelete="SET NULL",
+        ),
+    )
+
+    # --- confirmation_requests ---
+    op.create_table(
+        "confirmation_requests",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("schedule_id", sa.CHAR(36), nullable=False),
+        sa.Column("request_type", sa.VARCHAR(20), nullable=False),
+        sa.Column("requested_by", sa.CHAR(36), nullable=False),
+        sa.Column("proposed_at", MYSQL_DATETIME(fsp=6), nullable=False),
+        sa.Column("resolution", sa.VARCHAR(20), nullable=False),
+        sa.Column("resolved_by", sa.CHAR(36), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["schedule_id"],
+            ["schedules.id"],
+            name="fk_confirmation_requests_schedule_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["requested_by"],
+            ["users.id"],
+            name="fk_confirmation_requests_requested_by",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["resolved_by"],
+            ["users.id"],
+            name="fk_confirmation_requests_resolved_by",
+            ondelete="RESTRICT",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("confirmation_requests")
+    op.drop_table("schedules")
+    op.drop_table("schedule_group_agenda_templates")
+    op.drop_table("schedule_groups")
+    op.drop_table("template_agenda_templates")
+    op.drop_table("template_default_counterparts")
+    op.drop_table("templates")

--- a/backend/tests/contexts/preparation/infrastructure/conftest.py
+++ b/backend/tests/contexts/preparation/infrastructure/conftest.py
@@ -50,7 +50,11 @@ async def test_engine() -> AsyncGenerator[AsyncEngine]:
 async def session(
     test_engine: AsyncEngine,
 ) -> AsyncGenerator[AsyncSession]:
-    """Provide a transactional session that rolls back after each test."""
+    """Provide a session that rolls back uncommitted changes after each test.
+
+    Note: committed data persists across tests within the same session.
+    Each test is responsible for its own data setup.
+    """
     session_factory = async_sessionmaker(
         test_engine,
         class_=AsyncSession,

--- a/backend/tests/contexts/preparation/infrastructure/conftest.py
+++ b/backend/tests/contexts/preparation/infrastructure/conftest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+import foundation.db.models  # noqa: F401
+from foundation.config.settings import settings
+from foundation.db.base import Base
+
+
+def _test_database_url() -> str:
+    """Build a URL pointing to the perigee_test database."""
+    return (
+        f"mysql+asyncmy://{settings.db_user}:{settings.db_password}"
+        f"@{settings.db_host}:{settings.db_port}/perigee_test"
+    )
+
+
+@pytest_asyncio.fixture(scope="session")
+async def test_engine() -> AsyncGenerator[AsyncEngine]:
+    """Create a test engine that connects to perigee_test."""
+    engine = create_async_engine(
+        _test_database_url(),
+        echo=False,
+        pool_pre_ping=True,
+        connect_args={"init_command": "SET time_zone='+00:00'"},
+    )
+    # Create all tables at the start of the test session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    # Drop all tables at the end of the test session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(
+    test_engine: AsyncEngine,
+) -> AsyncGenerator[AsyncSession]:
+    """Provide a transactional session that rolls back after each test."""
+    session_factory = async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as session:
+        yield session
+        # Roll back any uncommitted changes after each test
+        await session.rollback()
+
+
+@pytest.fixture
+def session_factory(
+    test_engine: AsyncEngine,
+) -> async_sessionmaker[AsyncSession]:
+    """Provide a session factory for tests that need multiple sessions."""
+    return async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )

--- a/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_group_repository.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_group_repository.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import ScheduleGroupId
+from contexts.preparation.infrastructure.sqlalchemy_schedule_group_repository import (
+    SqlAlchemyScheduleGroupRepository,
+)
+from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+    SqlAlchemyScheduleRepository,
+)
+from shared.domain.value_objects import UserId
+from shared.infrastructure.tables import UserTable
+
+pytestmark = pytest.mark.integration
+
+NOW = datetime(2026, 4, 1, 10, 0)
+
+
+async def _create_user(session: AsyncSession) -> UserId:
+    user_id = UserId.generate()
+    session.add(UserTable(id=str(user_id.value)))
+    await session.flush()
+    return user_id
+
+
+def _make_schedule_group(
+    *,
+    organizer_id: UserId,
+    title: str = "Weekly Group",
+    agenda_templates: list[AgendaTemplate] | None = None,
+    now: datetime = NOW,
+) -> ScheduleGroup:
+    return ScheduleGroup.create(
+        organizer_id=organizer_id,
+        title=ScheduleTitle(title),
+        agenda_templates=agenda_templates,
+        now=now,
+    )
+
+
+class TestSaveAndGetById:
+    """save() -> get_by_id() round-trip."""
+
+    async def test_save_and_restore_empty_group(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyScheduleGroupRepository(session)
+        org = await _create_user(session)
+
+        group = _make_schedule_group(organizer_id=org)
+        await repo.save(group)
+        await session.commit()
+
+        loaded = await repo.get_by_id(group.id)
+
+        assert loaded is not None
+        assert loaded.id == group.id
+        assert loaded.organizer_id == org
+        assert loaded.title == ScheduleTitle("Weekly Group")
+        assert loaded.template_id is None
+        assert loaded.agenda_templates == []
+        assert loaded.schedule_ids == []
+
+    async def test_save_with_agenda_templates(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyScheduleGroupRepository(session)
+        org = await _create_user(session)
+
+        templates = [AgendaTemplate("Progress"), AgendaTemplate("Blockers")]
+        group = _make_schedule_group(organizer_id=org, agenda_templates=templates)
+        await repo.save(group)
+        await session.commit()
+
+        loaded = await repo.get_by_id(group.id)
+
+        assert loaded is not None
+        assert len(loaded.agenda_templates) == 2
+        assert loaded.agenda_templates[0].topic.value == "Progress"
+        assert loaded.agenda_templates[1].topic.value == "Blockers"
+
+    async def test_get_by_id_returns_none_for_missing(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyScheduleGroupRepository(session)
+        result = await repo.get_by_id(ScheduleGroupId.generate())
+        assert result is None
+
+
+class TestScheduleIdsRestoration:
+    """schedule_ids are restored from the schedules table."""
+
+    async def test_schedule_ids_restored_in_order(self, session: AsyncSession) -> None:
+        group_repo = SqlAlchemyScheduleGroupRepository(session)
+        schedule_repo = SqlAlchemyScheduleRepository(session)
+        org = await _create_user(session)
+        cp = await _create_user(session)
+
+        group = _make_schedule_group(organizer_id=org)
+        await group_repo.save(group)
+
+        # Create schedules belonging to this group
+        s1 = Schedule.create(
+            organizer_id=org,
+            counterpart_id=cp,
+            scheduled_at=datetime(2026, 4, 10, 14, 0),
+            requested_by=org,
+            title=ScheduleTitle("Meeting 1"),
+            schedule_group_id=group.id,
+            now=datetime(2026, 4, 1, 10, 0, 0),
+        )
+        s2 = Schedule.create(
+            organizer_id=org,
+            counterpart_id=cp,
+            scheduled_at=datetime(2026, 4, 17, 14, 0),
+            requested_by=org,
+            title=ScheduleTitle("Meeting 2"),
+            schedule_group_id=group.id,
+            now=datetime(2026, 4, 1, 10, 0, 1),
+        )
+        await schedule_repo.save(s1)
+        await schedule_repo.save(s2)
+        await session.commit()
+
+        loaded = await group_repo.get_by_id(group.id)
+
+        assert loaded is not None
+        assert len(loaded.schedule_ids) == 2
+        assert loaded.schedule_ids[0] == s1.id
+        assert loaded.schedule_ids[1] == s2.id
+
+
+class TestUpdateAgendaTemplates:
+    """save() with agenda template changes."""
+
+    async def test_add_agenda_template(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyScheduleGroupRepository(session)
+        org = await _create_user(session)
+
+        group = _make_schedule_group(
+            organizer_id=org,
+            agenda_templates=[AgendaTemplate("Topic A")],
+        )
+        await repo.save(group)
+        await session.commit()
+
+        # Modify agenda templates via internal state for testing persistence
+        group._agenda_templates.append(AgendaTemplate("Topic B"))
+        group._updated_at = datetime(2026, 4, 2, 10, 0)
+        await repo.save(group)
+        await session.commit()
+
+        loaded = await repo.get_by_id(group.id)
+        assert loaded is not None
+        assert len(loaded.agenda_templates) == 2
+        assert loaded.agenda_templates[0].topic.value == "Topic A"
+        assert loaded.agenda_templates[1].topic.value == "Topic B"
+
+    async def test_remove_agenda_template(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyScheduleGroupRepository(session)
+        org = await _create_user(session)
+
+        group = _make_schedule_group(
+            organizer_id=org,
+            agenda_templates=[AgendaTemplate("Keep"), AgendaTemplate("Remove")],
+        )
+        await repo.save(group)
+        await session.commit()
+
+        # Remove second template
+        group._agenda_templates.pop(1)
+        group._updated_at = datetime(2026, 4, 2, 10, 0)
+        await repo.save(group)
+        await session.commit()
+
+        loaded = await repo.get_by_id(group.id)
+        assert loaded is not None
+        assert len(loaded.agenda_templates) == 1
+        assert loaded.agenda_templates[0].topic.value == "Keep"

--- a/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_repository.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_repository.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import (
+    ConfirmationResolution,
+    ScheduleId,
+    ScheduleStatus,
+)
+from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+    SqlAlchemyScheduleRepository,
+)
+from shared.domain.value_objects import UserId
+from shared.infrastructure.tables import UserTable
+
+pytestmark = pytest.mark.integration
+
+NOW = datetime(2026, 4, 1, 10, 0)
+SCHEDULED_AT = datetime(2026, 4, 10, 14, 0)
+
+
+async def _create_user(session: AsyncSession) -> UserId:
+    """Insert a user row and return its UserId (needed for FK constraints)."""
+    user_id = UserId.generate()
+    session.add(UserTable(id=str(user_id.value)))
+    await session.flush()
+    return user_id
+
+
+def _make_schedule(
+    *,
+    organizer_id: UserId,
+    counterpart_id: UserId,
+    title: str = "Weekly 1on1",
+    scheduled_at: datetime = SCHEDULED_AT,
+    now: datetime = NOW,
+) -> Schedule:
+    return Schedule.create(
+        organizer_id=organizer_id,
+        counterpart_id=counterpart_id,
+        scheduled_at=scheduled_at,
+        requested_by=organizer_id,
+        title=ScheduleTitle(title),
+        now=now,
+    )
+
+
+class TestSaveAndGetById:
+    """save() -> get_by_id() round-trip."""
+
+    async def test_save_and_restore_new_schedule(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyScheduleRepository(session)
+        org = await _create_user(session)
+        cp = await _create_user(session)
+
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        await repo.save(schedule)
+        await session.commit()
+
+        loaded = await repo.get_by_id(schedule.id)
+
+        assert loaded is not None
+        assert loaded.id == schedule.id
+        assert loaded.organizer_id == org
+        assert loaded.counterpart_id == cp
+        assert loaded.title == ScheduleTitle("Weekly 1on1")
+        assert loaded.scheduled_at == SCHEDULED_AT
+        assert loaded.status == ScheduleStatus.REQUESTED
+        assert loaded.schedule_group_id is None
+        assert len(loaded.confirmation_requests) == 1
+
+        cr = loaded.confirmation_requests[0]
+        assert cr.requested_by == org
+        assert cr.resolution == ConfirmationResolution.PENDING
+        assert cr.resolved_by is None
+
+    async def test_get_by_id_returns_none_for_missing(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyScheduleRepository(session)
+        result = await repo.get_by_id(ScheduleId.generate())
+        assert result is None
+
+
+class TestUpdateScalarFields:
+    """save() with scalar field changes."""
+
+    async def test_update_title_and_status(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyScheduleRepository(session)
+        org = await _create_user(session)
+        cp = await _create_user(session)
+
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        await repo.save(schedule)
+        await session.commit()
+
+        # Confirm the schedule
+        confirm_time = datetime(2026, 4, 2, 10, 0)
+        schedule.confirm(actor_id=cp, now=confirm_time)
+        await repo.save(schedule)
+        await session.commit()
+
+        loaded = await repo.get_by_id(schedule.id)
+        assert loaded is not None
+        assert loaded.status == ScheduleStatus.CONFIRMED
+        cr = loaded.confirmation_requests[0]
+        assert cr.resolution == ConfirmationResolution.APPROVED
+        assert cr.resolved_by == cp
+
+
+class TestConfirmationRequestReconciliation:
+    """save() with child entity (ConfirmationRequest) add/update."""
+
+    async def test_reschedule_adds_new_confirmation_request(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyScheduleRepository(session)
+        org = await _create_user(session)
+        cp = await _create_user(session)
+
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        await repo.save(schedule)
+        await session.commit()
+
+        # Reschedule by organizer
+        new_time = datetime(2026, 4, 15, 14, 0)
+        reschedule_now = datetime(2026, 4, 3, 10, 0)
+        schedule.reschedule(actor_id=org, new_proposed_at=new_time, now=reschedule_now)
+        await repo.save(schedule)
+        await session.commit()
+
+        loaded = await repo.get_by_id(schedule.id)
+        assert loaded is not None
+        assert len(loaded.confirmation_requests) == 2
+        assert loaded.status == ScheduleStatus.REQUESTED
+
+        # First request should be superseded (same actor reschedules)
+        resolutions = {cr.resolution for cr in loaded.confirmation_requests}
+        assert ConfirmationResolution.SUPERSEDED in resolutions
+        assert ConfirmationResolution.PENDING in resolutions
+
+    async def test_multiple_confirmation_requests_round_trip(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyScheduleRepository(session)
+        org = await _create_user(session)
+        cp = await _create_user(session)
+
+        schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
+        # Confirm
+        schedule.confirm(actor_id=cp, now=datetime(2026, 4, 2, 10, 0))
+        # Reschedule by counterpart
+        schedule.reschedule(
+            actor_id=cp,
+            new_proposed_at=datetime(2026, 4, 20, 14, 0),
+            now=datetime(2026, 4, 5, 10, 0),
+        )
+        await repo.save(schedule)
+        await session.commit()
+
+        loaded = await repo.get_by_id(schedule.id)
+        assert loaded is not None
+        assert len(loaded.confirmation_requests) == 2
+
+        # First: approved, Second: pending
+        sorted_crs = sorted(loaded.confirmation_requests, key=lambda x: x.created_at)
+        assert sorted_crs[0].resolution == ConfirmationResolution.APPROVED
+        assert sorted_crs[1].resolution == ConfirmationResolution.PENDING
+
+
+class TestAlembicMigration:
+    """Verify Alembic upgrade/downgrade with preparation tables."""
+
+    async def test_upgrade_and_downgrade(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Run Alembic upgrade to head then downgrade to base."""
+        import os
+
+        from alembic import command
+        from alembic.config import Config
+        from sqlalchemy import text
+
+        monkeypatch.setenv("PERIGEE_DB_NAME", "perigee_test")
+        from foundation.config import settings as settings_mod
+        from foundation.config.settings import Settings
+
+        patched_settings = Settings()
+        monkeypatch.setattr(settings_mod, "settings", patched_settings)
+        import migrations.env as mig_env_mod
+
+        monkeypatch.setattr(mig_env_mod, "settings", patched_settings)
+
+        alembic_cfg = Config(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../../../alembic.ini",
+            )
+        )
+        alembic_cfg.set_main_option("script_location", "migrations")
+
+        # Drop all tables to start from clean state
+        async with session_factory() as s:
+            from foundation.db.base import Base
+
+            conn = await s.connection()
+            await conn.run_sync(Base.metadata.drop_all)
+            await s.execute(text("DROP TABLE IF EXISTS alembic_version"))
+            await s.commit()
+
+        # Upgrade to head
+        command.upgrade(alembic_cfg, "head")
+
+        # Verify preparation tables exist
+        async with session_factory() as s:
+            result = await s.execute(text("SHOW TABLES"))
+            tables = {row[0] for row in result.fetchall()}
+            assert "schedules" in tables
+            assert "confirmation_requests" in tables
+            assert "schedule_groups" in tables
+            assert "schedule_group_agenda_templates" in tables
+            assert "templates" in tables
+            assert "template_default_counterparts" in tables
+            assert "template_agenda_templates" in tables
+
+        # Downgrade to base
+        command.downgrade(alembic_cfg, "base")
+
+        async with session_factory() as s:
+            result = await s.execute(text("SHOW TABLES"))
+            tables = {row[0] for row in result.fetchall()}
+            assert "schedules" not in tables
+            assert "confirmation_requests" not in tables
+
+        # Re-create tables so session-scoped fixture teardown works
+        async with session_factory() as s:
+            from foundation.db.base import Base
+
+            conn = await s.connection()
+            await conn.run_sync(Base.metadata.create_all)
+            await s.commit()

--- a/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_template_repository.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_template_repository.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_name import TemplateName
+from contexts.preparation.domain.value_objects import TemplateId
+from contexts.preparation.infrastructure.sqlalchemy_template_repository import (
+    SqlAlchemyTemplateRepository,
+)
+from shared.domain.value_objects import UserId
+from shared.infrastructure.tables import UserTable
+
+pytestmark = pytest.mark.integration
+
+NOW = datetime(2026, 4, 1, 10, 0)
+
+
+async def _create_user(session: AsyncSession) -> UserId:
+    user_id = UserId.generate()
+    session.add(UserTable(id=str(user_id.value)))
+    await session.flush()
+    return user_id
+
+
+def _make_template(
+    *,
+    organizer_id: UserId,
+    name: str = "Default Template",
+    default_counterparts: list[UserId] | None = None,
+    agenda_templates: list[AgendaTemplate] | None = None,
+    now: datetime = NOW,
+) -> Template:
+    return Template.create(
+        organizer_id=organizer_id,
+        name=TemplateName(name),
+        default_counterparts=default_counterparts,
+        agenda_templates=agenda_templates,
+        now=now,
+    )
+
+
+class TestSaveAndGetById:
+    """save() -> get_by_id() round-trip."""
+
+    async def test_save_and_restore_minimal_template(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+
+        template = _make_template(organizer_id=org)
+        await repo.save(template)
+        await session.commit()
+
+        loaded = await repo.get_by_id(template.id)
+
+        assert loaded is not None
+        assert loaded.id == template.id
+        assert loaded.organizer_id == org
+        assert loaded.name == TemplateName("Default Template")
+        assert loaded.default_counterparts == []
+        assert loaded.agenda_templates == []
+
+    async def test_save_with_counterparts_and_agendas(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+        cp1 = await _create_user(session)
+        cp2 = await _create_user(session)
+
+        template = _make_template(
+            organizer_id=org,
+            default_counterparts=[cp1, cp2],
+            agenda_templates=[AgendaTemplate("Topic A"), AgendaTemplate("Topic B")],
+        )
+        await repo.save(template)
+        await session.commit()
+
+        loaded = await repo.get_by_id(template.id)
+
+        assert loaded is not None
+        assert len(loaded.default_counterparts) == 2
+        assert loaded.default_counterparts[0] == cp1
+        assert loaded.default_counterparts[1] == cp2
+        assert len(loaded.agenda_templates) == 2
+        assert loaded.agenda_templates[0].topic.value == "Topic A"
+        assert loaded.agenda_templates[1].topic.value == "Topic B"
+
+    async def test_get_by_id_returns_none_for_missing(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyTemplateRepository(session)
+        result = await repo.get_by_id(TemplateId.generate())
+        assert result is None
+
+
+class TestUpdateTemplate:
+    """save() with template updates."""
+
+    async def test_update_name_and_lists(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+        cp1 = await _create_user(session)
+        cp2 = await _create_user(session)
+
+        template = _make_template(
+            organizer_id=org,
+            default_counterparts=[cp1],
+            agenda_templates=[AgendaTemplate("Old Topic")],
+        )
+        await repo.save(template)
+        await session.commit()
+
+        # Update via domain method
+        template.update(
+            actor_id=org,
+            name=TemplateName("Updated Template"),
+            default_counterparts=[cp2, cp1],
+            agenda_templates=[
+                AgendaTemplate("New Topic A"),
+                AgendaTemplate("New Topic B"),
+            ],
+            now=datetime(2026, 4, 2, 10, 0),
+        )
+        await repo.save(template)
+        await session.commit()
+
+        loaded = await repo.get_by_id(template.id)
+
+        assert loaded is not None
+        assert loaded.name == TemplateName("Updated Template")
+        assert len(loaded.default_counterparts) == 2
+        assert loaded.default_counterparts[0] == cp2
+        assert loaded.default_counterparts[1] == cp1
+        assert len(loaded.agenda_templates) == 2
+        assert loaded.agenda_templates[0].topic.value == "New Topic A"
+        assert loaded.agenda_templates[1].topic.value == "New Topic B"
+
+    async def test_update_removes_all_children(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+        cp1 = await _create_user(session)
+
+        template = _make_template(
+            organizer_id=org,
+            default_counterparts=[cp1],
+            agenda_templates=[AgendaTemplate("Topic")],
+        )
+        await repo.save(template)
+        await session.commit()
+
+        # Update to empty lists
+        template.update(
+            actor_id=org,
+            name=TemplateName("Empty Template"),
+            default_counterparts=[],
+            agenda_templates=[],
+            now=datetime(2026, 4, 2, 10, 0),
+        )
+        await repo.save(template)
+        await session.commit()
+
+        loaded = await repo.get_by_id(template.id)
+
+        assert loaded is not None
+        assert loaded.default_counterparts == []
+        assert loaded.agenda_templates == []
+
+
+class TestPositionOrdering:
+    """Verify position-based ordering is preserved."""
+
+    async def test_counterpart_order_preserved(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+        users = [await _create_user(session) for _ in range(5)]
+
+        template = _make_template(
+            organizer_id=org,
+            default_counterparts=users,
+        )
+        await repo.save(template)
+        await session.commit()
+
+        loaded = await repo.get_by_id(template.id)
+
+        assert loaded is not None
+        assert loaded.default_counterparts == users
+
+    async def test_agenda_template_order_preserved(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+
+        topics = [f"Topic {i}" for i in range(5)]
+        agenda_templates = [AgendaTemplate(t) for t in topics]
+
+        template = _make_template(
+            organizer_id=org,
+            agenda_templates=agenda_templates,
+        )
+        await repo.save(template)
+        await session.commit()
+
+        loaded = await repo.get_by_id(template.id)
+
+        assert loaded is not None
+        loaded_topics = [at.topic.value for at in loaded.agenda_templates]
+        assert loaded_topics == topics


### PR DESCRIPTION
## 変更内容

Preparation コンテキストの 3 つの集約（Schedule, ScheduleGroup, Template）に対して、リポジトリインターフェース・SQLAlchemy ORM テーブル定義・リポジトリ実装・Alembic マイグレーション・インテグレーションテストを作成。

### 新規ファイル

**ドメイン層（リポジトリインターフェース）**
- `backend/contexts/preparation/domain/schedule_repository.py`
- `backend/contexts/preparation/domain/schedule_group_repository.py`
- `backend/contexts/preparation/domain/template_repository.py`

**インフラ層（ORM テーブル定義）**
- `backend/contexts/preparation/infrastructure/tables.py` — 7 テーブル定義（全テーブル TimestampMixin 適用）

**インフラ層（リポジトリ実装）**
- `backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py` — ConfirmationRequest の reconciliation パターン
- `backend/contexts/preparation/infrastructure/sqlalchemy_schedule_group_repository.py` — schedule_ids を schedules テーブルから逆引き復元、AgendaTemplate は全削除+全挿入
- `backend/contexts/preparation/infrastructure/sqlalchemy_template_repository.py` — DefaultCounterparts・AgendaTemplates とも全削除+全挿入

**マイグレーション**
- `backend/migrations/versions/0003_create_preparation_tables.py`

**テスト**
- `backend/tests/contexts/preparation/infrastructure/conftest.py`
- `backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_repository.py`
- `backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_group_repository.py`
- `backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_template_repository.py`

### 設計判断

- **AgendaTemplate の永続化**: JSON カラムではなく子テーブルを採用（順序の明示管理、将来の検索柔軟性）
- **position カラム**: AgendaTemplate と DefaultCounterparts はリスト順序が意味を持つため `position INTEGER NOT NULL` で保持
- **ScheduleGroup の schedule_ids**: DB 上は `schedules.schedule_group_id` FK が正（single source of truth）。get_by_id 時に `created_at ASC, id ASC` で逆引き
- **Template の子エンティティ更新**: ID に意味がないため全削除+全挿入で実装（reconciliation よりシンプル）
- **scheduled_at / proposed_at**: `DATETIME(fsp=6)` でマイクロ秒精度を保持

### テスト結果

- ユニットテスト: 334 passed（ruff check / ruff format / pyright 全パス）
- インテグレーションテスト: ローカル環境では greenlet 未対応のためスキップ（CI で実行される想定）

Closes #20
