### PR TITLE
Record コンテキストのリポジトリ・ORM・マイグレーション実装

### DIFF
--- a/backend/contexts/record/domain/action_item.py
+++ b/backend/contexts/record/domain/action_item.py
@@ -36,11 +36,16 @@ class ActionItem:
     title: ActionItemTitle
     _is_completed: bool
     created_at: datetime
+    _updated_at: datetime
     _events: list[_ActionItemEvent] = field(default_factory=list, repr=False)
 
     @property
     def is_completed(self) -> bool:
         return self._is_completed
+
+    @property
+    def updated_at(self) -> datetime:
+        return self._updated_at
 
     @staticmethod
     def create(
@@ -64,6 +69,7 @@ class ActionItem:
             title=title,
             _is_completed=False,
             created_at=ts,
+            _updated_at=ts,
         )
         action_item._events.append(
             ActionItemAdded(
@@ -85,6 +91,7 @@ class ActionItem:
         if self._is_completed:
             raise ActionItemAlreadyCompletedError("Action item is already completed.")
         self._is_completed = True
+        self._updated_at = now
         self._events.append(
             ActionItemCompleted(
                 occurred_at=now,

--- a/backend/contexts/record/domain/action_item_repository.py
+++ b/backend/contexts/record/domain/action_item_repository.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.value_objects import ActionItemId
+from foundation.domain.base_repository import BaseRepository
+
+
+class ActionItemRepository(BaseRepository[ActionItem, ActionItemId]):
+    """Repository interface for ActionItem aggregates."""
+
+    pass  # get_by_id + save (insert or update)

--- a/backend/contexts/record/domain/comment_repository.py
+++ b/backend/contexts/record/domain/comment_repository.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from contexts.record.domain.comment import Comment
+from contexts.record.domain.value_objects import CommentId
+from foundation.domain.base_repository import BaseRepository
+
+
+class CommentRepository(BaseRepository[Comment, CommentId]):
+    """Repository interface for Comment aggregates.
+
+    Comment is insert-only: save() must raise an exception
+    if the entity already exists.
+    """
+
+    pass

--- a/backend/contexts/record/domain/exceptions.py
+++ b/backend/contexts/record/domain/exceptions.py
@@ -36,6 +36,13 @@ class InvalidCommentBodyError(Exception):
         super().__init__(message)
 
 
+class CommentAlreadyExistsError(Exception):
+    """Raised when attempting to save a comment that already exists."""
+
+    def __init__(self, message: str = "Comment already exists.") -> None:
+        super().__init__(message)
+
+
 class InvalidMemoError(Exception):
     """Raised when a memo fails validation."""
 

--- a/backend/contexts/record/domain/record_repository.py
+++ b/backend/contexts/record/domain/record_repository.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import RecordId
+from foundation.domain.base_repository import BaseRepository
+
+
+class RecordRepository(BaseRepository[Record, RecordId]):
+    """Repository interface for Record aggregates."""
+
+    pass  # get_by_id + save only

--- a/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
-
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -45,14 +43,14 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
             title=entity.title.value,
             is_completed=entity.is_completed,
             created_at=entity.created_at,
+            updated_at=entity.updated_at,
         )
         self._session.add(action_item_row)
         await self._session.flush()
 
     async def _update(self, entity: ActionItem, existing: ActionItemTable) -> None:
-        now = datetime.now(UTC)
         existing.is_completed = entity.is_completed
-        existing.updated_at = now
+        existing.updated_at = entity.updated_at
         await self._session.flush()
 
     @staticmethod
@@ -64,4 +62,5 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
             title=ActionItemTitle(row.title),
             _is_completed=row.is_completed,
             created_at=row.created_at,
+            _updated_at=row.updated_at,
         )

--- a/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle, RecordId
+from contexts.record.infrastructure.tables import ActionItemTable
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyActionItemRepository(ActionItemRepository):
+    """SQLAlchemy-based implementation of ActionItemRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: ActionItemId) -> ActionItem | None:
+        stmt = select(ActionItemTable).where(ActionItemTable.id == str(entity_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def save(self, entity: ActionItem) -> None:
+        existing = await self._session.get(ActionItemTable, str(entity.id.value))
+        if existing is None:
+            await self._insert(entity)
+        else:
+            await self._update(entity, existing)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _insert(self, entity: ActionItem) -> None:
+        action_item_row = ActionItemTable(
+            id=str(entity.id.value),
+            counterpart_id=str(entity.counterpart_id.value),
+            record_id=str(entity.record_id.value),
+            title=entity.title.value,
+            is_completed=entity.is_completed,
+            created_at=entity.created_at,
+        )
+        self._session.add(action_item_row)
+        await self._session.flush()
+
+    async def _update(self, entity: ActionItem, existing: ActionItemTable) -> None:
+        now = datetime.now(UTC)
+        existing.is_completed = entity.is_completed
+        existing.updated_at = now
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: ActionItemTable) -> ActionItem:
+        return ActionItem(
+            id=ActionItemId.from_str(row.id),
+            counterpart_id=UserId.from_str(row.counterpart_id),
+            record_id=RecordId.from_str(row.record_id),
+            title=ActionItemTitle(row.title),
+            _is_completed=row.is_completed,
+            created_at=row.created_at,
+        )

--- a/backend/contexts/record/infrastructure/sqlalchemy_comment_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_comment_repository.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.record.domain.comment import Comment
+from contexts.record.domain.comment_body import CommentBody
+from contexts.record.domain.comment_repository import CommentRepository
+from contexts.record.domain.exceptions import CommentAlreadyExistsError
+from contexts.record.domain.value_objects import CommentId, RecordId
+from contexts.record.infrastructure.tables import CommentTable
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyCommentRepository(CommentRepository):
+    """SQLAlchemy-based implementation of CommentRepository.
+
+    Comment is insert-only: save() raises CommentAlreadyExistsError
+    if the entity already exists.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: CommentId) -> Comment | None:
+        stmt = select(CommentTable).where(CommentTable.id == str(entity_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def save(self, entity: Comment) -> None:
+        existing = await self._session.get(CommentTable, str(entity.id.value))
+        if existing is not None:
+            raise CommentAlreadyExistsError(
+                f"Comment {entity.id.value} already exists."
+            )
+        comment_row = CommentTable(
+            id=str(entity.id.value),
+            record_id=str(entity.record_id.value),
+            author_id=str(entity.author_id.value),
+            body=entity.body.value,
+            created_at=entity.created_at,
+        )
+        self._session.add(comment_row)
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: CommentTable) -> Comment:
+        return Comment(
+            id=CommentId.from_str(row.id),
+            record_id=RecordId.from_str(row.record_id),
+            author_id=UserId.from_str(row.author_id),
+            body=CommentBody(row.body),
+            created_at=row.created_at,
+        )

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.record.domain.memo import Memo
+from contexts.record.domain.record import Record
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import RecordId, RecordStatus
+from contexts.record.infrastructure.tables import RecordTable, RecordViewerTable
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyRecordRepository(RecordRepository):
+    """SQLAlchemy-based implementation of RecordRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: RecordId) -> Record | None:
+        stmt = select(RecordTable).where(RecordTable.id == str(entity_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def save(self, entity: Record) -> None:
+        existing = await self._session.get(RecordTable, str(entity.id.value))
+        if existing is None:
+            await self._insert(entity)
+        else:
+            await self._update(entity, existing)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _insert(self, entity: Record) -> None:
+        record_row = RecordTable(
+            id=str(entity.id.value),
+            organizer_id=str(entity.organizer_id.value),
+            counterpart_id=str(entity.counterpart_id.value),
+            schedule_id=(str(entity.schedule_id.value) if entity.schedule_id else None),
+            memo=entity.memo.value,
+            status=entity.status.value,
+            conducted_at=entity.conducted_at,
+            created_at=entity.created_at,
+            updated_at=entity.updated_at,
+        )
+        for viewer_id in entity.viewers:
+            viewer_row = RecordViewerTable(
+                id=str(uuid.uuid4()),
+                record_id=str(entity.id.value),
+                user_id=str(viewer_id.value),
+                created_at=entity.created_at,
+                updated_at=entity.updated_at,
+            )
+            record_row.viewers.append(viewer_row)
+        self._session.add(record_row)
+        await self._session.flush()
+
+    async def _update(self, entity: Record, existing: RecordTable) -> None:
+        now = datetime.now(UTC)
+
+        # Update scalar fields
+        existing.memo = entity.memo.value
+        existing.status = entity.status.value
+        existing.conducted_at = entity.conducted_at
+        existing.schedule_id = (
+            str(entity.schedule_id.value) if entity.schedule_id else None
+        )
+        existing.updated_at = now
+
+        # Replace viewers: delete all, then re-insert
+        existing.viewers.clear()
+        await self._session.flush()
+
+        for viewer_id in entity.viewers:
+            new_viewer = RecordViewerTable(
+                id=str(uuid.uuid4()),
+                record_id=str(entity.id.value),
+                user_id=str(viewer_id.value),
+                created_at=now,
+                updated_at=now,
+            )
+            existing.viewers.append(new_viewer)
+
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: RecordTable) -> Record:
+        viewers = [UserId.from_str(v.user_id) for v in row.viewers]
+        return Record(
+            id=RecordId.from_str(row.id),
+            organizer_id=UserId.from_str(row.organizer_id),
+            counterpart_id=UserId.from_str(row.counterpart_id),
+            schedule_id=(
+                ScheduleId.from_str(row.schedule_id) if row.schedule_id else None
+            ),
+            _memo=Memo(row.memo),
+            _status=RecordStatus(row.status),
+            _viewers=viewers,
+            conducted_at=row.conducted_at,
+            created_at=row.created_at,
+            _updated_at=row.updated_at,
+        )

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -65,8 +64,6 @@ class SqlAlchemyRecordRepository(RecordRepository):
         await self._session.flush()
 
     async def _update(self, entity: Record, existing: RecordTable) -> None:
-        now = datetime.now(UTC)
-
         # Update scalar fields
         existing.memo = entity.memo.value
         existing.status = entity.status.value
@@ -74,7 +71,7 @@ class SqlAlchemyRecordRepository(RecordRepository):
         existing.schedule_id = (
             str(entity.schedule_id.value) if entity.schedule_id else None
         )
-        existing.updated_at = now
+        existing.updated_at = entity.updated_at
 
         # Replace viewers: delete all, then re-insert
         existing.viewers.clear()
@@ -85,8 +82,8 @@ class SqlAlchemyRecordRepository(RecordRepository):
                 id=str(uuid.uuid4()),
                 record_id=str(entity.id.value),
                 user_id=str(viewer_id.value),
-                created_at=now,
-                updated_at=now,
+                created_at=entity.updated_at,
+                updated_at=entity.updated_at,
             )
             existing.viewers.append(new_viewer)
 

--- a/backend/contexts/record/infrastructure/tables.py
+++ b/backend/contexts/record/infrastructure/tables.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+
+from sqlalchemy import CHAR, TEXT, VARCHAR, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.mysql import DATETIME
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from foundation.db.base import Base, TimestampMixin
+
+
+class RecordTable(Base, TimestampMixin):
+    """ORM model for the records table."""
+
+    __tablename__ = "records"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    organizer_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey("users.id", ondelete="RESTRICT", name="fk_records_organizer_id"),
+        nullable=False,
+    )
+    counterpart_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey("users.id", ondelete="RESTRICT", name="fk_records_counterpart_id"),
+        nullable=False,
+    )
+    schedule_id: Mapped[str | None] = mapped_column(CHAR(36), nullable=True)
+    memo: Mapped[str] = mapped_column(TEXT, nullable=False)
+    status: Mapped[str] = mapped_column(VARCHAR(20), nullable=False)
+    conducted_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
+
+    viewers: Mapped[list["RecordViewerTable"]] = relationship(
+        back_populates="record",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
+
+
+class RecordViewerTable(Base, TimestampMixin):
+    """ORM model for the record_viewers table."""
+
+    __tablename__ = "record_viewers"
+    __table_args__ = (
+        UniqueConstraint(
+            "record_id", "user_id", name="uq_record_viewers_record_id_user_id"
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    record_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "records.id", ondelete="CASCADE", name="fk_record_viewers_record_id"
+        ),
+        nullable=False,
+    )
+    user_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey("users.id", ondelete="RESTRICT", name="fk_record_viewers_user_id"),
+        nullable=False,
+    )
+
+    record: Mapped["RecordTable"] = relationship(back_populates="viewers")
+
+
+class CommentTable(Base, TimestampMixin):
+    """ORM model for the comments table."""
+
+    __tablename__ = "comments"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    record_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey("records.id", ondelete="CASCADE", name="fk_comments_record_id"),
+        nullable=False,
+    )
+    author_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey("users.id", ondelete="RESTRICT", name="fk_comments_author_id"),
+        nullable=False,
+    )
+    body: Mapped[str] = mapped_column(TEXT, nullable=False)
+
+
+class ActionItemTable(Base, TimestampMixin):
+    """ORM model for the action_items table."""
+
+    __tablename__ = "action_items"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    counterpart_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id", ondelete="RESTRICT", name="fk_action_items_counterpart_id"
+        ),
+        nullable=False,
+    )
+    record_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey("records.id", ondelete="CASCADE", name="fk_action_items_record_id"),
+        nullable=False,
+    )
+    title: Mapped[str] = mapped_column(VARCHAR(200), nullable=False)
+    is_completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -4,10 +4,24 @@ Import all table models here so that Alembic's autogenerate can detect them
 via Base.metadata. When adding a new table, add an explicit import below.
 """
 
+from contexts.record.infrastructure.tables import (
+    ActionItemTable,  # noqa: F401
+    CommentTable,  # noqa: F401
+    RecordTable,  # noqa: F401
+    RecordViewerTable,  # noqa: F401
+)
 from contexts.workspace.infrastructure.tables import (
     MembershipTable,  # noqa: F401
     WorkspaceTable,  # noqa: F401
 )
 from shared.infrastructure.tables import UserTable  # noqa: F401
 
-__all__ = ["MembershipTable", "UserTable", "WorkspaceTable"]
+__all__ = [
+    "ActionItemTable",
+    "CommentTable",
+    "MembershipTable",
+    "RecordTable",
+    "RecordViewerTable",
+    "UserTable",
+    "WorkspaceTable",
+]

--- a/backend/migrations/versions/0003_create_record_tables.py
+++ b/backend/migrations/versions/0003_create_record_tables.py
@@ -1,0 +1,168 @@
+"""create record tables
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "records",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("organizer_id", sa.CHAR(36), nullable=False),
+        sa.Column("counterpart_id", sa.CHAR(36), nullable=False),
+        sa.Column("schedule_id", sa.CHAR(36), nullable=True),
+        sa.Column("memo", sa.TEXT(), nullable=False),
+        sa.Column("status", sa.VARCHAR(20), nullable=False),
+        sa.Column(
+            "conducted_at",
+            mysql.DATETIME(fsp=6),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["organizer_id"],
+            ["users.id"],
+            name="fk_records_organizer_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["counterpart_id"],
+            ["users.id"],
+            name="fk_records_counterpart_id",
+            ondelete="RESTRICT",
+        ),
+    )
+
+    op.create_table(
+        "record_viewers",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("record_id", sa.CHAR(36), nullable=False),
+        sa.Column("user_id", sa.CHAR(36), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["record_id"],
+            ["records.id"],
+            name="fk_record_viewers_record_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_record_viewers_user_id",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint(
+            "record_id", "user_id", name="uq_record_viewers_record_id_user_id"
+        ),
+    )
+
+    op.create_table(
+        "comments",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("record_id", sa.CHAR(36), nullable=False),
+        sa.Column("author_id", sa.CHAR(36), nullable=False),
+        sa.Column("body", sa.TEXT(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["record_id"],
+            ["records.id"],
+            name="fk_comments_record_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["author_id"],
+            ["users.id"],
+            name="fk_comments_author_id",
+            ondelete="RESTRICT",
+        ),
+    )
+
+    op.create_table(
+        "action_items",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("counterpart_id", sa.CHAR(36), nullable=False),
+        sa.Column("record_id", sa.CHAR(36), nullable=False),
+        sa.Column("title", sa.VARCHAR(200), nullable=False),
+        sa.Column("is_completed", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["counterpart_id"],
+            ["users.id"],
+            name="fk_action_items_counterpart_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["record_id"],
+            ["records.id"],
+            name="fk_action_items_record_id",
+            ondelete="CASCADE",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("action_items")
+    op.drop_table("comments")
+    op.drop_table("record_viewers")
+    op.drop_table("records")

--- a/backend/migrations/versions/0004_create_record_tables.py
+++ b/backend/migrations/versions/0004_create_record_tables.py
@@ -1,7 +1,7 @@
 """create record tables
 
-Revision ID: 0003
-Revises: 0002
+Revision ID: 0004
+Revises: 0003
 Create Date: 2026-03-24
 """
 
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql
 
-revision: str = "0003"
-down_revision: str | None = "0002"
+revision: str = "0004"
+down_revision: str | None = "0003"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/tests/contexts/record/infrastructure/conftest.py
+++ b/backend/tests/contexts/record/infrastructure/conftest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+import foundation.db.models  # noqa: F401
+from foundation.config.settings import settings
+from foundation.db.base import Base
+
+
+def _test_database_url() -> str:
+    """Build a URL pointing to the perigee_test database."""
+    return (
+        f"mysql+asyncmy://{settings.db_user}:{settings.db_password}"
+        f"@{settings.db_host}:{settings.db_port}/perigee_test"
+    )
+
+
+@pytest_asyncio.fixture(scope="session")
+async def test_engine() -> AsyncGenerator[AsyncEngine]:
+    """Create a test engine that connects to perigee_test."""
+    engine = create_async_engine(
+        _test_database_url(),
+        echo=False,
+        pool_pre_ping=True,
+        connect_args={"init_command": "SET time_zone='+00:00'"},
+    )
+    # Create all tables at the start of the test session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    # Drop all tables at the end of the test session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(
+    test_engine: AsyncEngine,
+) -> AsyncGenerator[AsyncSession]:
+    """Provide a transactional session that rolls back after each test."""
+    session_factory = async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as session:
+        yield session
+        # Roll back any uncommitted changes after each test
+        await session.rollback()
+
+
+@pytest.fixture
+def session_factory(
+    test_engine: AsyncEngine,
+) -> async_sessionmaker[AsyncSession]:
+    """Provide a session factory for tests that need multiple sessions."""
+    return async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_action_item_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_action_item_repository.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle
+from contexts.record.infrastructure.sqlalchemy_action_item_repository import (
+    SqlAlchemyActionItemRepository,
+)
+from contexts.record.infrastructure.sqlalchemy_record_repository import (
+    SqlAlchemyRecordRepository,
+)
+from shared.domain.value_objects import UserId
+from shared.infrastructure.tables import UserTable
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_user(session: AsyncSession) -> UserId:
+    """Insert a user row and return its UserId (needed for FK constraints)."""
+    user_id = UserId.generate()
+    session.add(UserTable(id=str(user_id.value)))
+    await session.flush()
+    return user_id
+
+
+async def _create_record(
+    session: AsyncSession, organizer: UserId, counterpart: UserId
+) -> Record:
+    """Create and persist a Record (needed for FK constraints on action items)."""
+    record = Record.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        conducted_at=datetime(2026, 3, 20, 14, 0),
+        now=datetime(2026, 3, 20, 10, 0),
+    )
+    repo = SqlAlchemyRecordRepository(session)
+    await repo.save(record)
+    await session.flush()
+    return record
+
+
+class TestSaveAndGetById:
+    """save() -> get_by_id() round-trip."""
+
+    async def test_save_and_restore_action_item(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyActionItemRepository(session)
+        action_item = ActionItem.create(
+            counterpart_id=counterpart,
+            record_id=record.id,
+            title=ActionItemTitle("Review PR #42"),
+            actor_id=organizer,
+            organizer_id=organizer,
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(action_item)
+        await session.commit()
+
+        loaded = await repo.get_by_id(action_item.id)
+
+        assert loaded is not None
+        assert loaded.id == action_item.id
+        assert loaded.counterpart_id == counterpart
+        assert loaded.record_id == record.id
+        assert loaded.title == ActionItemTitle("Review PR #42")
+        assert loaded.is_completed is False
+
+    async def test_get_by_id_returns_none_for_missing(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyActionItemRepository(session)
+        result = await repo.get_by_id(ActionItemId.generate())
+        assert result is None
+
+
+class TestActionItemUpdate:
+    """save() with updates (complete)."""
+
+    async def test_complete_action_item(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyActionItemRepository(session)
+        action_item = ActionItem.create(
+            counterpart_id=counterpart,
+            record_id=record.id,
+            title=ActionItemTitle("Write tests"),
+            actor_id=organizer,
+            organizer_id=organizer,
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(action_item)
+        await session.commit()
+
+        # Complete the action item
+        action_item.complete(
+            actor_id=counterpart,
+            now=datetime(2026, 3, 20, 16, 0),
+        )
+        await repo.save(action_item)
+        await session.commit()
+
+        loaded = await repo.get_by_id(action_item.id)
+        assert loaded is not None
+        assert loaded.is_completed is True

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_comment_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_comment_repository.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.record.domain.comment import Comment
+from contexts.record.domain.comment_body import CommentBody
+from contexts.record.domain.exceptions import CommentAlreadyExistsError
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import CommentId
+from contexts.record.infrastructure.sqlalchemy_comment_repository import (
+    SqlAlchemyCommentRepository,
+)
+from contexts.record.infrastructure.sqlalchemy_record_repository import (
+    SqlAlchemyRecordRepository,
+)
+from shared.domain.value_objects import UserId
+from shared.infrastructure.tables import UserTable
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_user(session: AsyncSession) -> UserId:
+    """Insert a user row and return its UserId (needed for FK constraints)."""
+    user_id = UserId.generate()
+    session.add(UserTable(id=str(user_id.value)))
+    await session.flush()
+    return user_id
+
+
+async def _create_record(
+    session: AsyncSession, organizer: UserId, counterpart: UserId
+) -> Record:
+    """Create and persist a Record (needed for FK constraints on comments)."""
+    record = Record.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        conducted_at=datetime(2026, 3, 20, 14, 0),
+        now=datetime(2026, 3, 20, 10, 0),
+    )
+    repo = SqlAlchemyRecordRepository(session)
+    await repo.save(record)
+    await session.flush()
+    return record
+
+
+class TestSaveAndGetById:
+    """save() -> get_by_id() round-trip."""
+
+    async def test_save_and_restore_comment(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyCommentRepository(session)
+        comment = Comment.create(
+            record_id=record.id,
+            author_id=organizer,
+            body=CommentBody("Great session!"),
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(comment)
+        await session.commit()
+
+        loaded = await repo.get_by_id(comment.id)
+
+        assert loaded is not None
+        assert loaded.id == comment.id
+        assert loaded.record_id == record.id
+        assert loaded.author_id == organizer
+        assert loaded.body == CommentBody("Great session!")
+
+    async def test_get_by_id_returns_none_for_missing(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyCommentRepository(session)
+        result = await repo.get_by_id(CommentId.generate())
+        assert result is None
+
+
+class TestInsertOnly:
+    """Comment is insert-only: save() raises on duplicate."""
+
+    async def test_save_existing_comment_raises(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyCommentRepository(session)
+        comment = Comment.create(
+            record_id=record.id,
+            author_id=organizer,
+            body=CommentBody("First comment"),
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(comment)
+        await session.commit()
+
+        with pytest.raises(CommentAlreadyExistsError):
+            await repo.save(comment)

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_record_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_record_repository.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.record.domain.memo import Memo
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import RecordId, RecordStatus
+from contexts.record.infrastructure.sqlalchemy_record_repository import (
+    SqlAlchemyRecordRepository,
+)
+from shared.domain.value_objects import UserId
+from shared.infrastructure.tables import UserTable
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_user(session: AsyncSession) -> UserId:
+    """Insert a user row and return its UserId (needed for FK constraints)."""
+    user_id = UserId.generate()
+    session.add(UserTable(id=str(user_id.value)))
+    await session.flush()
+    return user_id
+
+
+def _make_record(
+    *,
+    organizer_id: UserId,
+    counterpart_id: UserId,
+    schedule_id: ScheduleId | None = None,
+    now: datetime | None = None,
+) -> Record:
+    return Record.create(
+        organizer_id=organizer_id,
+        counterpart_id=counterpart_id,
+        conducted_at=datetime(2026, 3, 20, 14, 0),
+        schedule_id=schedule_id,
+        now=now or datetime(2026, 3, 20, 10, 0),
+    )
+
+
+class TestSaveAndGetById:
+    """save() -> get_by_id() round-trip."""
+
+    async def test_save_and_restore_record(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        await repo.save(record)
+        await session.commit()
+
+        loaded = await repo.get_by_id(record.id)
+
+        assert loaded is not None
+        assert loaded.id == record.id
+        assert loaded.organizer_id == organizer
+        assert loaded.counterpart_id == counterpart
+        assert loaded.memo == Memo("")
+        assert loaded.status == RecordStatus.DRAFT
+        assert loaded.viewers == []
+        assert loaded.conducted_at == record.conducted_at
+        assert loaded.schedule_id is None
+
+    async def test_get_by_id_returns_none_for_missing(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        result = await repo.get_by_id(RecordId.generate())
+        assert result is None
+
+
+class TestRecordUpdate:
+    """save() with updates to memo, status, and viewers."""
+
+    async def test_update_memo_and_status(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        await repo.save(record)
+        await session.commit()
+
+        # Update memo
+        record.update_memo(
+            memo=Memo("Updated memo content"),
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 12, 0),
+        )
+        # Publish
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 13, 0))
+        await repo.save(record)
+        await session.commit()
+
+        loaded = await repo.get_by_id(record.id)
+        assert loaded is not None
+        assert loaded.memo == Memo("Updated memo content")
+        assert loaded.status == RecordStatus.PUBLISHED
+
+    async def test_save_with_viewers(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        viewer1 = await _create_user(session)
+        viewer2 = await _create_user(session)
+
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        record.set_viewers(
+            viewer_ids=[viewer1, viewer2],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+        await repo.save(record)
+        await session.commit()
+
+        loaded = await repo.get_by_id(record.id)
+        assert loaded is not None
+        loaded_viewer_ids = set(loaded.viewers)
+        assert loaded_viewer_ids == {viewer1, viewer2}
+
+    async def test_update_viewers_replace(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        viewer1 = await _create_user(session)
+        viewer2 = await _create_user(session)
+        viewer3 = await _create_user(session)
+
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        record.set_viewers(
+            viewer_ids=[viewer1, viewer2],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+        await repo.save(record)
+        await session.commit()
+
+        # Replace viewers: remove viewer1, keep viewer2, add viewer3
+        record.set_viewers(
+            viewer_ids=[viewer2, viewer3],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 12, 0),
+        )
+        await repo.save(record)
+        await session.commit()
+
+        loaded = await repo.get_by_id(record.id)
+        assert loaded is not None
+        loaded_viewer_ids = set(loaded.viewers)
+        assert loaded_viewer_ids == {viewer2, viewer3}
+
+    async def test_update_viewers_to_empty(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        viewer1 = await _create_user(session)
+
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        record.set_viewers(
+            viewer_ids=[viewer1],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+        await repo.save(record)
+        await session.commit()
+
+        # Clear all viewers
+        record.set_viewers(
+            viewer_ids=[],
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 12, 0),
+        )
+        await repo.save(record)
+        await session.commit()
+
+        loaded = await repo.get_by_id(record.id)
+        assert loaded is not None
+        assert loaded.viewers == []
+
+    async def test_save_with_schedule_id(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        schedule_id = ScheduleId.generate()
+
+        record = _make_record(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            schedule_id=schedule_id,
+        )
+        await repo.save(record)
+        await session.commit()
+
+        loaded = await repo.get_by_id(record.id)
+        assert loaded is not None
+        assert loaded.schedule_id == schedule_id
+
+    async def test_save_without_schedule_id(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyRecordRepository(session)
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+
+        record = _make_record(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            schedule_id=None,
+        )
+        await repo.save(record)
+        await session.commit()
+
+        loaded = await repo.get_by_id(record.id)
+        assert loaded is not None
+        assert loaded.schedule_id is None


### PR DESCRIPTION
## Summary

- Record コンテキストの 3 つの集約（Record, Comment, ActionItem）に対して、リポジトリインターフェース・SQLAlchemy ORM テーブル定義・リポジトリ実装・Alembic マイグレーション・テストを作成
- Workspace コンテキストの既存実装パターン（命名規則・ディレクトリ構造・TimestampMixin・FK 命名規則）に準拠
- Comment は insert-only 設計（既存 ID で save すると CommentAlreadyExistsError を送出）
- Record の viewers は子テーブル（record_viewers）で永続化し、更新時は全削除→全挿入で置換

## 変更内容

### ドメイン層
- `RecordRepository`, `CommentRepository`, `ActionItemRepository` インターフェース追加
- `CommentAlreadyExistsError` ドメイン例外追加

### インフラ層
- `RecordTable`, `RecordViewerTable`, `CommentTable`, `ActionItemTable` ORM テーブル定義
- `SqlAlchemyRecordRepository`, `SqlAlchemyCommentRepository`, `SqlAlchemyActionItemRepository` 実装
- Alembic マイグレーション 0003（records → record_viewers → comments → action_items）
- `foundation/db/models.py` に全テーブルクラスを登録

### テスト
- 各リポジトリのインテグレーションテスト（save/get_by_id ラウンドトリップ、更新、viewers 管理、insert-only 制約）

## Test plan

- [x] `ruff check` / `ruff format --check` パス
- [x] `pyright` 型チェックパス
- [x] `pytest -m "not integration"` ユニットテストパス
- [ ] `pytest -m "integration"` インテグレーションテスト（DB コンテナ起動が必要）

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)