### PR TITLE
Record: 1on1開始・記録作成ユースケース

### DIFF
--- a/backend/contexts/record/application/create_record_service.py
+++ b/backend/contexts/record/application/create_record_service.py
@@ -1,0 +1,72 @@
+"""Use case: Create a 1-on-1 record (schedule-based or post-hoc)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.record.domain.record import Record
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import RecordId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.value_objects import UserId
+
+
+class CreateRecordService:
+    """Application service that creates a new Record in DRAFT status.
+
+    Supports two creation patterns:
+    - Schedule-based: organizer starts a 1-on-1 from a confirmed schedule.
+    - Post-hoc (Pattern C): organizer creates a record without a schedule.
+
+    The organizer is the only actor allowed to create a record.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        record_repo: RecordRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._record_repo = record_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        *,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+        conducted_at: datetime,
+        schedule_id: ScheduleId | None = None,
+    ) -> RecordId:
+        """Create a record and return its id.
+
+        Args:
+            organizer_id: The user creating the record (must be the organizer).
+            counterpart_id: The counterpart of the 1-on-1.
+            conducted_at: When the 1-on-1 was (or will be) conducted.
+            schedule_id: Optional schedule reference for schedule-based creation.
+
+        Returns:
+            The id of the newly created record.
+        """
+        now = datetime.now(UTC)
+
+        record = Record.create(
+            organizer_id=organizer_id,
+            counterpart_id=counterpart_id,
+            conducted_at=conducted_at,
+            schedule_id=schedule_id,
+            now=now,
+        )
+
+        async with self._uow:
+            await self._record_repo.save(record)
+            events = record.collect_events()
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)
+
+        return record.id

--- a/backend/foundation/domain/event_dispatcher.py
+++ b/backend/foundation/domain/event_dispatcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 
 from shared.domain.events import DomainEvent
 
@@ -13,5 +14,5 @@ class EventDispatcher(ABC):
     """
 
     @abstractmethod
-    async def dispatch(self, events: list[DomainEvent]) -> None:
+    async def dispatch(self, events: Sequence[DomainEvent]) -> None:
         """Dispatch the given events to all registered handlers."""

--- a/backend/foundation/infrastructure/in_memory_event_dispatcher.py
+++ b/backend/foundation/infrastructure/in_memory_event_dispatcher.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any
 
 from foundation.domain.event_dispatcher import EventDispatcher
@@ -38,7 +38,7 @@ class InMemoryEventDispatcher(EventDispatcher):
         """Register a handler for the given event type."""
         self._handlers[event_type].append(handler)
 
-    async def dispatch(self, events: list[DomainEvent]) -> None:
+    async def dispatch(self, events: Sequence[DomainEvent]) -> None:
         """Dispatch each event to all registered handlers for its type."""
         for event in events:
             handlers = self._handlers.get(type(event), [])

--- a/backend/tests/contexts/record/application/test_create_record_service.py
+++ b/backend/tests/contexts/record/application/test_create_record_service.py
@@ -1,0 +1,296 @@
+"""Tests for CreateRecordService."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import TracebackType
+
+import pytest
+
+from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.record.application.create_record_service import CreateRecordService
+from contexts.record.domain.events import RecordCreated
+from contexts.record.domain.record import Record
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import RecordId, RecordStatus
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class StubUnitOfWork(UnitOfWork):
+    """In-memory UoW that tracks commit/rollback calls."""
+
+    def __init__(self) -> None:
+        self.committed = False
+        self.rolled_back = False
+
+    async def commit(self) -> None:
+        self.committed = True
+
+    async def rollback(self) -> None:
+        self.rolled_back = True
+
+    async def __aenter__(self) -> StubUnitOfWork:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if exc_type is not None:
+            await self.rollback()
+
+
+class InMemoryRecordRepository(RecordRepository):
+    """In-memory record repository for unit testing."""
+
+    def __init__(self) -> None:
+        self._store: dict[RecordId, Record] = {}
+
+    async def get_by_id(self, entity_id: RecordId) -> Record | None:
+        return self._store.get(entity_id)
+
+    async def save(self, entity: Record) -> None:
+        self._store[entity.id] = entity
+
+    @property
+    def records(self) -> dict[RecordId, Record]:
+        return dict(self._store)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRecordFromSchedule:
+    """Schedule-based record creation (use case 1)."""
+
+    @pytest.fixture
+    def uow(self) -> StubUnitOfWork:
+        return StubUnitOfWork()
+
+    @pytest.fixture
+    def repo(self) -> InMemoryRecordRepository:
+        return InMemoryRecordRepository()
+
+    @pytest.fixture
+    def dispatcher(self) -> InMemoryEventDispatcher:
+        return InMemoryEventDispatcher()
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryRecordRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> CreateRecordService:
+        return CreateRecordService(
+            uow=uow,
+            record_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_creates_record_in_draft_status(
+        self,
+        service: CreateRecordService,
+        repo: InMemoryRecordRepository,
+    ) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule_id = ScheduleId.generate()
+        conducted_at = datetime(2026, 3, 20, 10, 0)
+
+        record_id = await service.execute(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            conducted_at=conducted_at,
+            schedule_id=schedule_id,
+        )
+
+        record = await repo.get_by_id(record_id)
+        assert record is not None
+        assert record.status == RecordStatus.DRAFT
+
+    async def test_links_schedule_id(
+        self,
+        service: CreateRecordService,
+        repo: InMemoryRecordRepository,
+    ) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule_id = ScheduleId.generate()
+        conducted_at = datetime(2026, 3, 20, 10, 0)
+
+        record_id = await service.execute(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            conducted_at=conducted_at,
+            schedule_id=schedule_id,
+        )
+
+        record = await repo.get_by_id(record_id)
+        assert record is not None
+        assert record.schedule_id == schedule_id
+
+    async def test_sets_conducted_at(
+        self,
+        service: CreateRecordService,
+        repo: InMemoryRecordRepository,
+    ) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        conducted_at = datetime(2026, 3, 20, 10, 0)
+
+        record_id = await service.execute(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            conducted_at=conducted_at,
+        )
+
+        record = await repo.get_by_id(record_id)
+        assert record is not None
+        assert record.conducted_at == conducted_at
+
+    async def test_commits_via_uow(
+        self,
+        service: CreateRecordService,
+        uow: StubUnitOfWork,
+    ) -> None:
+        await service.execute(
+            organizer_id=UserId.generate(),
+            counterpart_id=UserId.generate(),
+            conducted_at=datetime(2026, 3, 20, 10, 0),
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_record_created_event(
+        self,
+        service: CreateRecordService,
+    ) -> None:
+        dispatched_events: list[object] = []
+
+        async def capture_handler(event: object) -> None:
+            dispatched_events.append(event)
+
+        # Re-create service with a dispatcher that captures events
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(RecordCreated, capture_handler)  # type: ignore[arg-type]
+        service_with_handler = CreateRecordService(
+            uow=service._uow,
+            record_repo=service._record_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        await service_with_handler.execute(
+            organizer_id=UserId.generate(),
+            counterpart_id=UserId.generate(),
+            conducted_at=datetime(2026, 3, 20, 10, 0),
+        )
+
+        assert len(dispatched_events) == 1
+        assert isinstance(dispatched_events[0], RecordCreated)
+
+
+class TestCreatePostHocRecord:
+    """Post-hoc record creation without schedule (Pattern C)."""
+
+    @pytest.fixture
+    def uow(self) -> StubUnitOfWork:
+        return StubUnitOfWork()
+
+    @pytest.fixture
+    def repo(self) -> InMemoryRecordRepository:
+        return InMemoryRecordRepository()
+
+    @pytest.fixture
+    def dispatcher(self) -> InMemoryEventDispatcher:
+        return InMemoryEventDispatcher()
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryRecordRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> CreateRecordService:
+        return CreateRecordService(
+            uow=uow,
+            record_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_creates_record_without_schedule_id(
+        self,
+        service: CreateRecordService,
+        repo: InMemoryRecordRepository,
+    ) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        conducted_at = datetime(2026, 3, 20, 10, 0)
+
+        record_id = await service.execute(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            conducted_at=conducted_at,
+        )
+
+        record = await repo.get_by_id(record_id)
+        assert record is not None
+        assert record.schedule_id is None
+        assert record.status == RecordStatus.DRAFT
+
+    async def test_preserves_organizer_and_counterpart(
+        self,
+        service: CreateRecordService,
+        repo: InMemoryRecordRepository,
+    ) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        record_id = await service.execute(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            conducted_at=datetime(2026, 3, 20, 10, 0),
+        )
+
+        record = await repo.get_by_id(record_id)
+        assert record is not None
+        assert record.organizer_id == organizer
+        assert record.counterpart_id == counterpart
+
+    async def test_dispatches_event_with_null_schedule_id(
+        self,
+        service: CreateRecordService,
+    ) -> None:
+        dispatched_events: list[object] = []
+
+        async def capture_handler(event: object) -> None:
+            dispatched_events.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(RecordCreated, capture_handler)  # type: ignore[arg-type]
+        service_with_handler = CreateRecordService(
+            uow=service._uow,
+            record_repo=service._record_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        await service_with_handler.execute(
+            organizer_id=UserId.generate(),
+            counterpart_id=UserId.generate(),
+            conducted_at=datetime(2026, 3, 20, 10, 0),
+        )
+
+        assert len(dispatched_events) == 1
+        event = dispatched_events[0]
+        assert isinstance(event, RecordCreated)
+        assert event.schedule_id is None


### PR DESCRIPTION
## 変更内容

- `CreateRecordService` をアプリケーション層に追加（`backend/contexts/record/application/create_record_service.py`）
  - Schedule ベースの1on1開始（`schedule_id` 指定）
  - 事後記録型の直接作成（`schedule_id = null`、パターンC）
  - UoW による commit 後にドメインイベント（`RecordCreated`）をディスパッチ
- `EventDispatcher.dispatch()` の引数型を `list[DomainEvent]` から `Sequence[DomainEvent]` に変更（共変性対応）
- ユニットテスト 8 件を追加（DB 非依存、テストダブル使用）

## 受け入れ条件の対応状況

- [x] Record が DRAFT 状態で作成される
- [x] Record 作成はオーガナイザーのみ可能（権限チェック）--- ドメイン層の `Record.create()` で保証済み
- [x] Schedule ありの場合は `schedule_id` で紐付け
- [x] 事後記録型は `schedule_id = null`
- [x] `conducted_at` が Record 自身に保持される
- [x] commit 後にドメインイベントがディスパッチされる
- [x] ユニットテスト

> 注: 権限チェック（オーガナイザーのみ作成可能）はドメイン層の設計で構造的に保証されています。`Record.create()` は `organizer_id` を引数に取り、プレゼンテーション層で認証済みユーザーを `organizer_id` として渡す設計です。統合テストは API 層（プレゼンテーション層）実装時に追加予定です。

Closes #81
