### PR TITLE
Record: 実施中の操作ユースケース（メモ・AI登録・アジェンダ確認・下書き保存）

### DIFF
--- a/backend/contexts/record/application/add_action_item.py
+++ b/backend/contexts/record/application/add_action_item.py
@@ -1,0 +1,94 @@
+"""Use case: Add an ActionItem to a Record.
+
+The organizer registers an action item during a 1-on-1 session.
+Action items are tied to the counterpart (person), not to the record.
+After a successful commit the ActionItemAdded domain event is dispatched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle, RecordId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class RecordNotFoundError(Exception):
+    """Raised when the specified record does not exist."""
+
+    def __init__(self, record_id: RecordId) -> None:
+        self.record_id = record_id
+        super().__init__(f"Record not found: {record_id.value}")
+
+
+@dataclass(frozen=True)
+class AddActionItemInput:
+    """Input DTO for AddActionItemUseCase."""
+
+    record_id: RecordId
+    actor_id: UserId
+    title: ActionItemTitle
+
+
+@dataclass(frozen=True)
+class AddActionItemOutput:
+    """Output DTO for AddActionItemUseCase."""
+
+    action_item_id: ActionItemId
+
+
+class AddActionItemUseCase:
+    """Add an action item to a record.
+
+    Workflow:
+    1. Load the record and verify it exists.
+    2. Create the action item (organizer check delegated to ActionItem.create).
+    3. Save within a transaction.
+    4. Dispatch domain events after commit.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        action_item_repository: ActionItemRepository,
+        unit_of_work: UnitOfWork,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._record_repository = record_repository
+        self._action_item_repository = action_item_repository
+        self._unit_of_work = unit_of_work
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(self, input_dto: AddActionItemInput) -> AddActionItemOutput:
+        now = datetime.now(UTC)
+
+        async with self._unit_of_work:
+            record = await self._record_repository.get_by_id(input_dto.record_id)
+            if record is None:
+                raise RecordNotFoundError(input_dto.record_id)
+
+            action_item = ActionItem.create(
+                counterpart_id=record.counterpart_id,
+                record_id=record.id,
+                title=input_dto.title,
+                actor_id=input_dto.actor_id,
+                organizer_id=record.organizer_id,
+                now=now,
+            )
+
+            await self._action_item_repository.save(action_item)
+            await self._unit_of_work.commit()
+
+        # Dispatch events after successful commit
+        events: list[DomainEvent] = list(action_item.collect_events())
+        await self._event_dispatcher.dispatch(events)
+
+        return AddActionItemOutput(action_item_id=action_item.id)

--- a/backend/contexts/record/application/confirm_agenda.py
+++ b/backend/contexts/record/application/confirm_agenda.py
@@ -1,0 +1,91 @@
+"""Use case: Confirm (check) an agenda item during a 1-on-1.
+
+Both the organizer and the counterpart can confirm an agenda item.
+After a successful commit the AgendaConfirmed domain event is dispatched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.value_objects import AgendaId
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import RecordId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class RecordNotFoundError(Exception):
+    """Raised when the specified record does not exist."""
+
+    def __init__(self, record_id: RecordId) -> None:
+        self.record_id = record_id
+        super().__init__(f"Record not found: {record_id.value}")
+
+
+@dataclass(frozen=True)
+class ConfirmAgendaInput:
+    """Input DTO for ConfirmAgendaUseCase."""
+
+    record_id: RecordId
+    agenda_id: AgendaId
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class ConfirmAgendaOutput:
+    """Output DTO for ConfirmAgendaUseCase."""
+
+    record_id: RecordId
+    agenda_id: AgendaId
+
+
+class ConfirmAgendaUseCase:
+    """Confirm (check) an agenda item during a 1-on-1.
+
+    Workflow:
+    1. Load the record and verify it exists.
+    2. Delegate to the domain method (participant check + draft check).
+    3. Save within a transaction.
+    4. Dispatch domain events after commit.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        unit_of_work: UnitOfWork,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._record_repository = record_repository
+        self._unit_of_work = unit_of_work
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(self, input_dto: ConfirmAgendaInput) -> ConfirmAgendaOutput:
+        now = datetime.now(UTC)
+
+        async with self._unit_of_work:
+            record = await self._record_repository.get_by_id(input_dto.record_id)
+            if record is None:
+                raise RecordNotFoundError(input_dto.record_id)
+
+            record.confirm_agenda(
+                agenda_id=input_dto.agenda_id,
+                actor_id=input_dto.actor_id,
+                now=now,
+            )
+
+            await self._record_repository.save(record)
+            await self._unit_of_work.commit()
+
+        # Dispatch events after successful commit
+        events: list[DomainEvent] = list(record.collect_events())
+        await self._event_dispatcher.dispatch(events)
+
+        return ConfirmAgendaOutput(
+            record_id=record.id,
+            agenda_id=input_dto.agenda_id,
+        )

--- a/backend/contexts/record/application/save_draft.py
+++ b/backend/contexts/record/application/save_draft.py
@@ -1,0 +1,88 @@
+"""Use case: Save a Record as draft.
+
+The organizer saves the record in DRAFT status. No Slack notification
+is sent for draft saves. After a successful commit the RecordDraftSaved
+domain event is dispatched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import RecordId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class RecordNotFoundError(Exception):
+    """Raised when the specified record does not exist."""
+
+    def __init__(self, record_id: RecordId) -> None:
+        self.record_id = record_id
+        super().__init__(f"Record not found: {record_id.value}")
+
+
+@dataclass(frozen=True)
+class SaveDraftInput:
+    """Input DTO for SaveDraftUseCase."""
+
+    record_id: RecordId
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class SaveDraftOutput:
+    """Output DTO for SaveDraftUseCase."""
+
+    record_id: RecordId
+
+
+class SaveDraftUseCase:
+    """Save a record as draft.
+
+    Workflow:
+    1. Load the record and verify it exists.
+    2. Delegate to the domain method (organizer check + draft check).
+    3. Save within a transaction.
+    4. Dispatch domain events after commit.
+
+    Note: RecordDraftSaved is dispatched, but this event does NOT trigger
+    Slack notifications (by design).
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        unit_of_work: UnitOfWork,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._record_repository = record_repository
+        self._unit_of_work = unit_of_work
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(self, input_dto: SaveDraftInput) -> SaveDraftOutput:
+        now = datetime.now(UTC)
+
+        async with self._unit_of_work:
+            record = await self._record_repository.get_by_id(input_dto.record_id)
+            if record is None:
+                raise RecordNotFoundError(input_dto.record_id)
+
+            record.save_draft(
+                actor_id=input_dto.actor_id,
+                now=now,
+            )
+
+            await self._record_repository.save(record)
+            await self._unit_of_work.commit()
+
+        # Dispatch events after successful commit
+        events: list[DomainEvent] = list(record.collect_events())
+        await self._event_dispatcher.dispatch(events)
+
+        return SaveDraftOutput(record_id=record.id)

--- a/backend/contexts/record/application/update_memo.py
+++ b/backend/contexts/record/application/update_memo.py
@@ -1,0 +1,87 @@
+"""Use case: Update the memo of a Record.
+
+The organizer writes or updates the memo content of a DRAFT record.
+After a successful commit the MemoUpdated domain event is dispatched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.record.domain.memo import Memo
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import RecordId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class RecordNotFoundError(Exception):
+    """Raised when the specified record does not exist."""
+
+    def __init__(self, record_id: RecordId) -> None:
+        self.record_id = record_id
+        super().__init__(f"Record not found: {record_id.value}")
+
+
+@dataclass(frozen=True)
+class UpdateMemoInput:
+    """Input DTO for UpdateMemoUseCase."""
+
+    record_id: RecordId
+    actor_id: UserId
+    memo: Memo
+
+
+@dataclass(frozen=True)
+class UpdateMemoOutput:
+    """Output DTO for UpdateMemoUseCase."""
+
+    record_id: RecordId
+
+
+class UpdateMemoUseCase:
+    """Update the memo content of a record.
+
+    Workflow:
+    1. Load the record and verify it exists.
+    2. Delegate to the domain method (organizer check + draft check).
+    3. Save within a transaction.
+    4. Dispatch domain events after commit.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        unit_of_work: UnitOfWork,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._record_repository = record_repository
+        self._unit_of_work = unit_of_work
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(self, input_dto: UpdateMemoInput) -> UpdateMemoOutput:
+        now = datetime.now(UTC)
+
+        async with self._unit_of_work:
+            record = await self._record_repository.get_by_id(input_dto.record_id)
+            if record is None:
+                raise RecordNotFoundError(input_dto.record_id)
+
+            record.update_memo(
+                memo=input_dto.memo,
+                actor_id=input_dto.actor_id,
+                now=now,
+            )
+
+            await self._record_repository.save(record)
+            await self._unit_of_work.commit()
+
+        # Dispatch events after successful commit
+        events: list[DomainEvent] = list(record.collect_events())
+        await self._event_dispatcher.dispatch(events)
+
+        return UpdateMemoOutput(record_id=record.id)

--- a/backend/contexts/record/domain/events.py
+++ b/backend/contexts/record/domain/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
 from contexts.record.domain.value_objects import ActionItemId, CommentId, RecordId
 from shared.domain.events import DomainEvent
 from shared.domain.value_objects import UserId
@@ -26,6 +26,15 @@ class MemoUpdated(DomainEvent):
 
     record_id: RecordId
     organizer_id: UserId
+
+
+@dataclass(frozen=True)
+class AgendaConfirmed(DomainEvent):
+    """Raised when an agenda item is confirmed (checked) during a 1-on-1."""
+
+    record_id: RecordId
+    agenda_id: AgendaId
+    confirmed_by: UserId
 
 
 @dataclass(frozen=True)

--- a/backend/contexts/record/domain/exceptions.py
+++ b/backend/contexts/record/domain/exceptions.py
@@ -43,6 +43,13 @@ class CommentAlreadyExistsError(Exception):
         super().__init__(message)
 
 
+class AgendaAlreadyConfirmedError(Exception):
+    """Raised when attempting to confirm an already-confirmed agenda item."""
+
+    def __init__(self, message: str = "Agenda is already confirmed.") -> None:
+        super().__init__(message)
+
+
 class InvalidMemoError(Exception):
     """Raised when a memo fails validation."""
 

--- a/backend/contexts/record/domain/record.py
+++ b/backend/contexts/record/domain/record.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
-from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
 from contexts.record.domain.events import (
+    AgendaConfirmed,
     MemoUpdated,
     RecordCreated,
     RecordDraftSaved,
@@ -12,6 +13,7 @@ from contexts.record.domain.events import (
     ViewersChanged,
 )
 from contexts.record.domain.exceptions import (
+    AgendaAlreadyConfirmedError,
     RecordAlreadyPublishedError,
     UnauthorizedOperationError,
 )
@@ -20,7 +22,12 @@ from contexts.record.domain.value_objects import RecordId, RecordStatus
 from shared.domain.value_objects import UserId
 
 type _RecordEvent = (
-    RecordCreated | MemoUpdated | RecordDraftSaved | RecordPublished | ViewersChanged
+    RecordCreated
+    | MemoUpdated
+    | AgendaConfirmed
+    | RecordDraftSaved
+    | RecordPublished
+    | ViewersChanged
 )
 
 
@@ -42,6 +49,7 @@ class Record:
     _memo: Memo
     _status: RecordStatus
     _viewers: list[UserId]
+    _confirmed_agenda_ids: set[AgendaId]
     conducted_at: datetime
     created_at: datetime
     _updated_at: datetime
@@ -58,6 +66,10 @@ class Record:
     @property
     def viewers(self) -> list[UserId]:
         return list(self._viewers)
+
+    @property
+    def confirmed_agenda_ids(self) -> set[AgendaId]:
+        return set(self._confirmed_agenda_ids)
 
     @property
     def updated_at(self) -> datetime:
@@ -83,6 +95,7 @@ class Record:
             _memo=Memo(""),
             _status=RecordStatus.DRAFT,
             _viewers=[],
+            _confirmed_agenda_ids=set(),
             conducted_at=conducted_at,
             created_at=ts,
             _updated_at=ts,
@@ -110,6 +123,27 @@ class Record:
                 occurred_at=now,
                 record_id=self.id,
                 organizer_id=self.organizer_id,
+            )
+        )
+
+    def confirm_agenda(
+        self, *, agenda_id: AgendaId, actor_id: UserId, now: datetime
+    ) -> None:
+        """Confirm (check) an agenda item. Organizer or counterpart may confirm."""
+        self._assert_participant(actor_id)
+        self._assert_draft()
+        if agenda_id in self._confirmed_agenda_ids:
+            raise AgendaAlreadyConfirmedError(
+                f"Agenda {agenda_id.value} is already confirmed."
+            )
+        self._confirmed_agenda_ids.add(agenda_id)
+        self._updated_at = now
+        self._events.append(
+            AgendaConfirmed(
+                occurred_at=now,
+                record_id=self.id,
+                agenda_id=agenda_id,
+                confirmed_by=actor_id,
             )
         )
 
@@ -193,6 +227,12 @@ class Record:
     def _assert_organizer(self, actor_id: UserId) -> None:
         if actor_id != self.organizer_id:
             raise UnauthorizedOperationError("Only the organizer can edit the record.")
+
+    def _assert_participant(self, actor_id: UserId) -> None:
+        if actor_id != self.organizer_id and actor_id != self.counterpart_id:
+            raise UnauthorizedOperationError(
+                "Only the organizer or counterpart can perform this operation."
+            )
 
     def _assert_draft(self) -> None:
         if self._status != RecordStatus.DRAFT:

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -5,12 +5,16 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
 from contexts.record.domain.memo import Memo
 from contexts.record.domain.record import Record
 from contexts.record.domain.record_repository import RecordRepository
 from contexts.record.domain.value_objects import RecordId, RecordStatus
-from contexts.record.infrastructure.tables import RecordTable, RecordViewerTable
+from contexts.record.infrastructure.tables import (
+    RecordConfirmedAgendaTable,
+    RecordTable,
+    RecordViewerTable,
+)
 from shared.domain.value_objects import UserId
 
 
@@ -60,6 +64,15 @@ class SqlAlchemyRecordRepository(RecordRepository):
                 updated_at=entity.updated_at,
             )
             record_row.viewers.append(viewer_row)
+        for agenda_id in entity.confirmed_agenda_ids:
+            agenda_row = RecordConfirmedAgendaTable(
+                id=str(uuid.uuid4()),
+                record_id=str(entity.id.value),
+                agenda_id=str(agenda_id.value),
+                created_at=entity.created_at,
+                updated_at=entity.updated_at,
+            )
+            record_row.confirmed_agendas.append(agenda_row)
         self._session.add(record_row)
         await self._session.flush()
 
@@ -87,11 +100,28 @@ class SqlAlchemyRecordRepository(RecordRepository):
             )
             existing.viewers.append(new_viewer)
 
+        # Replace confirmed agendas: delete all, then re-insert
+        existing.confirmed_agendas.clear()
+        await self._session.flush()
+
+        for agenda_id in entity.confirmed_agenda_ids:
+            new_agenda = RecordConfirmedAgendaTable(
+                id=str(uuid.uuid4()),
+                record_id=str(entity.id.value),
+                agenda_id=str(agenda_id.value),
+                created_at=entity.updated_at,
+                updated_at=entity.updated_at,
+            )
+            existing.confirmed_agendas.append(new_agenda)
+
         await self._session.flush()
 
     @staticmethod
     def _to_entity(row: RecordTable) -> Record:
         viewers = [UserId.from_str(v.user_id) for v in row.viewers]
+        confirmed_agenda_ids = {
+            AgendaId.from_str(a.agenda_id) for a in row.confirmed_agendas
+        }
         return Record(
             id=RecordId.from_str(row.id),
             organizer_id=UserId.from_str(row.organizer_id),
@@ -102,6 +132,7 @@ class SqlAlchemyRecordRepository(RecordRepository):
             _memo=Memo(row.memo),
             _status=RecordStatus(row.status),
             _viewers=viewers,
+            _confirmed_agenda_ids=confirmed_agenda_ids,
             conducted_at=row.conducted_at,
             created_at=row.created_at,
             _updated_at=row.updated_at,

--- a/backend/contexts/record/infrastructure/tables.py
+++ b/backend/contexts/record/infrastructure/tables.py
@@ -33,6 +33,11 @@ class RecordTable(Base, TimestampMixin):
         lazy="selectin",
         cascade="all, delete-orphan",
     )
+    confirmed_agendas: Mapped[list["RecordConfirmedAgendaTable"]] = relationship(
+        back_populates="record",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
 
 
 class RecordViewerTable(Base, TimestampMixin):
@@ -60,6 +65,33 @@ class RecordViewerTable(Base, TimestampMixin):
     )
 
     record: Mapped["RecordTable"] = relationship(back_populates="viewers")
+
+
+class RecordConfirmedAgendaTable(Base, TimestampMixin):
+    """ORM model for the record_confirmed_agendas table."""
+
+    __tablename__ = "record_confirmed_agendas"
+    __table_args__ = (
+        UniqueConstraint(
+            "record_id",
+            "agenda_id",
+            name="uq_record_confirmed_agendas_record_id_agenda_id",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    record_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "records.id",
+            ondelete="CASCADE",
+            name="fk_record_confirmed_agendas_record_id",
+        ),
+        nullable=False,
+    )
+    agenda_id: Mapped[str] = mapped_column(CHAR(36), nullable=False)
+
+    record: Mapped["RecordTable"] = relationship(back_populates="confirmed_agendas")
 
 
 class CommentTable(Base, TimestampMixin):

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -16,6 +16,7 @@ from contexts.preparation.infrastructure.tables import (
 from contexts.record.infrastructure.tables import (
     ActionItemTable,  # noqa: F401
     CommentTable,  # noqa: F401
+    RecordConfirmedAgendaTable,  # noqa: F401
     RecordTable,  # noqa: F401
     RecordViewerTable,  # noqa: F401
 )
@@ -30,6 +31,7 @@ __all__ = [
     "CommentTable",
     "ConfirmationRequestTable",
     "MembershipTable",
+    "RecordConfirmedAgendaTable",
     "RecordTable",
     "RecordViewerTable",
     "ScheduleGroupAgendaTemplateTable",

--- a/backend/migrations/versions/0005_create_record_confirmed_agendas.py
+++ b/backend/migrations/versions/0005_create_record_confirmed_agendas.py
@@ -1,0 +1,53 @@
+"""create record_confirmed_agendas table
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-03-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "record_confirmed_agendas",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("record_id", sa.CHAR(36), nullable=False),
+        sa.Column("agenda_id", sa.CHAR(36), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["record_id"],
+            ["records.id"],
+            name="fk_record_confirmed_agendas_record_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "record_id",
+            "agenda_id",
+            name="uq_record_confirmed_agendas_record_id_agenda_id",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("record_confirmed_agendas")

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -7,9 +7,11 @@ from types import TracebackType
 from contexts.preparation.domain.schedule import Schedule
 from contexts.preparation.domain.schedule_repository import ScheduleRepository
 from contexts.preparation.domain.value_objects import ScheduleGroupId, ScheduleId
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.action_item_repository import ActionItemRepository
 from contexts.record.domain.record import Record
 from contexts.record.domain.record_repository import RecordRepository
-from contexts.record.domain.value_objects import RecordId
+from contexts.record.domain.value_objects import ActionItemId, RecordId
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
 from shared.domain.events import DomainEvent
@@ -32,6 +34,23 @@ class InMemoryRecordRepository(RecordRepository):
         return list(self._records.values())
 
 
+class InMemoryActionItemRepository(ActionItemRepository):
+    """In-memory stub for ActionItemRepository."""
+
+    def __init__(self) -> None:
+        self._items: dict[ActionItemId, ActionItem] = {}
+
+    async def get_by_id(self, entity_id: ActionItemId) -> ActionItem | None:
+        return self._items.get(entity_id)
+
+    async def save(self, entity: ActionItem) -> None:
+        self._items[entity.id] = entity
+
+    @property
+    def saved_items(self) -> list[ActionItem]:
+        return list(self._items.values())
+
+
 class InMemoryScheduleRepository(ScheduleRepository):
     """In-memory stub for ScheduleRepository."""
 
@@ -48,7 +67,8 @@ class InMemoryScheduleRepository(ScheduleRepository):
         self, schedule_group_id: ScheduleGroupId
     ) -> list[Schedule]:
         return [
-            s for s in self._schedules.values()
+            s
+            for s in self._schedules.values()
             if getattr(s, "schedule_group_id", None) == schedule_group_id
         ]
 

--- a/backend/tests/contexts/record/application/test_add_action_item.py
+++ b/backend/tests/contexts/record/application/test_add_action_item.py
@@ -1,0 +1,213 @@
+"""Tests for AddActionItemUseCase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from contexts.record.application.add_action_item import (
+    AddActionItemInput,
+    AddActionItemOutput,
+    AddActionItemUseCase,
+    RecordNotFoundError,
+)
+from contexts.record.domain.events import ActionItemAdded
+from contexts.record.domain.exceptions import UnauthorizedOperationError
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import ActionItemTitle, RecordId
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    FakeUnitOfWork,
+    InMemoryActionItemRepository,
+    InMemoryRecordRepository,
+    SpyEventDispatcher,
+)
+
+
+def _make_draft_record(
+    organizer: UserId | None = None,
+    counterpart: UserId | None = None,
+) -> Record:
+    return Record.create(
+        organizer_id=organizer or UserId.generate(),
+        counterpart_id=counterpart or UserId.generate(),
+        conducted_at=datetime(2026, 3, 25, 10, 0),
+    )
+
+
+def _build_use_case(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+    action_item_repo: InMemoryActionItemRepository | None = None,
+    uow: FakeUnitOfWork | None = None,
+    event_dispatcher: SpyEventDispatcher | None = None,
+) -> tuple[
+    AddActionItemUseCase,
+    InMemoryRecordRepository,
+    InMemoryActionItemRepository,
+    FakeUnitOfWork,
+    SpyEventDispatcher,
+]:
+    rr = record_repo or InMemoryRecordRepository()
+    air = action_item_repo or InMemoryActionItemRepository()
+    u = uow or FakeUnitOfWork()
+    ed = event_dispatcher or SpyEventDispatcher()
+    uc = AddActionItemUseCase(
+        record_repository=rr,
+        action_item_repository=air,
+        unit_of_work=u,
+        event_dispatcher=ed,
+    )
+    return uc, rr, air, u, ed
+
+
+class TestAddActionItem:
+    """Tests for successful action item addition."""
+
+    async def test_creates_action_item_linked_to_counterpart(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        uc, rr, air, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        output = await uc.execute(
+            AddActionItemInput(
+                record_id=record.id,
+                actor_id=organizer,
+                title=ActionItemTitle("Follow up on project status"),
+            )
+        )
+
+        assert isinstance(output, AddActionItemOutput)
+        saved_items = air.saved_items
+        assert len(saved_items) == 1
+        item = saved_items[0]
+        assert item.id == output.action_item_id
+        assert item.counterpart_id == counterpart
+        assert item.record_id == record.id
+        assert item.title.value == "Follow up on project status"
+        assert item.is_completed is False
+
+    async def test_commits_transaction(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _air, uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            AddActionItemInput(
+                record_id=record.id,
+                actor_id=organizer,
+                title=ActionItemTitle("Task"),
+            )
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_action_item_added_event(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        uc, rr, _air, _uow, ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        output = await uc.execute(
+            AddActionItemInput(
+                record_id=record.id,
+                actor_id=organizer,
+                title=ActionItemTitle("Review document"),
+            )
+        )
+
+        added_events = [
+            e for e in ed.dispatched_events if isinstance(e, ActionItemAdded)
+        ]
+        assert len(added_events) == 1
+        event = added_events[0]
+        assert event.action_item_id == output.action_item_id
+        assert event.counterpart_id == counterpart
+        assert event.record_id == record.id
+        assert event.title == "Review document"
+
+
+class TestAddActionItemErrors:
+    """Tests for error conditions."""
+
+    async def test_raises_when_record_not_found(self) -> None:
+        uc, _rr, _air, _uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                AddActionItemInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                    title=ActionItemTitle("Task"),
+                )
+            )
+
+    async def test_raises_when_actor_is_not_organizer(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        uc, rr, _air, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(UnauthorizedOperationError, match="Only the organizer"):
+            await uc.execute(
+                AddActionItemInput(
+                    record_id=record.id,
+                    actor_id=counterpart,
+                    title=ActionItemTitle("Unauthorized task"),
+                )
+            )
+
+    async def test_raises_when_viewer_tries_to_add(self) -> None:
+        organizer = UserId.generate()
+        viewer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _air, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(UnauthorizedOperationError):
+            await uc.execute(
+                AddActionItemInput(
+                    record_id=record.id,
+                    actor_id=viewer,
+                    title=ActionItemTitle("Unauthorized task"),
+                )
+            )
+
+    async def test_does_not_commit_on_error(self) -> None:
+        uc, _rr, _air, uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                AddActionItemInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                    title=ActionItemTitle("Task"),
+                )
+            )
+
+        assert uow.committed is False
+
+    async def test_does_not_dispatch_events_on_error(self) -> None:
+        uc, _rr, _air, _uow, ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                AddActionItemInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                    title=ActionItemTitle("Task"),
+                )
+            )
+
+        assert ed.dispatched_events == []

--- a/backend/tests/contexts/record/application/test_confirm_agenda.py
+++ b/backend/tests/contexts/record/application/test_confirm_agenda.py
@@ -1,0 +1,285 @@
+"""Tests for ConfirmAgendaUseCase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from contexts.preparation.domain.value_objects import AgendaId
+from contexts.record.application.confirm_agenda import (
+    ConfirmAgendaInput,
+    ConfirmAgendaOutput,
+    ConfirmAgendaUseCase,
+    RecordNotFoundError,
+)
+from contexts.record.domain.events import AgendaConfirmed
+from contexts.record.domain.exceptions import (
+    AgendaAlreadyConfirmedError,
+    RecordAlreadyPublishedError,
+    UnauthorizedOperationError,
+)
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import RecordId
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    FakeUnitOfWork,
+    InMemoryRecordRepository,
+    SpyEventDispatcher,
+)
+
+
+def _make_draft_record(
+    organizer: UserId | None = None,
+    counterpart: UserId | None = None,
+) -> Record:
+    return Record.create(
+        organizer_id=organizer or UserId.generate(),
+        counterpart_id=counterpart or UserId.generate(),
+        conducted_at=datetime(2026, 3, 25, 10, 0),
+    )
+
+
+def _build_use_case(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+    uow: FakeUnitOfWork | None = None,
+    event_dispatcher: SpyEventDispatcher | None = None,
+) -> tuple[
+    ConfirmAgendaUseCase,
+    InMemoryRecordRepository,
+    FakeUnitOfWork,
+    SpyEventDispatcher,
+]:
+    rr = record_repo or InMemoryRecordRepository()
+    u = uow or FakeUnitOfWork()
+    ed = event_dispatcher or SpyEventDispatcher()
+    uc = ConfirmAgendaUseCase(
+        record_repository=rr,
+        unit_of_work=u,
+        event_dispatcher=ed,
+    )
+    return uc, rr, u, ed
+
+
+class TestConfirmAgenda:
+    """Tests for successful agenda confirmation."""
+
+    async def test_organizer_can_confirm_agenda(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        agenda_id = AgendaId.generate()
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        output = await uc.execute(
+            ConfirmAgendaInput(
+                record_id=record.id,
+                agenda_id=agenda_id,
+                actor_id=organizer,
+            )
+        )
+
+        assert isinstance(output, ConfirmAgendaOutput)
+        assert output.record_id == record.id
+        assert output.agenda_id == agenda_id
+        saved = await rr.get_by_id(record.id)
+        assert saved is not None
+        assert agenda_id in saved.confirmed_agenda_ids
+
+    async def test_counterpart_can_confirm_agenda(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        agenda_id = AgendaId.generate()
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        output = await uc.execute(
+            ConfirmAgendaInput(
+                record_id=record.id,
+                agenda_id=agenda_id,
+                actor_id=counterpart,
+            )
+        )
+
+        assert isinstance(output, ConfirmAgendaOutput)
+        saved = await rr.get_by_id(record.id)
+        assert saved is not None
+        assert agenda_id in saved.confirmed_agenda_ids
+
+    async def test_multiple_agendas_can_be_confirmed(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        agenda1 = AgendaId.generate()
+        agenda2 = AgendaId.generate()
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            ConfirmAgendaInput(
+                record_id=record.id, agenda_id=agenda1, actor_id=organizer
+            )
+        )
+        await uc.execute(
+            ConfirmAgendaInput(
+                record_id=record.id, agenda_id=agenda2, actor_id=organizer
+            )
+        )
+
+        saved = await rr.get_by_id(record.id)
+        assert saved is not None
+        assert agenda1 in saved.confirmed_agenda_ids
+        assert agenda2 in saved.confirmed_agenda_ids
+
+    async def test_commits_transaction(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            ConfirmAgendaInput(
+                record_id=record.id,
+                agenda_id=AgendaId.generate(),
+                actor_id=organizer,
+            )
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_agenda_confirmed_event(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        agenda_id = AgendaId.generate()
+        uc, rr, _uow, ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            ConfirmAgendaInput(
+                record_id=record.id,
+                agenda_id=agenda_id,
+                actor_id=organizer,
+            )
+        )
+
+        confirmed_events = [
+            e for e in ed.dispatched_events if isinstance(e, AgendaConfirmed)
+        ]
+        assert len(confirmed_events) == 1
+        event = confirmed_events[0]
+        assert event.record_id == record.id
+        assert event.agenda_id == agenda_id
+        assert event.confirmed_by == organizer
+
+
+class TestConfirmAgendaErrors:
+    """Tests for error conditions."""
+
+    async def test_raises_when_record_not_found(self) -> None:
+        uc, _rr, _uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                ConfirmAgendaInput(
+                    record_id=RecordId.generate(),
+                    agenda_id=AgendaId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_raises_when_viewer_tries_to_confirm(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        viewer = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(
+            UnauthorizedOperationError, match="organizer or counterpart"
+        ):
+            await uc.execute(
+                ConfirmAgendaInput(
+                    record_id=record.id,
+                    agenda_id=AgendaId.generate(),
+                    actor_id=viewer,
+                )
+            )
+
+    async def test_raises_when_agenda_already_confirmed(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        agenda_id = AgendaId.generate()
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            ConfirmAgendaInput(
+                record_id=record.id,
+                agenda_id=agenda_id,
+                actor_id=organizer,
+            )
+        )
+
+        with pytest.raises(AgendaAlreadyConfirmedError):
+            await uc.execute(
+                ConfirmAgendaInput(
+                    record_id=record.id,
+                    agenda_id=agenda_id,
+                    actor_id=organizer,
+                )
+            )
+
+    async def test_raises_when_record_is_published(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 25, 12, 0))
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(RecordAlreadyPublishedError):
+            await uc.execute(
+                ConfirmAgendaInput(
+                    record_id=record.id,
+                    agenda_id=AgendaId.generate(),
+                    actor_id=organizer,
+                )
+            )
+
+    async def test_does_not_commit_on_error(self) -> None:
+        uc, _rr, uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                ConfirmAgendaInput(
+                    record_id=RecordId.generate(),
+                    agenda_id=AgendaId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+        assert uow.committed is False
+
+    async def test_does_not_dispatch_events_on_error(self) -> None:
+        uc, _rr, _uow, ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                ConfirmAgendaInput(
+                    record_id=RecordId.generate(),
+                    agenda_id=AgendaId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+        assert ed.dispatched_events == []

--- a/backend/tests/contexts/record/application/test_save_draft.py
+++ b/backend/tests/contexts/record/application/test_save_draft.py
@@ -1,0 +1,220 @@
+"""Tests for SaveDraftUseCase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from contexts.record.application.save_draft import (
+    RecordNotFoundError,
+    SaveDraftInput,
+    SaveDraftOutput,
+    SaveDraftUseCase,
+)
+from contexts.record.domain.events import RecordDraftSaved, RecordPublished
+from contexts.record.domain.exceptions import (
+    RecordAlreadyPublishedError,
+    UnauthorizedOperationError,
+)
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import RecordId, RecordStatus
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    FakeUnitOfWork,
+    InMemoryRecordRepository,
+    SpyEventDispatcher,
+)
+
+
+def _make_draft_record(
+    organizer: UserId | None = None,
+    counterpart: UserId | None = None,
+) -> Record:
+    return Record.create(
+        organizer_id=organizer or UserId.generate(),
+        counterpart_id=counterpart or UserId.generate(),
+        conducted_at=datetime(2026, 3, 25, 10, 0),
+    )
+
+
+def _build_use_case(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+    uow: FakeUnitOfWork | None = None,
+    event_dispatcher: SpyEventDispatcher | None = None,
+) -> tuple[
+    SaveDraftUseCase,
+    InMemoryRecordRepository,
+    FakeUnitOfWork,
+    SpyEventDispatcher,
+]:
+    rr = record_repo or InMemoryRecordRepository()
+    u = uow or FakeUnitOfWork()
+    ed = event_dispatcher or SpyEventDispatcher()
+    uc = SaveDraftUseCase(
+        record_repository=rr,
+        unit_of_work=u,
+        event_dispatcher=ed,
+    )
+    return uc, rr, u, ed
+
+
+class TestSaveDraft:
+    """Tests for successful draft save."""
+
+    async def test_saves_record_as_draft(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        output = await uc.execute(
+            SaveDraftInput(
+                record_id=record.id,
+                actor_id=organizer,
+            )
+        )
+
+        assert isinstance(output, SaveDraftOutput)
+        assert output.record_id == record.id
+        saved = await rr.get_by_id(record.id)
+        assert saved is not None
+        assert saved.status == RecordStatus.DRAFT
+
+    async def test_commits_transaction(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            SaveDraftInput(
+                record_id=record.id,
+                actor_id=organizer,
+            )
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_draft_saved_event_not_published(self) -> None:
+        """Draft save should dispatch RecordDraftSaved, not RecordPublished."""
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _uow, ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            SaveDraftInput(
+                record_id=record.id,
+                actor_id=organizer,
+            )
+        )
+
+        draft_events = [
+            e for e in ed.dispatched_events if isinstance(e, RecordDraftSaved)
+        ]
+        publish_events = [
+            e for e in ed.dispatched_events if isinstance(e, RecordPublished)
+        ]
+        assert len(draft_events) == 1
+        assert draft_events[0].record_id == record.id
+        assert draft_events[0].organizer_id == organizer
+        assert len(publish_events) == 0
+
+    async def test_draft_is_only_visible_to_organizer(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            SaveDraftInput(
+                record_id=record.id,
+                actor_id=organizer,
+            )
+        )
+
+        saved = await rr.get_by_id(record.id)
+        assert saved is not None
+        assert saved.is_visible_to(organizer) is True
+        assert saved.is_visible_to(counterpart) is False
+        assert saved.is_visible_to(UserId.generate()) is False
+
+
+class TestSaveDraftErrors:
+    """Tests for error conditions."""
+
+    async def test_raises_when_record_not_found(self) -> None:
+        uc, _rr, _uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                SaveDraftInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_raises_when_actor_is_not_organizer(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_draft_record(organizer=organizer, counterpart=counterpart)
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(UnauthorizedOperationError, match="Only the organizer"):
+            await uc.execute(
+                SaveDraftInput(
+                    record_id=record.id,
+                    actor_id=counterpart,
+                )
+            )
+
+    async def test_raises_when_record_is_published(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 25, 12, 0))
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(RecordAlreadyPublishedError):
+            await uc.execute(
+                SaveDraftInput(
+                    record_id=record.id,
+                    actor_id=organizer,
+                )
+            )
+
+    async def test_does_not_commit_on_error(self) -> None:
+        uc, _rr, uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                SaveDraftInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+        assert uow.committed is False
+
+    async def test_does_not_dispatch_events_on_error(self) -> None:
+        uc, _rr, _uow, ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                SaveDraftInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+        assert ed.dispatched_events == []

--- a/backend/tests/contexts/record/application/test_update_memo.py
+++ b/backend/tests/contexts/record/application/test_update_memo.py
@@ -1,0 +1,220 @@
+"""Tests for UpdateMemoUseCase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from contexts.record.application.update_memo import (
+    RecordNotFoundError,
+    UpdateMemoInput,
+    UpdateMemoOutput,
+    UpdateMemoUseCase,
+)
+from contexts.record.domain.events import MemoUpdated
+from contexts.record.domain.exceptions import (
+    RecordAlreadyPublishedError,
+    UnauthorizedOperationError,
+)
+from contexts.record.domain.memo import Memo
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import RecordId, RecordStatus
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    FakeUnitOfWork,
+    InMemoryRecordRepository,
+    SpyEventDispatcher,
+)
+
+
+def _make_draft_record(
+    organizer: UserId | None = None,
+    counterpart: UserId | None = None,
+) -> Record:
+    return Record.create(
+        organizer_id=organizer or UserId.generate(),
+        counterpart_id=counterpart or UserId.generate(),
+        conducted_at=datetime(2026, 3, 25, 10, 0),
+    )
+
+
+def _build_use_case(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+    uow: FakeUnitOfWork | None = None,
+    event_dispatcher: SpyEventDispatcher | None = None,
+) -> tuple[
+    UpdateMemoUseCase,
+    InMemoryRecordRepository,
+    FakeUnitOfWork,
+    SpyEventDispatcher,
+]:
+    rr = record_repo or InMemoryRecordRepository()
+    u = uow or FakeUnitOfWork()
+    ed = event_dispatcher or SpyEventDispatcher()
+    uc = UpdateMemoUseCase(
+        record_repository=rr,
+        unit_of_work=u,
+        event_dispatcher=ed,
+    )
+    return uc, rr, u, ed
+
+
+class TestUpdateMemo:
+    """Tests for successful memo update."""
+
+    async def test_updates_memo_content(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()  # Clear creation events
+
+        output = await uc.execute(
+            UpdateMemoInput(
+                record_id=record.id,
+                actor_id=organizer,
+                memo=Memo("New memo content"),
+            )
+        )
+
+        assert isinstance(output, UpdateMemoOutput)
+        assert output.record_id == record.id
+        saved = await rr.get_by_id(record.id)
+        assert saved is not None
+        assert saved.memo.value == "New memo content"
+
+    async def test_commits_transaction(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            UpdateMemoInput(
+                record_id=record.id,
+                actor_id=organizer,
+                memo=Memo("Updated"),
+            )
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_memo_updated_event(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _uow, ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            UpdateMemoInput(
+                record_id=record.id,
+                actor_id=organizer,
+                memo=Memo("Event test"),
+            )
+        )
+
+        memo_events = [e for e in ed.dispatched_events if isinstance(e, MemoUpdated)]
+        assert len(memo_events) == 1
+        assert memo_events[0].record_id == record.id
+        assert memo_events[0].organizer_id == organizer
+
+    async def test_record_status_remains_draft(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        await uc.execute(
+            UpdateMemoInput(
+                record_id=record.id,
+                actor_id=organizer,
+                memo=Memo("Still draft"),
+            )
+        )
+
+        saved = await rr.get_by_id(record.id)
+        assert saved is not None
+        assert saved.status == RecordStatus.DRAFT
+
+
+class TestUpdateMemoErrors:
+    """Tests for error conditions."""
+
+    async def test_raises_when_record_not_found(self) -> None:
+        uc, _rr, _uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                UpdateMemoInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                    memo=Memo("Test"),
+                )
+            )
+
+    async def test_raises_when_actor_is_not_organizer(self) -> None:
+        organizer = UserId.generate()
+        other_user = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(UnauthorizedOperationError, match="Only the organizer"):
+            await uc.execute(
+                UpdateMemoInput(
+                    record_id=record.id,
+                    actor_id=other_user,
+                    memo=Memo("Unauthorized"),
+                )
+            )
+
+    async def test_raises_when_record_is_published(self) -> None:
+        organizer = UserId.generate()
+        record = _make_draft_record(organizer=organizer)
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 25, 12, 0))
+        uc, rr, _uow, _ed = _build_use_case()
+        await rr.save(record)
+        record.collect_events()
+
+        with pytest.raises(RecordAlreadyPublishedError):
+            await uc.execute(
+                UpdateMemoInput(
+                    record_id=record.id,
+                    actor_id=organizer,
+                    memo=Memo("Too late"),
+                )
+            )
+
+    async def test_does_not_commit_on_error(self) -> None:
+        uc, _rr, uow, _ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                UpdateMemoInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                    memo=Memo("Test"),
+                )
+            )
+
+        assert uow.committed is False
+
+    async def test_does_not_dispatch_events_on_error(self) -> None:
+        uc, _rr, _uow, ed = _build_use_case()
+
+        with pytest.raises(RecordNotFoundError):
+            await uc.execute(
+                UpdateMemoInput(
+                    record_id=RecordId.generate(),
+                    actor_id=UserId.generate(),
+                    memo=Memo("Test"),
+                )
+            )
+
+        assert ed.dispatched_events == []

--- a/backend/tests/contexts/record/domain/test_record.py
+++ b/backend/tests/contexts/record/domain/test_record.py
@@ -2,8 +2,9 @@ from datetime import datetime
 
 import pytest
 
-from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
 from contexts.record.domain.events import (
+    AgendaConfirmed,
     MemoUpdated,
     RecordCreated,
     RecordDraftSaved,
@@ -11,6 +12,7 @@ from contexts.record.domain.events import (
     ViewersChanged,
 )
 from contexts.record.domain.exceptions import (
+    AgendaAlreadyConfirmedError,
     RecordAlreadyPublishedError,
     UnauthorizedOperationError,
 )
@@ -201,6 +203,118 @@ class TestRecordPublish:
         pub_events = [e for e in events if isinstance(e, RecordPublished)]
         assert len(pub_events) == 1
         assert pub_events[0].occurred_at == now
+
+
+class TestRecordConfirmAgenda:
+    def test_organizer_can_confirm_agenda(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        agenda_id = AgendaId.generate()
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.confirm_agenda(agenda_id=agenda_id, actor_id=organizer, now=now)
+
+        assert agenda_id in record.confirmed_agenda_ids
+        assert record.updated_at == now
+
+    def test_counterpart_can_confirm_agenda(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+        agenda_id = AgendaId.generate()
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.confirm_agenda(agenda_id=agenda_id, actor_id=counterpart, now=now)
+
+        assert agenda_id in record.confirmed_agenda_ids
+
+    def test_viewer_cannot_confirm_agenda(self) -> None:
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        viewer = UserId.generate()
+        record = _make_record(organizer_id=organizer, counterpart_id=counterpart)
+
+        with pytest.raises(
+            UnauthorizedOperationError, match="organizer or counterpart"
+        ):
+            record.confirm_agenda(
+                agenda_id=AgendaId.generate(),
+                actor_id=viewer,
+                now=datetime(2026, 3, 20, 11, 0),
+            )
+
+    def test_cannot_confirm_same_agenda_twice(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        agenda_id = AgendaId.generate()
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.confirm_agenda(agenda_id=agenda_id, actor_id=organizer, now=now)
+
+        with pytest.raises(AgendaAlreadyConfirmedError):
+            record.confirm_agenda(
+                agenda_id=agenda_id,
+                actor_id=organizer,
+                now=datetime(2026, 3, 20, 11, 5),
+            )
+
+    def test_cannot_confirm_agenda_when_published(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 10, 45))
+
+        with pytest.raises(RecordAlreadyPublishedError):
+            record.confirm_agenda(
+                agenda_id=AgendaId.generate(),
+                actor_id=organizer,
+                now=datetime(2026, 3, 20, 11, 0),
+            )
+
+    def test_emits_agenda_confirmed_event(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        record.collect_events()  # clear creation event
+        agenda_id = AgendaId.generate()
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.confirm_agenda(agenda_id=agenda_id, actor_id=organizer, now=now)
+
+        events = record.collect_events()
+        confirmed_events = [e for e in events if isinstance(e, AgendaConfirmed)]
+        assert len(confirmed_events) == 1
+        assert confirmed_events[0].record_id == record.id
+        assert confirmed_events[0].agenda_id == agenda_id
+        assert confirmed_events[0].confirmed_by == organizer
+        assert confirmed_events[0].occurred_at == now
+
+    def test_confirmed_agenda_ids_returns_copy(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        agenda_id = AgendaId.generate()
+        record.confirm_agenda(
+            agenda_id=agenda_id,
+            actor_id=organizer,
+            now=datetime(2026, 3, 20, 11, 0),
+        )
+
+        returned = record.confirmed_agenda_ids
+        returned.add(AgendaId.generate())
+
+        assert len(record.confirmed_agenda_ids) == 1
+
+    def test_multiple_agendas_can_be_confirmed(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        agenda1 = AgendaId.generate()
+        agenda2 = AgendaId.generate()
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.confirm_agenda(agenda_id=agenda1, actor_id=organizer, now=now)
+        record.confirm_agenda(agenda_id=agenda2, actor_id=organizer, now=now)
+
+        assert agenda1 in record.confirmed_agenda_ids
+        assert agenda2 in record.confirmed_agenda_ids
+        assert len(record.confirmed_agenda_ids) == 2
 
 
 class TestRecordVisibility:


### PR DESCRIPTION
## Summary

Issue #82 の実装: 1on1実施中〜直後の操作に関する4つのユースケースを application 層に実装。

- **UpdateMemoUseCase**: オーガナイザーが Record にメモを書き込む（MemoUpdated イベント発行）
- **AddActionItemUseCase**: オーガナイザーが Record にアクションアイテムを登録（カウンターパートに紐づく、ActionItemAdded イベント発行）
- **ConfirmAgendaUseCase**: オーガナイザー・カウンターパートどちらでもアジェンダを確認済みにできる（AgendaConfirmed イベント発行）
- **SaveDraftUseCase**: DRAFT 状態のまま保存（RecordDraftSaved イベント発行、Slack 通知なし）

### ドメイン変更
- Record エンティティに confirmed_agenda_ids フィールドと confirm_agenda() メソッドを追加
- AgendaConfirmed ドメインイベントと AgendaAlreadyConfirmedError 例外を追加
- _assert_participant() ヘルパー（オーガナイザーまたはカウンターパートの権限チェック）を追加

### インフラ変更
- RecordConfirmedAgendaTable を追加（確認済みアジェンダ ID の永続化）
- SqlAlchemyRecordRepository を更新（confirmed_agendas の読み書き対応）
- foundation/db/models.py に新テーブルを登録

### 権限

| 操作 | オーガナイザー | カウンターパート | Viewer |
|---|---|---|---|
| メモ記録 | o | x | x |
| AI登録 | o | x | x |
| アジェンダ確認 | o | o | x |
| 下書き保存 | o | x | x |

Closes #82

## Test plan

- [x] ドメイン層テスト: Record の confirm_agenda メソッド（権限・状態遷移・イベント・重複確認・コピー防御）
- [x] UpdateMemoUseCase テスト（正常系・エラー系・イベント・トランザクション）
- [x] AddActionItemUseCase テスト（正常系・権限・イベント・counterpart_id 紐づけ）
- [x] ConfirmAgendaUseCase テスト（organizer/counterpart 両方可・viewer 不可・重複エラー）
- [x] SaveDraftUseCase テスト（正常系・権限・RecordDraftSaved のみ発行・可視性確認）
- [x] 既存テスト全 435 件パス
- [x] ruff check / ruff format / pyright 全パス

Generated with [Claude Code](https://claude.com/claude-code)
