### PR TITLE
feat(workspace): メンバー管理ユースケースの実装

### DIFF
--- a/backend/contexts/workspace/application/add_member_service.py
+++ b/backend/contexts/workspace/application/add_member_service.py
@@ -1,0 +1,94 @@
+"""Use case: Add a member to a workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.workspace.domain.value_objects import (
+    MembershipId,
+    MembershipRole,
+    WorkspaceId,
+)
+from contexts.workspace.domain.workspace_repository import WorkspaceRepository
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class WorkspaceNotFoundError(Exception):
+    """Raised when the specified workspace does not exist."""
+
+    def __init__(self, message: str = "Workspace not found.") -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class AddMemberInput:
+    """Input DTO for adding a member to a workspace."""
+
+    workspace_id: WorkspaceId
+    user_id: UserId
+    role: MembershipRole = MembershipRole.MEMBER
+
+
+@dataclass(frozen=True)
+class AddMemberOutput:
+    """Output DTO for adding a member to a workspace."""
+
+    membership_id: MembershipId
+
+
+class AddMemberService:
+    """Application service that adds a member to a workspace.
+
+    The user is added with the specified role (defaults to Member).
+    Domain layer prevents duplicate memberships.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        workspace_repo: WorkspaceRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._workspace_repo = workspace_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: AddMemberInput,
+    ) -> AddMemberOutput:
+        """Add a member to the workspace and return the membership id.
+
+        Args:
+            input_dto: The input containing workspace id, user id, and role.
+
+        Returns:
+            Output containing the id of the newly created membership.
+
+        Raises:
+            WorkspaceNotFoundError: If the workspace does not exist.
+            DuplicateMembershipError: If the user is already a member.
+        """
+        now = datetime.now(UTC)
+
+        async with self._uow:
+            workspace = await self._workspace_repo.get_by_id(input_dto.workspace_id)
+            if workspace is None:
+                raise WorkspaceNotFoundError()
+
+            membership = workspace.add_member(
+                user_id=input_dto.user_id,
+                role=input_dto.role,
+                now=now,
+            )
+            await self._workspace_repo.save(workspace)
+            events: list[DomainEvent] = list(workspace.collect_events())
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)
+
+        return AddMemberOutput(membership_id=membership.id)

--- a/backend/contexts/workspace/application/change_member_role_service.py
+++ b/backend/contexts/workspace/application/change_member_role_service.py
@@ -1,0 +1,78 @@
+"""Use case: Change a member's role in a workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.workspace.domain.value_objects import MembershipRole, WorkspaceId
+from contexts.workspace.domain.workspace_repository import WorkspaceRepository
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class WorkspaceNotFoundError(Exception):
+    """Raised when the specified workspace does not exist."""
+
+    def __init__(self, message: str = "Workspace not found.") -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class ChangeMemberRoleInput:
+    """Input DTO for changing a member's role."""
+
+    workspace_id: WorkspaceId
+    user_id: UserId
+    new_role: MembershipRole
+
+
+class ChangeMemberRoleService:
+    """Application service that changes a member's role in a workspace.
+
+    Domain layer raises MembershipNotFoundError if the user is not a member.
+    No-op if the new role is the same as the current role.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        workspace_repo: WorkspaceRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._workspace_repo = workspace_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: ChangeMemberRoleInput,
+    ) -> None:
+        """Change the member's role.
+
+        Args:
+            input_dto: The input containing workspace id, user id, and new role.
+
+        Raises:
+            WorkspaceNotFoundError: If the workspace does not exist.
+            MembershipNotFoundError: If the user is not a member.
+        """
+        now = datetime.now(UTC)
+
+        async with self._uow:
+            workspace = await self._workspace_repo.get_by_id(input_dto.workspace_id)
+            if workspace is None:
+                raise WorkspaceNotFoundError()
+
+            workspace.change_member_role(
+                user_id=input_dto.user_id,
+                new_role=input_dto.new_role,
+                now=now,
+            )
+            await self._workspace_repo.save(workspace)
+            events: list[DomainEvent] = list(workspace.collect_events())
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/workspace/application/remove_member_service.py
+++ b/backend/contexts/workspace/application/remove_member_service.py
@@ -1,0 +1,72 @@
+"""Use case: Remove a member from a workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.workspace.domain.value_objects import WorkspaceId
+from contexts.workspace.domain.workspace_repository import WorkspaceRepository
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class WorkspaceNotFoundError(Exception):
+    """Raised when the specified workspace does not exist."""
+
+    def __init__(self, message: str = "Workspace not found.") -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class RemoveMemberInput:
+    """Input DTO for removing a member from a workspace."""
+
+    workspace_id: WorkspaceId
+    user_id: UserId
+
+
+class RemoveMemberService:
+    """Application service that removes a member from a workspace.
+
+    Domain layer raises MembershipNotFoundError if the user is not a member.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        workspace_repo: WorkspaceRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._workspace_repo = workspace_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: RemoveMemberInput,
+    ) -> None:
+        """Remove a member from the workspace.
+
+        Args:
+            input_dto: The input containing workspace id and user id.
+
+        Raises:
+            WorkspaceNotFoundError: If the workspace does not exist.
+            MembershipNotFoundError: If the user is not a member.
+        """
+        now = datetime.now(UTC)
+
+        async with self._uow:
+            workspace = await self._workspace_repo.get_by_id(input_dto.workspace_id)
+            if workspace is None:
+                raise WorkspaceNotFoundError()
+
+            workspace.remove_member(user_id=input_dto.user_id, now=now)
+            await self._workspace_repo.save(workspace)
+            events: list[DomainEvent] = list(workspace.collect_events())
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)

--- a/backend/tests/contexts/workspace/application/test_add_member_service.py
+++ b/backend/tests/contexts/workspace/application/test_add_member_service.py
@@ -1,0 +1,207 @@
+"""Tests for AddMemberService."""
+
+from __future__ import annotations
+
+import pytest
+
+from contexts.workspace.application.add_member_service import (
+    AddMemberInput,
+    AddMemberOutput,
+    AddMemberService,
+    WorkspaceNotFoundError,
+)
+from contexts.workspace.domain.events import MemberAdded
+from contexts.workspace.domain.exceptions import DuplicateMembershipError
+from contexts.workspace.domain.value_objects import (
+    MembershipRole,
+    WorkspaceId,
+)
+from contexts.workspace.domain.workspace import Workspace
+from contexts.workspace.domain.workspace_name import WorkspaceName
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.workspace.application.conftest import (
+    InMemoryWorkspaceRepository,
+    StubUnitOfWork,
+)
+
+
+class TestAddMember:
+    """Add member to workspace use case."""
+
+    @pytest.fixture
+    def uow(self) -> StubUnitOfWork:
+        return StubUnitOfWork()
+
+    @pytest.fixture
+    def repo(self) -> InMemoryWorkspaceRepository:
+        return InMemoryWorkspaceRepository()
+
+    @pytest.fixture
+    def dispatcher(self) -> InMemoryEventDispatcher:
+        return InMemoryEventDispatcher()
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> AddMemberService:
+        return AddMemberService(
+            uow=uow,
+            workspace_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+    @pytest.fixture
+    async def workspace(self, repo: InMemoryWorkspaceRepository) -> Workspace:
+        """Pre-populate repository with a workspace."""
+        ws = Workspace.create(name=WorkspaceName("Engineering"))
+        ws.collect_events()  # discard creation event
+        await repo.save(ws)
+        return ws
+
+    async def test_adds_member_with_default_role(
+        self,
+        service: AddMemberService,
+        repo: InMemoryWorkspaceRepository,
+        workspace: Workspace,
+    ) -> None:
+        """Member is added with default Member role."""
+        user_id = UserId.generate()
+
+        output = await service.execute(
+            AddMemberInput(workspace_id=workspace.id, user_id=user_id)
+        )
+
+        assert isinstance(output, AddMemberOutput)
+        ws = await repo.get_by_id(workspace.id)
+        assert ws is not None
+        assert len(ws.memberships) == 1
+        assert ws.memberships[0].user_id == user_id
+        assert ws.memberships[0].role == MembershipRole.MEMBER
+
+    async def test_adds_member_as_captain(
+        self,
+        service: AddMemberService,
+        repo: InMemoryWorkspaceRepository,
+        workspace: Workspace,
+    ) -> None:
+        """Member is added with Captain role when specified."""
+        user_id = UserId.generate()
+
+        output = await service.execute(
+            AddMemberInput(
+                workspace_id=workspace.id,
+                user_id=user_id,
+                role=MembershipRole.CAPTAIN,
+            )
+        )
+
+        assert isinstance(output, AddMemberOutput)
+        ws = await repo.get_by_id(workspace.id)
+        assert ws is not None
+        assert ws.memberships[0].role == MembershipRole.CAPTAIN
+
+    async def test_commits_via_uow(
+        self,
+        service: AddMemberService,
+        uow: StubUnitOfWork,
+        workspace: Workspace,
+    ) -> None:
+        """UoW commit is called after save."""
+        await service.execute(
+            AddMemberInput(workspace_id=workspace.id, user_id=UserId.generate())
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_member_added_event(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        workspace: Workspace,
+    ) -> None:
+        """MemberAdded event is dispatched after commit."""
+        dispatched_events: list[object] = []
+
+        async def capture_handler(event: object) -> None:
+            dispatched_events.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(MemberAdded, capture_handler)  # type: ignore[arg-type]
+        service = AddMemberService(
+            uow=uow,
+            workspace_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+        user_id = UserId.generate()
+
+        await service.execute(
+            AddMemberInput(workspace_id=workspace.id, user_id=user_id)
+        )
+
+        assert len(dispatched_events) == 1
+        event = dispatched_events[0]
+        assert isinstance(event, MemberAdded)
+        assert event.workspace_id == workspace.id
+        assert event.user_id == user_id
+        assert event.role == MembershipRole.MEMBER
+
+    async def test_raises_when_workspace_not_found(
+        self,
+        service: AddMemberService,
+    ) -> None:
+        """WorkspaceNotFoundError is raised when workspace does not exist."""
+        with pytest.raises(WorkspaceNotFoundError):
+            await service.execute(
+                AddMemberInput(
+                    workspace_id=WorkspaceId.generate(),
+                    user_id=UserId.generate(),
+                )
+            )
+
+    async def test_raises_when_duplicate_membership(
+        self,
+        service: AddMemberService,
+        workspace: Workspace,
+    ) -> None:
+        """DuplicateMembershipError is raised when user is already a member."""
+        user_id = UserId.generate()
+        await service.execute(
+            AddMemberInput(workspace_id=workspace.id, user_id=user_id)
+        )
+
+        with pytest.raises(DuplicateMembershipError):
+            await service.execute(
+                AddMemberInput(workspace_id=workspace.id, user_id=user_id)
+            )
+
+    async def test_user_can_join_multiple_workspaces(
+        self,
+        service: AddMemberService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """A user can belong to multiple workspaces."""
+        ws1 = Workspace.create(name=WorkspaceName("Engineering"))
+        ws1.collect_events()
+        await repo.save(ws1)
+
+        ws2 = Workspace.create(name=WorkspaceName("Design"))
+        ws2.collect_events()
+        await repo.save(ws2)
+
+        user_id = UserId.generate()
+
+        await service.execute(AddMemberInput(workspace_id=ws1.id, user_id=user_id))
+        await service.execute(AddMemberInput(workspace_id=ws2.id, user_id=user_id))
+
+        saved_ws1 = await repo.get_by_id(ws1.id)
+        saved_ws2 = await repo.get_by_id(ws2.id)
+        assert saved_ws1 is not None
+        assert saved_ws2 is not None
+        assert len(saved_ws1.memberships) == 1
+        assert len(saved_ws2.memberships) == 1
+        assert saved_ws1.memberships[0].user_id == user_id
+        assert saved_ws2.memberships[0].user_id == user_id

--- a/backend/tests/contexts/workspace/application/test_change_member_role_service.py
+++ b/backend/tests/contexts/workspace/application/test_change_member_role_service.py
@@ -1,0 +1,293 @@
+"""Tests for ChangeMemberRoleService."""
+
+from __future__ import annotations
+
+import pytest
+
+from contexts.workspace.application.change_member_role_service import (
+    ChangeMemberRoleInput,
+    ChangeMemberRoleService,
+    WorkspaceNotFoundError,
+)
+from contexts.workspace.domain.events import MemberRoleChanged
+from contexts.workspace.domain.exceptions import MembershipNotFoundError
+from contexts.workspace.domain.value_objects import (
+    MembershipRole,
+    WorkspaceId,
+)
+from contexts.workspace.domain.workspace import Workspace
+from contexts.workspace.domain.workspace_name import WorkspaceName
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.workspace.application.conftest import (
+    InMemoryWorkspaceRepository,
+    StubUnitOfWork,
+)
+
+
+class TestChangeMemberRole:
+    """Change member role use case."""
+
+    @pytest.fixture
+    def uow(self) -> StubUnitOfWork:
+        return StubUnitOfWork()
+
+    @pytest.fixture
+    def repo(self) -> InMemoryWorkspaceRepository:
+        return InMemoryWorkspaceRepository()
+
+    @pytest.fixture
+    def dispatcher(self) -> InMemoryEventDispatcher:
+        return InMemoryEventDispatcher()
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> ChangeMemberRoleService:
+        return ChangeMemberRoleService(
+            uow=uow,
+            workspace_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+    @pytest.fixture
+    async def workspace_with_member(
+        self, repo: InMemoryWorkspaceRepository
+    ) -> tuple[Workspace, UserId]:
+        """Pre-populate repository with a workspace that has one Member."""
+        ws = Workspace.create(name=WorkspaceName("Engineering"))
+        user_id = UserId.generate()
+        ws.add_member(user_id=user_id, role=MembershipRole.MEMBER, now=ws.created_at)
+        ws.collect_events()  # discard creation and add events
+        await repo.save(ws)
+        return ws, user_id
+
+    async def test_changes_role_to_captain(
+        self,
+        service: ChangeMemberRoleService,
+        repo: InMemoryWorkspaceRepository,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """Member role is changed from Member to Captain."""
+        ws, user_id = workspace_with_member
+
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id,
+                user_id=user_id,
+                new_role=MembershipRole.CAPTAIN,
+            )
+        )
+
+        saved_ws = await repo.get_by_id(ws.id)
+        assert saved_ws is not None
+        assert saved_ws.memberships[0].role == MembershipRole.CAPTAIN
+
+    async def test_changes_role_to_member(
+        self,
+        repo: InMemoryWorkspaceRepository,
+        uow: StubUnitOfWork,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> None:
+        """Captain role is changed back to Member."""
+        ws = Workspace.create(name=WorkspaceName("Engineering"))
+        user_id = UserId.generate()
+        ws.add_member(user_id=user_id, role=MembershipRole.CAPTAIN, now=ws.created_at)
+        ws.collect_events()
+        await repo.save(ws)
+
+        service = ChangeMemberRoleService(
+            uow=uow, workspace_repo=repo, event_dispatcher=dispatcher
+        )
+
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id,
+                user_id=user_id,
+                new_role=MembershipRole.MEMBER,
+            )
+        )
+
+        saved_ws = await repo.get_by_id(ws.id)
+        assert saved_ws is not None
+        assert saved_ws.memberships[0].role == MembershipRole.MEMBER
+
+    async def test_noop_when_same_role(
+        self,
+        service: ChangeMemberRoleService,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """No event is dispatched when the role is unchanged."""
+        ws, user_id = workspace_with_member
+
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id,
+                user_id=user_id,
+                new_role=MembershipRole.MEMBER,  # same as current
+            )
+        )
+
+        # UoW still commits (the service always commits),
+        # but no MemberRoleChanged event should be collected.
+        assert uow.committed is True
+        saved_ws = await repo.get_by_id(ws.id)
+        assert saved_ws is not None
+        # Events were already collected in the service; verify no
+        # MemberRoleChanged was dispatched by checking no events remain.
+        assert saved_ws.memberships[0].role == MembershipRole.MEMBER
+
+    async def test_commits_via_uow(
+        self,
+        service: ChangeMemberRoleService,
+        uow: StubUnitOfWork,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """UoW commit is called after save."""
+        ws, user_id = workspace_with_member
+
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id,
+                user_id=user_id,
+                new_role=MembershipRole.CAPTAIN,
+            )
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_member_role_changed_event(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """MemberRoleChanged event is dispatched after commit."""
+        ws, user_id = workspace_with_member
+        dispatched_events: list[object] = []
+
+        async def capture_handler(event: object) -> None:
+            dispatched_events.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(MemberRoleChanged, capture_handler)  # type: ignore[arg-type]
+        service = ChangeMemberRoleService(
+            uow=uow,
+            workspace_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id,
+                user_id=user_id,
+                new_role=MembershipRole.CAPTAIN,
+            )
+        )
+
+        assert len(dispatched_events) == 1
+        event = dispatched_events[0]
+        assert isinstance(event, MemberRoleChanged)
+        assert event.workspace_id == ws.id
+        assert event.user_id == user_id
+        assert event.old_role == MembershipRole.MEMBER
+        assert event.new_role == MembershipRole.CAPTAIN
+
+    async def test_no_event_dispatched_when_same_role(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """No MemberRoleChanged event when role is unchanged."""
+        ws, user_id = workspace_with_member
+        dispatched_events: list[object] = []
+
+        async def capture_handler(event: object) -> None:
+            dispatched_events.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(MemberRoleChanged, capture_handler)  # type: ignore[arg-type]
+        service = ChangeMemberRoleService(
+            uow=uow,
+            workspace_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id,
+                user_id=user_id,
+                new_role=MembershipRole.MEMBER,  # same as current
+            )
+        )
+
+        assert len(dispatched_events) == 0
+
+    async def test_raises_when_workspace_not_found(
+        self,
+        service: ChangeMemberRoleService,
+    ) -> None:
+        """WorkspaceNotFoundError is raised when workspace does not exist."""
+        with pytest.raises(WorkspaceNotFoundError):
+            await service.execute(
+                ChangeMemberRoleInput(
+                    workspace_id=WorkspaceId.generate(),
+                    user_id=UserId.generate(),
+                    new_role=MembershipRole.CAPTAIN,
+                )
+            )
+
+    async def test_raises_when_membership_not_found(
+        self,
+        service: ChangeMemberRoleService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """MembershipNotFoundError is raised when user is not a member."""
+        ws = Workspace.create(name=WorkspaceName("Engineering"))
+        ws.collect_events()
+        await repo.save(ws)
+
+        with pytest.raises(MembershipNotFoundError):
+            await service.execute(
+                ChangeMemberRoleInput(
+                    workspace_id=ws.id,
+                    user_id=UserId.generate(),
+                    new_role=MembershipRole.CAPTAIN,
+                )
+            )
+
+    async def test_multiple_captains_allowed(
+        self,
+        service: ChangeMemberRoleService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Multiple members can be promoted to Captain in the same workspace."""
+        ws = Workspace.create(name=WorkspaceName("Engineering"))
+        user1 = UserId.generate()
+        user2 = UserId.generate()
+        ws.add_member(user_id=user1, role=MembershipRole.MEMBER, now=ws.created_at)
+        ws.add_member(user_id=user2, role=MembershipRole.MEMBER, now=ws.created_at)
+        ws.collect_events()
+        await repo.save(ws)
+
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id, user_id=user1, new_role=MembershipRole.CAPTAIN
+            )
+        )
+        await service.execute(
+            ChangeMemberRoleInput(
+                workspace_id=ws.id, user_id=user2, new_role=MembershipRole.CAPTAIN
+            )
+        )
+
+        saved_ws = await repo.get_by_id(ws.id)
+        assert saved_ws is not None
+        captains = [m for m in saved_ws.memberships if m.role == MembershipRole.CAPTAIN]
+        assert len(captains) == 2

--- a/backend/tests/contexts/workspace/application/test_remove_member_service.py
+++ b/backend/tests/contexts/workspace/application/test_remove_member_service.py
@@ -1,0 +1,154 @@
+"""Tests for RemoveMemberService."""
+
+from __future__ import annotations
+
+import pytest
+
+from contexts.workspace.application.remove_member_service import (
+    RemoveMemberInput,
+    RemoveMemberService,
+    WorkspaceNotFoundError,
+)
+from contexts.workspace.domain.events import MemberRemoved
+from contexts.workspace.domain.exceptions import MembershipNotFoundError
+from contexts.workspace.domain.value_objects import (
+    MembershipRole,
+    WorkspaceId,
+)
+from contexts.workspace.domain.workspace import Workspace
+from contexts.workspace.domain.workspace_name import WorkspaceName
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.workspace.application.conftest import (
+    InMemoryWorkspaceRepository,
+    StubUnitOfWork,
+)
+
+
+class TestRemoveMember:
+    """Remove member from workspace use case."""
+
+    @pytest.fixture
+    def uow(self) -> StubUnitOfWork:
+        return StubUnitOfWork()
+
+    @pytest.fixture
+    def repo(self) -> InMemoryWorkspaceRepository:
+        return InMemoryWorkspaceRepository()
+
+    @pytest.fixture
+    def dispatcher(self) -> InMemoryEventDispatcher:
+        return InMemoryEventDispatcher()
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> RemoveMemberService:
+        return RemoveMemberService(
+            uow=uow,
+            workspace_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+    @pytest.fixture
+    async def workspace_with_member(
+        self, repo: InMemoryWorkspaceRepository
+    ) -> tuple[Workspace, UserId]:
+        """Pre-populate repository with a workspace that has one member."""
+        ws = Workspace.create(name=WorkspaceName("Engineering"))
+        user_id = UserId.generate()
+        ws.add_member(user_id=user_id, role=MembershipRole.MEMBER, now=ws.created_at)
+        ws.collect_events()  # discard creation and add events
+        await repo.save(ws)
+        return ws, user_id
+
+    async def test_removes_member(
+        self,
+        service: RemoveMemberService,
+        repo: InMemoryWorkspaceRepository,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """Member is removed from the workspace."""
+        ws, user_id = workspace_with_member
+
+        await service.execute(RemoveMemberInput(workspace_id=ws.id, user_id=user_id))
+
+        saved_ws = await repo.get_by_id(ws.id)
+        assert saved_ws is not None
+        assert len(saved_ws.memberships) == 0
+
+    async def test_commits_via_uow(
+        self,
+        service: RemoveMemberService,
+        uow: StubUnitOfWork,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """UoW commit is called after save."""
+        ws, user_id = workspace_with_member
+
+        await service.execute(RemoveMemberInput(workspace_id=ws.id, user_id=user_id))
+
+        assert uow.committed is True
+
+    async def test_dispatches_member_removed_event(
+        self,
+        uow: StubUnitOfWork,
+        repo: InMemoryWorkspaceRepository,
+        workspace_with_member: tuple[Workspace, UserId],
+    ) -> None:
+        """MemberRemoved event is dispatched after commit."""
+        ws, user_id = workspace_with_member
+        dispatched_events: list[object] = []
+
+        async def capture_handler(event: object) -> None:
+            dispatched_events.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(MemberRemoved, capture_handler)  # type: ignore[arg-type]
+        service = RemoveMemberService(
+            uow=uow,
+            workspace_repo=repo,
+            event_dispatcher=dispatcher,
+        )
+
+        await service.execute(RemoveMemberInput(workspace_id=ws.id, user_id=user_id))
+
+        assert len(dispatched_events) == 1
+        event = dispatched_events[0]
+        assert isinstance(event, MemberRemoved)
+        assert event.workspace_id == ws.id
+        assert event.user_id == user_id
+
+    async def test_raises_when_workspace_not_found(
+        self,
+        service: RemoveMemberService,
+    ) -> None:
+        """WorkspaceNotFoundError is raised when workspace does not exist."""
+        with pytest.raises(WorkspaceNotFoundError):
+            await service.execute(
+                RemoveMemberInput(
+                    workspace_id=WorkspaceId.generate(),
+                    user_id=UserId.generate(),
+                )
+            )
+
+    async def test_raises_when_membership_not_found(
+        self,
+        service: RemoveMemberService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """MembershipNotFoundError is raised when user is not a member."""
+        ws = Workspace.create(name=WorkspaceName("Engineering"))
+        ws.collect_events()
+        await repo.save(ws)
+
+        with pytest.raises(MembershipNotFoundError):
+            await service.execute(
+                RemoveMemberInput(
+                    workspace_id=ws.id,
+                    user_id=UserId.generate(),
+                )
+            )


### PR DESCRIPTION
## Summary
- AddMemberService / RemoveMemberService / ChangeMemberRoleService
- UnitOfWork + EventDispatcher
- Tests: 21

Closes #75

Generated with [Claude Code](https://claude.com/claude-code)