### PR TITLE
feat(workspace): add CaptainQueryService for default viewer suggestion

### DIFF
--- a/backend/contexts/workspace/application/captain_query_service.py
+++ b/backend/contexts/workspace/application/captain_query_service.py
@@ -1,0 +1,74 @@
+"""Use case: Query Captain user IDs for default viewer suggestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from contexts.workspace.domain.value_objects import MembershipRole
+from contexts.workspace.domain.workspace import Workspace
+from contexts.workspace.domain.workspace_repository import WorkspaceRepository
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class CaptainQueryInput:
+    """Input DTO for captain query."""
+
+    counterpart_id: UserId
+
+
+@dataclass(frozen=True)
+class CaptainQueryOutput:
+    """Output DTO for captain query."""
+
+    captain_user_ids: list[UserId]
+
+
+class CaptainQueryService:
+    """Collect Captain user IDs from a counterpart's workspaces.
+
+    Starting from all workspaces the counterpart belongs to, recursively
+    traverses ancestor workspaces and collects users with the Captain role.
+    Results are deduplicated by UserId.
+
+    This is a read-only query service; no UoW or EventDispatcher is needed.
+    """
+
+    def __init__(self, workspace_repo: WorkspaceRepository) -> None:
+        self._workspace_repo = workspace_repo
+
+    async def execute(self, input_dto: CaptainQueryInput) -> CaptainQueryOutput:
+        """Collect Captain user IDs for default viewer suggestion.
+
+        Args:
+            input_dto: Contains the counterpart's UserId.
+
+        Returns:
+            Output containing deduplicated list of Captain user IDs.
+        """
+        # 1. Get all workspaces the counterpart belongs to
+        workspaces = await self._workspace_repo.get_by_member_user_id(
+            input_dto.counterpart_id,
+        )
+
+        # 2. For each workspace, collect captains from itself and all ancestors
+        captain_ids: dict[UserId, None] = {}
+
+        for ws in workspaces:
+            self._collect_captains(ws, captain_ids)
+
+            ancestors = await self._workspace_repo.get_ancestors(ws.id)
+            for ancestor in ancestors:
+                self._collect_captains(ancestor, captain_ids)
+
+        return CaptainQueryOutput(captain_user_ids=list(captain_ids))
+
+    @staticmethod
+    def _collect_captains(
+        workspace: Workspace,
+        captain_ids: dict[UserId, None],
+    ) -> None:
+        """Extract Captain user IDs from a workspace's memberships."""
+        for membership in workspace.memberships:
+            if membership.role == MembershipRole.CAPTAIN:
+                captain_ids[membership.user_id] = None

--- a/backend/contexts/workspace/domain/workspace_repository.py
+++ b/backend/contexts/workspace/domain/workspace_repository.py
@@ -5,13 +5,15 @@ from abc import abstractmethod
 from contexts.workspace.domain.value_objects import WorkspaceId
 from contexts.workspace.domain.workspace import Workspace
 from foundation.domain.base_repository import BaseRepository
+from shared.domain.value_objects import UserId
 
 
 class WorkspaceRepository(BaseRepository[Workspace, WorkspaceId]):
     """Repository interface for Workspace aggregates.
 
     Extends the base interface with ``get_ancestors`` for
-    ancestor-chain cycle detection at the application layer.
+    ancestor-chain cycle detection at the application layer,
+    and ``get_by_member_user_id`` for querying by membership.
     """
 
     @abstractmethod
@@ -21,4 +23,11 @@ class WorkspaceRepository(BaseRepository[Workspace, WorkspaceId]):
         The list is ordered from the immediate parent to the root.
         Returns an empty list if the workspace has no parent or
         if the workspace_id does not exist.
+        """
+
+    @abstractmethod
+    async def get_by_member_user_id(self, user_id: UserId) -> list[Workspace]:
+        """Return all workspaces where the given user is a member.
+
+        Returns an empty list if the user does not belong to any workspace.
         """

--- a/backend/contexts/workspace/infrastructure/sqlalchemy_workspace_repository.py
+++ b/backend/contexts/workspace/infrastructure/sqlalchemy_workspace_repository.py
@@ -38,6 +38,16 @@ class SqlAlchemyWorkspaceRepository(WorkspaceRepository):
         else:
             await self._update(entity, existing)
 
+    async def get_by_member_user_id(self, user_id: UserId) -> list[Workspace]:
+        stmt = (
+            select(WorkspaceTable)
+            .join(MembershipTable, WorkspaceTable.id == MembershipTable.workspace_id)
+            .where(MembershipTable.user_id == str(user_id.value))
+        )
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [self._to_entity(row) for row in rows]
+
     async def get_ancestors(self, workspace_id: WorkspaceId) -> list[Workspace]:
         ancestors: list[Workspace] = []
         current_id: str | None = str(workspace_id.value)

--- a/backend/tests/contexts/workspace/application/conftest.py
+++ b/backend/tests/contexts/workspace/application/conftest.py
@@ -8,6 +8,7 @@ from contexts.workspace.domain.value_objects import WorkspaceId
 from contexts.workspace.domain.workspace import Workspace
 from contexts.workspace.domain.workspace_repository import WorkspaceRepository
 from foundation.application.unit_of_work import UnitOfWork
+from shared.domain.value_objects import UserId
 
 
 class StubUnitOfWork(UnitOfWork):
@@ -65,6 +66,14 @@ class InMemoryWorkspaceRepository(WorkspaceRepository):
             current_id = workspace.parent_id
 
         return ancestors
+
+    async def get_by_member_user_id(self, user_id: UserId) -> list[Workspace]:
+        """Return all workspaces where the given user is a member."""
+        return [
+            ws
+            for ws in self._store.values()
+            if any(m.user_id == user_id for m in ws.memberships)
+        ]
 
     @property
     def workspaces(self) -> dict[WorkspaceId, Workspace]:

--- a/backend/tests/contexts/workspace/application/test_captain_query_service.py
+++ b/backend/tests/contexts/workspace/application/test_captain_query_service.py
@@ -1,0 +1,247 @@
+"""Tests for CaptainQueryService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from contexts.workspace.application.captain_query_service import (
+    CaptainQueryInput,
+    CaptainQueryService,
+)
+from contexts.workspace.domain.value_objects import MembershipRole
+from contexts.workspace.domain.workspace import Workspace
+from contexts.workspace.domain.workspace_name import WorkspaceName
+from shared.domain.value_objects import UserId
+from tests.contexts.workspace.application.conftest import InMemoryWorkspaceRepository
+
+
+def _make_workspace(
+    *,
+    name: str = "ws",
+    parent_id: object = None,
+    now: datetime | None = None,
+) -> Workspace:
+    """Helper: create a workspace with an optional parent."""
+    from contexts.workspace.domain.value_objects import WorkspaceId
+
+    ws = Workspace.create(
+        name=WorkspaceName(name),
+        parent_id=parent_id if isinstance(parent_id, WorkspaceId) else None,
+        now=now or datetime(2025, 1, 1, tzinfo=UTC),
+    )
+    ws.collect_events()  # discard creation events
+    return ws
+
+
+class TestCaptainQueryService:
+    """Captain query use case for default viewer suggestion."""
+
+    @pytest.fixture
+    def repo(self) -> InMemoryWorkspaceRepository:
+        return InMemoryWorkspaceRepository()
+
+    @pytest.fixture
+    def service(self, repo: InMemoryWorkspaceRepository) -> CaptainQueryService:
+        return CaptainQueryService(workspace_repo=repo)
+
+    async def test_returns_empty_when_user_has_no_workspaces(
+        self,
+        service: CaptainQueryService,
+    ) -> None:
+        """No workspaces means no captains."""
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=UserId.generate()),
+        )
+        assert result.captain_user_ids == []
+
+    async def test_returns_captains_from_own_workspace(
+        self,
+        service: CaptainQueryService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Captains in the counterpart's own workspace are returned."""
+        now = datetime(2025, 1, 1, tzinfo=UTC)
+        counterpart = UserId.generate()
+        captain = UserId.generate()
+
+        ws = _make_workspace(name="Team A", now=now)
+        ws.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        ws.add_member(user_id=captain, role=MembershipRole.CAPTAIN, now=now)
+        ws.collect_events()
+        await repo.save(ws)
+
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=counterpart),
+        )
+        assert result.captain_user_ids == [captain]
+
+    async def test_returns_captains_from_ancestor_workspaces(
+        self,
+        service: CaptainQueryService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Captains in ancestor workspaces are included."""
+        now = datetime(2025, 1, 1, tzinfo=UTC)
+        counterpart = UserId.generate()
+        root_captain = UserId.generate()
+        mid_captain = UserId.generate()
+
+        # root -> mid -> leaf
+        root = _make_workspace(name="Company", now=now)
+        root.add_member(user_id=root_captain, role=MembershipRole.CAPTAIN, now=now)
+        root.collect_events()
+        await repo.save(root)
+
+        mid = _make_workspace(name="Division", parent_id=root.id, now=now)
+        mid.add_member(user_id=mid_captain, role=MembershipRole.CAPTAIN, now=now)
+        mid.collect_events()
+        await repo.save(mid)
+
+        leaf = _make_workspace(name="Team", parent_id=mid.id, now=now)
+        leaf.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        leaf.collect_events()
+        await repo.save(leaf)
+
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=counterpart),
+        )
+        assert set(result.captain_user_ids) == {root_captain, mid_captain}
+
+    async def test_deduplicates_captains_across_workspaces(
+        self,
+        service: CaptainQueryService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Same captain in multiple workspaces appears only once."""
+        now = datetime(2025, 1, 1, tzinfo=UTC)
+        counterpart = UserId.generate()
+        shared_captain = UserId.generate()
+
+        ws_a = _make_workspace(name="Team A", now=now)
+        ws_a.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        ws_a.add_member(user_id=shared_captain, role=MembershipRole.CAPTAIN, now=now)
+        ws_a.collect_events()
+        await repo.save(ws_a)
+
+        ws_b = _make_workspace(name="Team B", now=now)
+        ws_b.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        ws_b.add_member(user_id=shared_captain, role=MembershipRole.CAPTAIN, now=now)
+        ws_b.collect_events()
+        await repo.save(ws_b)
+
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=counterpart),
+        )
+        assert result.captain_user_ids == [shared_captain]
+
+    async def test_deduplicates_captains_across_ancestor_chains(
+        self,
+        service: CaptainQueryService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Captain in shared ancestor of multiple workspaces appears once."""
+        now = datetime(2025, 1, 1, tzinfo=UTC)
+        counterpart = UserId.generate()
+        root_captain = UserId.generate()
+
+        # root -> team_a, root -> team_b, counterpart in both teams
+        root = _make_workspace(name="Company", now=now)
+        root.add_member(user_id=root_captain, role=MembershipRole.CAPTAIN, now=now)
+        root.collect_events()
+        await repo.save(root)
+
+        team_a = _make_workspace(name="Team A", parent_id=root.id, now=now)
+        team_a.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        team_a.collect_events()
+        await repo.save(team_a)
+
+        team_b = _make_workspace(name="Team B", parent_id=root.id, now=now)
+        team_b.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        team_b.collect_events()
+        await repo.save(team_b)
+
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=counterpart),
+        )
+        assert result.captain_user_ids == [root_captain]
+
+    async def test_excludes_members_who_are_not_captains(
+        self,
+        service: CaptainQueryService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Regular members are not included in the result."""
+        now = datetime(2025, 1, 1, tzinfo=UTC)
+        counterpart = UserId.generate()
+        captain = UserId.generate()
+        regular_member = UserId.generate()
+
+        ws = _make_workspace(name="Team", now=now)
+        ws.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        ws.add_member(user_id=captain, role=MembershipRole.CAPTAIN, now=now)
+        ws.add_member(user_id=regular_member, role=MembershipRole.MEMBER, now=now)
+        ws.collect_events()
+        await repo.save(ws)
+
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=counterpart),
+        )
+        assert result.captain_user_ids == [captain]
+        assert regular_member not in result.captain_user_ids
+
+    async def test_multiple_captains_in_single_workspace(
+        self,
+        service: CaptainQueryService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Multiple captains in one workspace are all returned."""
+        now = datetime(2025, 1, 1, tzinfo=UTC)
+        counterpart = UserId.generate()
+        captain_1 = UserId.generate()
+        captain_2 = UserId.generate()
+
+        ws = _make_workspace(name="Team", now=now)
+        ws.add_member(user_id=counterpart, role=MembershipRole.MEMBER, now=now)
+        ws.add_member(user_id=captain_1, role=MembershipRole.CAPTAIN, now=now)
+        ws.add_member(user_id=captain_2, role=MembershipRole.CAPTAIN, now=now)
+        ws.collect_events()
+        await repo.save(ws)
+
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=counterpart),
+        )
+        assert set(result.captain_user_ids) == {captain_1, captain_2}
+
+    async def test_deep_hierarchy_traversal(
+        self,
+        service: CaptainQueryService,
+        repo: InMemoryWorkspaceRepository,
+    ) -> None:
+        """Captains are collected from deeply nested ancestor chains."""
+        now = datetime(2025, 1, 1, tzinfo=UTC)
+        counterpart = UserId.generate()
+        captains = [UserId.generate() for _ in range(5)]
+
+        # Build a chain: ws_0 -> ws_1 -> ws_2 -> ws_3 -> ws_4
+        workspaces: list[Workspace] = []
+        for i in range(5):
+            parent_id = workspaces[i - 1].id if i > 0 else None
+            ws = _make_workspace(name=f"Level {i}", parent_id=parent_id, now=now)
+            ws.add_member(user_id=captains[i], role=MembershipRole.CAPTAIN, now=now)
+            ws.collect_events()
+            await repo.save(ws)
+            workspaces.append(ws)
+
+        # Counterpart belongs to the deepest workspace
+        workspaces[-1].add_member(
+            user_id=counterpart, role=MembershipRole.MEMBER, now=now
+        )
+        workspaces[-1].collect_events()
+        await repo.save(workspaces[-1])
+
+        result = await service.execute(
+            CaptainQueryInput(counterpart_id=counterpart),
+        )
+        assert set(result.captain_user_ids) == set(captains)


### PR DESCRIPTION
## 概要

カウンターパートの所属 Workspace を起点に、祖先 Workspace の Captain を収集するクエリサービスを実装。Record 公開時のデフォルト Viewer 提案に使用する。

## 変更内容

- `WorkspaceRepository` に `get_by_member_user_id` メソッドを追加（ユーザーが所属する全 Workspace を取得）
- `SqlAlchemyWorkspaceRepository` に SQLAlchemy 実装を追加
- `CaptainQueryService` を application 層に追加（読み取り専用、UoW/EventDispatcher 不要）
- テスト用 `InMemoryWorkspaceRepository` に `get_by_member_user_id` の実装を追加
- ユニットテスト 8 ケースを追加

## 設計判断

- Workspace コンテキスト内に配置（Workspace の階層データにアクセスするため）
- Record コンテキストからは ID 経由で呼び出す想定
- キャッシュ不要（都度計算。Workspace 階層変更が過去の Record に影響しないため）
- 読み取り専用のクエリサービスのため UoW・EventDispatcher は不要

## テスト計画

- [x] 所属 Workspace がない場合は空リストを返す
- [x] 所属 Workspace の Captain を返す
- [x] 祖先 Workspace の Captain を含む
- [x] 複数 Workspace 間で重複する Captain を解消
- [x] 共通祖先の Captain を重複なく返す
- [x] Member ロールのユーザーは除外
- [x] 1つの Workspace に複数 Captain がいる場合に全員返す
- [x] 深い階層を再帰的に辿る

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)