### PR TITLE
feat(preparation): アドホック相談ユースケースの実装

### DIFF
--- a/backend/contexts/preparation/application/accept_consultation_request_service.py
+++ b/backend/contexts/preparation/application/accept_consultation_request_service.py
@@ -1,0 +1,94 @@
+"""Use case: Accept a consultation request (ad-hoc pattern B).
+
+The organizer accepts the consultation request, confirming the schedule.
+The Schedule transitions from REQUESTED to CONFIRMED.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.exceptions import UnauthorizedScheduleOperationError
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.value_objects import ScheduleId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class ScheduleNotFoundError(Exception):
+    """Raised when the specified Schedule does not exist."""
+
+    def __init__(self, schedule_id: ScheduleId) -> None:
+        self.schedule_id = schedule_id
+        super().__init__(f"Schedule not found: {schedule_id.value}")
+
+
+@dataclass(frozen=True)
+class AcceptConsultationRequestInput:
+    """Input DTO for AcceptConsultationRequestService."""
+
+    schedule_id: ScheduleId
+    actor_id: UserId
+
+
+class AcceptConsultationRequestService:
+    """Application service that accepts a consultation request.
+
+    Only the organizer can accept (confirm) a consultation request
+    sent by the counterpart.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        schedule_repo: ScheduleRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._schedule_repo = schedule_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: AcceptConsultationRequestInput,
+    ) -> None:
+        """Accept the consultation request.
+
+        The organizer confirms the schedule. The domain's confirm()
+        method handles the pending ConfirmationRequest approval and
+        status transition.
+
+        Args:
+            input_dto: Input parameters for accepting.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+            UnauthorizedScheduleOperationError: If the actor is not
+                the organizer.
+            ScheduleAlreadyCancelledError: If the schedule is cancelled.
+            NoPendingConfirmationRequestError: If no pending request.
+        """
+        now = datetime.now(UTC)
+
+        schedule = await self._schedule_repo.get_by_id(input_dto.schedule_id)
+        if schedule is None:
+            raise ScheduleNotFoundError(input_dto.schedule_id)
+
+        # Only the organizer can accept a consultation request
+        if input_dto.actor_id != schedule.organizer_id:
+            raise UnauthorizedScheduleOperationError(
+                "Only the organizer can accept a consultation request."
+            )
+
+        schedule.confirm(actor_id=input_dto.actor_id, now=now)
+
+        events: list[DomainEvent] = list(schedule.collect_events())
+
+        async with self._uow:
+            await self._schedule_repo.save(schedule)
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/reject_consultation_request_service.py
+++ b/backend/contexts/preparation/application/reject_consultation_request_service.py
@@ -1,0 +1,96 @@
+"""Use case: Reject a consultation request (ad-hoc pattern B).
+
+The organizer rejects the consultation request.
+Since this is a CREATION-type ConfirmationRequest, rejecting it
+cancels the schedule entirely (ScheduleCancelled event).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.exceptions import UnauthorizedScheduleOperationError
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.value_objects import ScheduleId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class ScheduleNotFoundError(Exception):
+    """Raised when the specified Schedule does not exist."""
+
+    def __init__(self, schedule_id: ScheduleId) -> None:
+        self.schedule_id = schedule_id
+        super().__init__(f"Schedule not found: {schedule_id.value}")
+
+
+@dataclass(frozen=True)
+class RejectConsultationRequestInput:
+    """Input DTO for RejectConsultationRequestService."""
+
+    schedule_id: ScheduleId
+    actor_id: UserId
+
+
+class RejectConsultationRequestService:
+    """Application service that rejects a consultation request.
+
+    Only the organizer can reject a consultation request sent by
+    the counterpart. Rejecting a CREATION-type request cancels
+    the schedule entirely.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        schedule_repo: ScheduleRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._schedule_repo = schedule_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: RejectConsultationRequestInput,
+    ) -> None:
+        """Reject the consultation request.
+
+        The organizer rejects the schedule. The domain's reject()
+        method handles the pending ConfirmationRequest rejection.
+        For CREATION-type requests, this results in schedule cancellation.
+
+        Args:
+            input_dto: Input parameters for rejecting.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+            UnauthorizedScheduleOperationError: If the actor is not
+                the organizer.
+            ScheduleAlreadyCancelledError: If the schedule is cancelled.
+            NoPendingConfirmationRequestError: If no pending request.
+        """
+        now = datetime.now(UTC)
+
+        schedule = await self._schedule_repo.get_by_id(input_dto.schedule_id)
+        if schedule is None:
+            raise ScheduleNotFoundError(input_dto.schedule_id)
+
+        # Only the organizer can reject a consultation request
+        if input_dto.actor_id != schedule.organizer_id:
+            raise UnauthorizedScheduleOperationError(
+                "Only the organizer can reject a consultation request."
+            )
+
+        schedule.reject(actor_id=input_dto.actor_id, now=now)
+
+        events: list[DomainEvent] = list(schedule.collect_events())
+
+        async with self._uow:
+            await self._schedule_repo.save(schedule)
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/send_consultation_request_service.py
+++ b/backend/contexts/preparation/application/send_consultation_request_service.py
@@ -1,0 +1,125 @@
+"""Use case: Send a consultation request (ad-hoc pattern B).
+
+The counterpart sends a consultation request to the organizer.
+A Schedule is created in REQUESTED status with a CREATION-type
+ConfirmationRequest. The counterpart provides agendas.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.agenda_repository import AgendaRepository
+from contexts.preparation.domain.exceptions import UnauthorizedScheduleOperationError
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.topic import Topic
+from contexts.preparation.domain.value_objects import ScheduleId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class SendConsultationRequestInput:
+    """Input DTO for SendConsultationRequestService."""
+
+    organizer_id: UserId
+    counterpart_id: UserId
+    scheduled_at: datetime
+    title: str
+    agenda_topics: list[str]
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class SendConsultationRequestOutput:
+    """Output DTO for SendConsultationRequestService."""
+
+    schedule_id: ScheduleId
+
+
+class SendConsultationRequestService:
+    """Application service for ad-hoc consultation requests.
+
+    The counterpart initiates a consultation request to the organizer.
+    The organizer cannot send a consultation request (only the counterpart can).
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        schedule_repo: ScheduleRepository,
+        agenda_repo: AgendaRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._schedule_repo = schedule_repo
+        self._agenda_repo = agenda_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: SendConsultationRequestInput,
+    ) -> SendConsultationRequestOutput:
+        """Send a consultation request.
+
+        Only the counterpart can send a consultation request.
+        The organizer cannot initiate this flow.
+
+        Args:
+            input_dto: Input parameters for the consultation request.
+
+        Returns:
+            Output containing the id of the newly created schedule.
+
+        Raises:
+            UnauthorizedScheduleOperationError: If the actor is not the
+                counterpart (e.g. organizer attempts to send).
+            InvalidScheduleOperationError: If organizer == counterpart
+                or scheduled_at is in the past.
+        """
+        if input_dto.actor_id != input_dto.counterpart_id:
+            raise UnauthorizedScheduleOperationError(
+                "Only the counterpart can send a consultation request."
+            )
+
+        now = datetime.now(UTC)
+        schedule_title = ScheduleTitle(input_dto.title)
+
+        # The counterpart is the requester in ad-hoc consultation
+        schedule = Schedule.create(
+            organizer_id=input_dto.organizer_id,
+            counterpart_id=input_dto.counterpart_id,
+            scheduled_at=input_dto.scheduled_at,
+            requested_by=input_dto.counterpart_id,
+            title=schedule_title,
+            now=now,
+        )
+
+        # Create agendas from the counterpart's topics
+        agendas: list[Agenda] = []
+        for topic_str in input_dto.agenda_topics:
+            agenda = Agenda.create(
+                schedule_id=schedule.id,
+                topic=Topic(topic_str),
+                added_by=input_dto.counterpart_id,
+                now=now,
+            )
+            agendas.append(agenda)
+
+        events: list[DomainEvent] = list(schedule.collect_events())
+
+        async with self._uow:
+            await self._schedule_repo.save(schedule)
+            if agendas:
+                await self._agenda_repo.save_all(agendas)
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)
+
+        return SendConsultationRequestOutput(schedule_id=schedule.id)

--- a/backend/tests/contexts/preparation/application/test_accept_consultation_request_service.py
+++ b/backend/tests/contexts/preparation/application/test_accept_consultation_request_service.py
@@ -1,0 +1,215 @@
+"""Tests for AcceptConsultationRequestService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.accept_consultation_request_service import (
+    AcceptConsultationRequestInput,
+    AcceptConsultationRequestService,
+    ScheduleNotFoundError,
+)
+from contexts.preparation.domain.events import ScheduleConfirmed
+from contexts.preparation.domain.exceptions import (
+    ScheduleAlreadyCancelledError,
+    UnauthorizedScheduleOperationError,
+)
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import ScheduleId, ScheduleStatus
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryScheduleRepository,
+    StubUnitOfWork,
+)
+
+
+def _create_consultation_schedule(
+    organizer: UserId,
+    counterpart: UserId,
+    scheduled_at: datetime | None = None,
+) -> Schedule:
+    """Helper to create a schedule in REQUESTED status via counterpart request."""
+    ts = scheduled_at or datetime.now(UTC) + timedelta(days=1)
+    schedule = Schedule.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        scheduled_at=ts,
+        requested_by=counterpart,
+        title=ScheduleTitle("Consultation"),
+    )
+    schedule.collect_events()  # Clear creation events
+    return schedule
+
+
+class TestAcceptConsultationRequest:
+    """Accept a consultation request (ad-hoc pattern B)."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> AcceptConsultationRequestService:
+        return AcceptConsultationRequestService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_confirms_schedule(
+        self,
+        service: AcceptConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Schedule transitions from REQUESTED to CONFIRMED."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        await service.execute(
+            AcceptConsultationRequestInput(
+                schedule_id=schedule.id,
+                actor_id=organizer,
+            )
+        )
+
+        updated = await schedule_repo.get_by_id(schedule.id)
+        assert updated is not None
+        assert updated.status == ScheduleStatus.CONFIRMED
+
+    async def test_dispatches_confirmed_event(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """ScheduleConfirmed event is dispatched after commit."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(ScheduleConfirmed, capture)  # type: ignore[arg-type]
+
+        service = AcceptConsultationRequestService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        await service.execute(
+            AcceptConsultationRequestInput(
+                schedule_id=schedule.id,
+                actor_id=organizer,
+            )
+        )
+
+        assert len(dispatched) == 1
+        event = dispatched[0]
+        assert isinstance(event, ScheduleConfirmed)
+        assert event.confirmed_by == organizer
+        assert event.is_auto is False
+
+    async def test_counterpart_cannot_accept(
+        self,
+        service: AcceptConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Counterpart cannot accept a consultation request."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            await service.execute(
+                AcceptConsultationRequestInput(
+                    schedule_id=schedule.id,
+                    actor_id=counterpart,
+                )
+            )
+
+    async def test_third_party_cannot_accept(
+        self,
+        service: AcceptConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """A third-party user cannot accept a consultation request."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            await service.execute(
+                AcceptConsultationRequestInput(
+                    schedule_id=schedule.id,
+                    actor_id=outsider,
+                )
+            )
+
+    async def test_schedule_not_found(
+        self,
+        service: AcceptConsultationRequestService,
+    ) -> None:
+        """Raises ScheduleNotFoundError for non-existent schedule."""
+        with pytest.raises(ScheduleNotFoundError):
+            await service.execute(
+                AcceptConsultationRequestInput(
+                    schedule_id=ScheduleId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_cancelled_schedule_cannot_be_accepted(
+        self,
+        service: AcceptConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Raises ScheduleAlreadyCancelledError for cancelled schedule."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        schedule.cancel(actor_id=organizer, now=datetime.now(UTC))
+        schedule.collect_events()
+        await schedule_repo.save(schedule)
+
+        with pytest.raises(ScheduleAlreadyCancelledError):
+            await service.execute(
+                AcceptConsultationRequestInput(
+                    schedule_id=schedule.id,
+                    actor_id=organizer,
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: AcceptConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+        uow: StubUnitOfWork,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        await service.execute(
+            AcceptConsultationRequestInput(
+                schedule_id=schedule.id,
+                actor_id=organizer,
+            )
+        )
+        assert uow.committed is True

--- a/backend/tests/contexts/preparation/application/test_reject_consultation_request_service.py
+++ b/backend/tests/contexts/preparation/application/test_reject_consultation_request_service.py
@@ -1,0 +1,214 @@
+"""Tests for RejectConsultationRequestService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.reject_consultation_request_service import (
+    RejectConsultationRequestInput,
+    RejectConsultationRequestService,
+    ScheduleNotFoundError,
+)
+from contexts.preparation.domain.events import ScheduleCancelled
+from contexts.preparation.domain.exceptions import (
+    ScheduleAlreadyCancelledError,
+    UnauthorizedScheduleOperationError,
+)
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import ScheduleId, ScheduleStatus
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryScheduleRepository,
+    StubUnitOfWork,
+)
+
+
+def _create_consultation_schedule(
+    organizer: UserId,
+    counterpart: UserId,
+    scheduled_at: datetime | None = None,
+) -> Schedule:
+    """Helper to create a schedule in REQUESTED status via counterpart request."""
+    ts = scheduled_at or datetime.now(UTC) + timedelta(days=1)
+    schedule = Schedule.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        scheduled_at=ts,
+        requested_by=counterpart,
+        title=ScheduleTitle("Consultation"),
+    )
+    schedule.collect_events()  # Clear creation events
+    return schedule
+
+
+class TestRejectConsultationRequest:
+    """Reject a consultation request (ad-hoc pattern B)."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> RejectConsultationRequestService:
+        return RejectConsultationRequestService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_cancels_schedule(
+        self,
+        service: RejectConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Rejecting a CREATION-type request cancels the schedule."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        await service.execute(
+            RejectConsultationRequestInput(
+                schedule_id=schedule.id,
+                actor_id=organizer,
+            )
+        )
+
+        updated = await schedule_repo.get_by_id(schedule.id)
+        assert updated is not None
+        assert updated.status == ScheduleStatus.CANCELLED
+
+    async def test_dispatches_cancelled_event(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """ScheduleCancelled event is dispatched (not ScheduleRejected)."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(ScheduleCancelled, capture)  # type: ignore[arg-type]
+
+        service = RejectConsultationRequestService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        await service.execute(
+            RejectConsultationRequestInput(
+                schedule_id=schedule.id,
+                actor_id=organizer,
+            )
+        )
+
+        assert len(dispatched) == 1
+        event = dispatched[0]
+        assert isinstance(event, ScheduleCancelled)
+        assert event.cancelled_by == organizer
+
+    async def test_counterpart_cannot_reject(
+        self,
+        service: RejectConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Counterpart cannot reject a consultation request."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            await service.execute(
+                RejectConsultationRequestInput(
+                    schedule_id=schedule.id,
+                    actor_id=counterpart,
+                )
+            )
+
+    async def test_third_party_cannot_reject(
+        self,
+        service: RejectConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """A third-party user cannot reject a consultation request."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            await service.execute(
+                RejectConsultationRequestInput(
+                    schedule_id=schedule.id,
+                    actor_id=outsider,
+                )
+            )
+
+    async def test_schedule_not_found(
+        self,
+        service: RejectConsultationRequestService,
+    ) -> None:
+        """Raises ScheduleNotFoundError for non-existent schedule."""
+        with pytest.raises(ScheduleNotFoundError):
+            await service.execute(
+                RejectConsultationRequestInput(
+                    schedule_id=ScheduleId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_cancelled_schedule_cannot_be_rejected(
+        self,
+        service: RejectConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Raises ScheduleAlreadyCancelledError for cancelled schedule."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        schedule.cancel(actor_id=organizer, now=datetime.now(UTC))
+        schedule.collect_events()
+        await schedule_repo.save(schedule)
+
+        with pytest.raises(ScheduleAlreadyCancelledError):
+            await service.execute(
+                RejectConsultationRequestInput(
+                    schedule_id=schedule.id,
+                    actor_id=organizer,
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: RejectConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+        uow: StubUnitOfWork,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _create_consultation_schedule(organizer, counterpart)
+        await schedule_repo.save(schedule)
+
+        await service.execute(
+            RejectConsultationRequestInput(
+                schedule_id=schedule.id,
+                actor_id=organizer,
+            )
+        )
+        assert uow.committed is True

--- a/backend/tests/contexts/preparation/application/test_send_consultation_request_service.py
+++ b/backend/tests/contexts/preparation/application/test_send_consultation_request_service.py
@@ -1,0 +1,286 @@
+"""Tests for SendConsultationRequestService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.send_consultation_request_service import (
+    SendConsultationRequestInput,
+    SendConsultationRequestOutput,
+    SendConsultationRequestService,
+)
+from contexts.preparation.domain.events import ScheduleCreated
+from contexts.preparation.domain.exceptions import (
+    InvalidScheduleOperationError,
+    UnauthorizedScheduleOperationError,
+)
+from contexts.preparation.domain.value_objects import (
+    ConfirmationRequestType,
+    ConfirmationResolution,
+    ScheduleStatus,
+)
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryAgendaRepository,
+    InMemoryScheduleRepository,
+    StubUnitOfWork,
+)
+
+
+class TestSendConsultationRequest:
+    """Send a consultation request (ad-hoc pattern B)."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> SendConsultationRequestService:
+        return SendConsultationRequestService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_creates_requested_schedule(
+        self,
+        service: SendConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Schedule is created in REQUESTED status with counterpart as requester."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        output = await service.execute(
+            SendConsultationRequestInput(
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                scheduled_at=scheduled_at,
+                title="Ad-hoc consultation",
+                agenda_topics=["Topic A"],
+                actor_id=counterpart,
+            )
+        )
+
+        assert isinstance(output, SendConsultationRequestOutput)
+        schedule = await schedule_repo.get_by_id(output.schedule_id)
+        assert schedule is not None
+        assert schedule.status == ScheduleStatus.REQUESTED
+        assert schedule.organizer_id == organizer
+        assert schedule.counterpart_id == counterpart
+
+    async def test_creates_creation_type_confirmation_request(
+        self,
+        service: SendConsultationRequestService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """A CREATION-type ConfirmationRequest is generated as pending."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        output = await service.execute(
+            SendConsultationRequestInput(
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                scheduled_at=scheduled_at,
+                title="Ad-hoc consultation",
+                agenda_topics=[],
+                actor_id=counterpart,
+            )
+        )
+
+        schedule = await schedule_repo.get_by_id(output.schedule_id)
+        assert schedule is not None
+        requests = schedule.confirmation_requests
+        assert len(requests) == 1
+        assert requests[0].request_type == ConfirmationRequestType.CREATION
+        assert requests[0].resolution == ConfirmationResolution.PENDING
+        assert requests[0].requested_by == counterpart
+
+    async def test_creates_agendas(
+        self,
+        service: SendConsultationRequestService,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Counterpart's agenda topics are persisted."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        output = await service.execute(
+            SendConsultationRequestInput(
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                scheduled_at=scheduled_at,
+                title="Ad-hoc consultation",
+                agenda_topics=["Career discussion", "Project update"],
+                actor_id=counterpart,
+            )
+        )
+
+        agendas = await agenda_repo.get_by_schedule_id(output.schedule_id)
+        assert len(agendas) == 2
+        topics = {a.topic.value for a in agendas}
+        assert topics == {"Career discussion", "Project update"}
+        for agenda in agendas:
+            assert agenda.added_by == counterpart
+
+    async def test_dispatches_schedule_created_event(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """ScheduleCreated event is dispatched after commit."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(ScheduleCreated, capture)  # type: ignore[arg-type]
+
+        service = SendConsultationRequestService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        await service.execute(
+            SendConsultationRequestInput(
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                scheduled_at=scheduled_at,
+                title="Ad-hoc consultation",
+                agenda_topics=[],
+                actor_id=counterpart,
+            )
+        )
+
+        assert len(dispatched) == 1
+        event = dispatched[0]
+        assert isinstance(event, ScheduleCreated)
+        assert event.requested_by == counterpart
+
+    async def test_organizer_cannot_send_consultation_request(
+        self,
+        service: SendConsultationRequestService,
+    ) -> None:
+        """Organizer attempting to send raises UnauthorizedScheduleOperationError."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            await service.execute(
+                SendConsultationRequestInput(
+                    organizer_id=organizer,
+                    counterpart_id=counterpart,
+                    scheduled_at=scheduled_at,
+                    title="Ad-hoc consultation",
+                    agenda_topics=[],
+                    actor_id=organizer,
+                )
+            )
+
+    async def test_third_party_cannot_send_consultation_request(
+        self,
+        service: SendConsultationRequestService,
+    ) -> None:
+        """A third-party user cannot send a consultation request."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        with pytest.raises(UnauthorizedScheduleOperationError):
+            await service.execute(
+                SendConsultationRequestInput(
+                    organizer_id=organizer,
+                    counterpart_id=counterpart,
+                    scheduled_at=scheduled_at,
+                    title="Ad-hoc consultation",
+                    agenda_topics=[],
+                    actor_id=outsider,
+                )
+            )
+
+    async def test_rejects_past_datetime(
+        self,
+        service: SendConsultationRequestService,
+    ) -> None:
+        """Raises InvalidScheduleOperationError for past scheduled_at."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        past_time = datetime.now(UTC) - timedelta(days=1)
+
+        with pytest.raises(InvalidScheduleOperationError):
+            await service.execute(
+                SendConsultationRequestInput(
+                    organizer_id=organizer,
+                    counterpart_id=counterpart,
+                    scheduled_at=past_time,
+                    title="Ad-hoc consultation",
+                    agenda_topics=[],
+                    actor_id=counterpart,
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: SendConsultationRequestService,
+        uow: StubUnitOfWork,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        await service.execute(
+            SendConsultationRequestInput(
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                scheduled_at=scheduled_at,
+                title="Ad-hoc consultation",
+                agenda_topics=[],
+                actor_id=counterpart,
+            )
+        )
+        assert uow.committed is True
+
+    async def test_no_agendas_is_valid(
+        self,
+        service: SendConsultationRequestService,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Empty agenda_topics list is allowed (counterpart may add later)."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        scheduled_at = datetime.now(UTC) + timedelta(days=1)
+
+        output = await service.execute(
+            SendConsultationRequestInput(
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                scheduled_at=scheduled_at,
+                title="Ad-hoc consultation",
+                agenda_topics=[],
+                actor_id=counterpart,
+            )
+        )
+
+        agendas = await agenda_repo.get_by_schedule_id(output.schedule_id)
+        assert len(agendas) == 0


### PR DESCRIPTION
## Summary

- カウンターパートが相談リクエストを送信するユースケース（SendConsultationRequestService）を追加
- オーガナイザーが相談リクエストを承認するユースケース（AcceptConsultationRequestService）を追加
- オーガナイザーが相談リクエストを却下するユースケース（RejectConsultationRequestService）を追加

### 権限制御
- 相談リクエスト送信: カウンターパートのみ（オーガナイザー・第三者は不可）
- 承認/却下: オーガナイザーのみ（カウンターパート・第三者は不可）

### 状態遷移
- 送信: Schedule を REQUESTED 状態で作成、CREATION タイプの ConfirmationRequest を生成
- 承認: REQUESTED -> CONFIRMED（ScheduleConfirmed イベント発行）
- 却下: CREATION タイプの却下 -> CANCELLED（ScheduleCancelled イベント発行）

### テスト
- 23 件のユニットテスト（全て DB 非依存）

## Test plan
- [x] 送信: カウンターパートが REQUESTED 状態のスケジュールを作成できる
- [x] 送信: CREATION タイプの ConfirmationRequest が生成される
- [x] 送信: アジェンダが永続化される
- [x] 送信: ScheduleCreated イベントが dispatch される
- [x] 送信: オーガナイザーは送信できない
- [x] 送信: 第三者は送信できない
- [x] 送信: 過去の日時は拒否される
- [x] 承認: CONFIRMED に遷移する
- [x] 承認: ScheduleConfirmed イベントが dispatch される
- [x] 承認: カウンターパートは承認できない
- [x] 承認: 第三者は承認できない
- [x] 却下: CANCELLED に遷移する
- [x] 却下: ScheduleCancelled イベントが dispatch される
- [x] 却下: カウンターパートは却下できない
- [x] 却下: 第三者は却下できない
- [x] UoW commit が正しく呼ばれる

Closes #79

Generated with [Claude Code](https://claude.com/claude-code)
