### PR TITLE
Preparation: アジェンダ管理ユースケース

### DIFF
--- a/backend/contexts/preparation/application/add_agenda_comment_service.py
+++ b/backend/contexts/preparation/application/add_agenda_comment_service.py
@@ -1,0 +1,134 @@
+"""Use case: Add a comment to an agenda topic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda_repository import AgendaRepository
+from contexts.preparation.domain.comment_body import CommentBody
+from contexts.preparation.domain.events import AgendaCommentAdded
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.value_objects import AgendaId, CommentId, ScheduleId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class AgendaNotFoundError(Exception):
+    """Raised when the specified Agenda does not exist."""
+
+    def __init__(self, agenda_id: AgendaId) -> None:
+        self.agenda_id = agenda_id
+        super().__init__(f"Agenda not found: {agenda_id.value}")
+
+
+class ScheduleNotFoundError(Exception):
+    """Raised when the specified Schedule does not exist."""
+
+    def __init__(self, schedule_id: ScheduleId) -> None:
+        self.schedule_id = schedule_id
+        super().__init__(f"Schedule not found: {schedule_id.value}")
+
+
+class UnauthorizedAgendaCommentError(Exception):
+    """Raised when a user without permission attempts to comment on an agenda."""
+
+    def __init__(
+        self,
+        message: str = "Only organizer or counterpart can comment on agendas.",
+    ) -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class AddAgendaCommentInput:
+    """Input DTO for AddAgendaCommentService."""
+
+    agenda_id: AgendaId
+    body: str
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class AddAgendaCommentOutput:
+    """Output DTO for AddAgendaCommentService."""
+
+    comment_id: CommentId
+
+
+class AddAgendaCommentService:
+    """Application service that adds a comment to an agenda topic.
+
+    Both organizer and counterpart can comment on any agenda.
+    Comments are always public (no private comments).
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        schedule_repo: ScheduleRepository,
+        agenda_repo: AgendaRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._schedule_repo = schedule_repo
+        self._agenda_repo = agenda_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(self, input_dto: AddAgendaCommentInput) -> AddAgendaCommentOutput:
+        """Add a comment to the agenda topic.
+
+        Args:
+            input_dto: Input parameters for adding a comment.
+
+        Returns:
+            Output containing the newly created comment ID.
+
+        Raises:
+            AgendaNotFoundError: If the agenda does not exist.
+            ScheduleNotFoundError: If the parent schedule does not exist.
+            UnauthorizedAgendaCommentError: If actor is not a participant.
+        """
+        now = datetime.now(UTC)
+
+        agenda = await self._agenda_repo.get_by_id(input_dto.agenda_id)
+        if agenda is None:
+            raise AgendaNotFoundError(input_dto.agenda_id)
+
+        schedule = await self._schedule_repo.get_by_id(agenda.schedule_id)
+        if schedule is None:
+            raise ScheduleNotFoundError(agenda.schedule_id)
+
+        # Permission check: only organizer or counterpart
+        if (
+            input_dto.actor_id != schedule.organizer_id
+            and input_dto.actor_id != schedule.counterpart_id
+        ):
+            raise UnauthorizedAgendaCommentError()
+
+        body = CommentBody(input_dto.body)
+        comment = agenda.add_comment(
+            author_id=input_dto.actor_id,
+            body=body,
+            now=now,
+        )
+
+        events: list[DomainEvent] = [
+            AgendaCommentAdded(
+                comment_id=comment.id,
+                agenda_id=agenda.id,
+                schedule_id=agenda.schedule_id,
+                author_id=input_dto.actor_id,
+                occurred_at=now,
+            )
+        ]
+
+        async with self._uow:
+            await self._agenda_repo.save(agenda)
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)
+
+        return AddAgendaCommentOutput(comment_id=comment.id)

--- a/backend/contexts/preparation/application/add_agenda_service.py
+++ b/backend/contexts/preparation/application/add_agenda_service.py
@@ -1,0 +1,129 @@
+"""Use case: Add an agenda topic to an individual Schedule."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.agenda_repository import AgendaRepository
+from contexts.preparation.domain.events import AgendaAdded
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.topic import Topic
+from contexts.preparation.domain.value_objects import AddedByTag, AgendaId, ScheduleId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class ScheduleNotFoundError(Exception):
+    """Raised when the specified Schedule does not exist."""
+
+    def __init__(self, schedule_id: ScheduleId) -> None:
+        self.schedule_id = schedule_id
+        super().__init__(f"Schedule not found: {schedule_id.value}")
+
+
+class UnauthorizedAgendaOperationError(Exception):
+    """Raised when a user without permission attempts an agenda operation."""
+
+    def __init__(
+        self, message: str = "Only organizer or counterpart can manage agendas."
+    ) -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class AddAgendaInput:
+    """Input DTO for AddAgendaService."""
+
+    schedule_id: ScheduleId
+    topic: str
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class AddAgendaOutput:
+    """Output DTO for AddAgendaService."""
+
+    agenda_id: AgendaId
+
+
+class AddAgendaService:
+    """Application service that adds an agenda topic to an individual schedule.
+
+    Both organizer and counterpart can add agendas.
+    The added_by_tag is determined by the actor's role in the schedule.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        schedule_repo: ScheduleRepository,
+        agenda_repo: AgendaRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._schedule_repo = schedule_repo
+        self._agenda_repo = agenda_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(self, input_dto: AddAgendaInput) -> AddAgendaOutput:
+        """Add an agenda topic to the schedule.
+
+        Args:
+            input_dto: Input parameters for adding an agenda.
+
+        Returns:
+            Output containing the newly created agenda ID.
+
+        Raises:
+            ScheduleNotFoundError: If the schedule does not exist.
+            UnauthorizedAgendaOperationError: If actor is not a participant.
+        """
+        now = datetime.now(UTC)
+
+        schedule = await self._schedule_repo.get_by_id(input_dto.schedule_id)
+        if schedule is None:
+            raise ScheduleNotFoundError(input_dto.schedule_id)
+
+        # Permission check: only organizer or counterpart
+        if (
+            input_dto.actor_id != schedule.organizer_id
+            and input_dto.actor_id != schedule.counterpart_id
+        ):
+            raise UnauthorizedAgendaOperationError()
+
+        # Determine added_by_tag based on actor role
+        added_by_tag = (
+            AddedByTag.ORGANIZER
+            if input_dto.actor_id == schedule.organizer_id
+            else AddedByTag.COUNTERPART
+        )
+
+        topic = Topic(input_dto.topic)
+        agenda = Agenda.create(
+            schedule_id=input_dto.schedule_id,
+            topic=topic,
+            added_by=input_dto.actor_id,
+            added_by_tag=added_by_tag,
+            now=now,
+        )
+
+        events: list[DomainEvent] = [
+            AgendaAdded(
+                agenda_id=agenda.id,
+                schedule_id=input_dto.schedule_id,
+                added_by=input_dto.actor_id,
+                occurred_at=now,
+            )
+        ]
+
+        async with self._uow:
+            await self._agenda_repo.save(agenda)
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)
+
+        return AddAgendaOutput(agenda_id=agenda.id)

--- a/backend/contexts/preparation/application/create_schedule_group_service.py
+++ b/backend/contexts/preparation/application/create_schedule_group_service.py
@@ -15,7 +15,11 @@ from contexts.preparation.domain.schedule_group_repository import (
 )
 from contexts.preparation.domain.schedule_repository import ScheduleRepository
 from contexts.preparation.domain.schedule_title import ScheduleTitle
-from contexts.preparation.domain.value_objects import ScheduleGroupId, TemplateId
+from contexts.preparation.domain.value_objects import (
+    AddedByTag,
+    ScheduleGroupId,
+    TemplateId,
+)
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
 from shared.domain.events import DomainEvent
@@ -125,6 +129,7 @@ class CreateScheduleGroupService:
                     schedule_id=schedule.id,
                     topic=tmpl.topic,
                     added_by=input_dto.organizer_id,
+                    added_by_tag=AddedByTag.TEMPLATE,
                     now=now,
                 )
                 all_agendas.append(agenda)

--- a/backend/contexts/preparation/application/delete_agenda_service.py
+++ b/backend/contexts/preparation/application/delete_agenda_service.py
@@ -1,0 +1,110 @@
+"""Use case: Delete an agenda topic from a Schedule."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda_repository import AgendaRepository
+from contexts.preparation.domain.events import AgendaDeleted
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class AgendaNotFoundError(Exception):
+    """Raised when the specified Agenda does not exist."""
+
+    def __init__(self, agenda_id: AgendaId) -> None:
+        self.agenda_id = agenda_id
+        super().__init__(f"Agenda not found: {agenda_id.value}")
+
+
+class ScheduleNotFoundError(Exception):
+    """Raised when the specified Schedule does not exist."""
+
+    def __init__(self, schedule_id: ScheduleId) -> None:
+        self.schedule_id = schedule_id
+        super().__init__(f"Schedule not found: {schedule_id.value}")
+
+
+class UnauthorizedAgendaOperationError(Exception):
+    """Raised when a user without permission attempts an agenda operation."""
+
+    def __init__(
+        self, message: str = "Only organizer or counterpart can manage agendas."
+    ) -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class DeleteAgendaInput:
+    """Input DTO for DeleteAgendaService."""
+
+    agenda_id: AgendaId
+    actor_id: UserId
+
+
+class DeleteAgendaService:
+    """Application service that deletes an agenda topic from a schedule.
+
+    Both organizer and counterpart can delete agendas.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        schedule_repo: ScheduleRepository,
+        agenda_repo: AgendaRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._schedule_repo = schedule_repo
+        self._agenda_repo = agenda_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(self, input_dto: DeleteAgendaInput) -> None:
+        """Delete the agenda topic.
+
+        Args:
+            input_dto: Input parameters for deleting an agenda.
+
+        Raises:
+            AgendaNotFoundError: If the agenda does not exist.
+            ScheduleNotFoundError: If the parent schedule does not exist.
+            UnauthorizedAgendaOperationError: If actor is not a participant.
+        """
+        now = datetime.now(UTC)
+
+        agenda = await self._agenda_repo.get_by_id(input_dto.agenda_id)
+        if agenda is None:
+            raise AgendaNotFoundError(input_dto.agenda_id)
+
+        schedule = await self._schedule_repo.get_by_id(agenda.schedule_id)
+        if schedule is None:
+            raise ScheduleNotFoundError(agenda.schedule_id)
+
+        # Permission check: only organizer or counterpart
+        if (
+            input_dto.actor_id != schedule.organizer_id
+            and input_dto.actor_id != schedule.counterpart_id
+        ):
+            raise UnauthorizedAgendaOperationError()
+
+        events: list[DomainEvent] = [
+            AgendaDeleted(
+                agenda_id=agenda.id,
+                schedule_id=agenda.schedule_id,
+                deleted_by=input_dto.actor_id,
+                occurred_at=now,
+            )
+        ]
+
+        async with self._uow:
+            await self._agenda_repo.delete_by_ids([agenda.id])
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/domain/agenda.py
+++ b/backend/contexts/preparation/domain/agenda.py
@@ -6,7 +6,12 @@ from datetime import UTC, datetime
 from contexts.preparation.domain.comment import Comment
 from contexts.preparation.domain.comment_body import CommentBody
 from contexts.preparation.domain.topic import Topic
-from contexts.preparation.domain.value_objects import AgendaId, CommentId, ScheduleId
+from contexts.preparation.domain.value_objects import (
+    AddedByTag,
+    AgendaId,
+    CommentId,
+    ScheduleId,
+)
 from shared.domain.value_objects import UserId
 
 
@@ -28,6 +33,7 @@ class Agenda:
     _schedule_id: ScheduleId
     _topic: Topic
     _added_by: UserId
+    _added_by_tag: AddedByTag
     _comments: list[Comment]
     _created_at: datetime
 
@@ -48,6 +54,10 @@ class Agenda:
         return self._added_by
 
     @property
+    def added_by_tag(self) -> AddedByTag:
+        return self._added_by_tag
+
+    @property
     def comments(self) -> list[Comment]:
         return list(self._comments)
 
@@ -61,6 +71,7 @@ class Agenda:
         schedule_id: ScheduleId,
         topic: Topic,
         added_by: UserId,
+        added_by_tag: AddedByTag,
         now: datetime | None = None,
     ) -> Agenda:
         """Factory method to create a new agenda item."""
@@ -70,6 +81,7 @@ class Agenda:
             _schedule_id=schedule_id,
             _topic=topic,
             _added_by=added_by,
+            _added_by_tag=added_by_tag,
             _comments=[],
             _created_at=ts,
         )

--- a/backend/contexts/preparation/domain/events.py
+++ b/backend/contexts/preparation/domain/events.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from contexts.preparation.domain.value_objects import (
     AgendaId,
+    CommentId,
     ScheduleGroupId,
     ScheduleId,
     TemplateId,
@@ -114,6 +115,42 @@ class AgendaRemovedViaGroup(DomainEvent):
     schedule_group_id: ScheduleGroupId
     topic: str
     removed_agenda_ids: list[AgendaId]
+
+
+# ------------------------------------------------------------------
+# Agenda events (individual schedule)
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgendaAdded(DomainEvent):
+    """Raised when an agenda topic is added to a schedule."""
+
+    agenda_id: AgendaId
+    schedule_id: ScheduleId
+    added_by: UserId
+
+
+@dataclass(frozen=True)
+class AgendaDeleted(DomainEvent):
+    """Raised when an agenda topic is deleted from a schedule."""
+
+    agenda_id: AgendaId
+    schedule_id: ScheduleId
+    deleted_by: UserId
+
+
+@dataclass(frozen=True)
+class AgendaCommentAdded(DomainEvent):
+    """Raised when a comment is added to an agenda topic.
+
+    This event triggers Slack notification (Preparation context).
+    """
+
+    comment_id: CommentId
+    agenda_id: AgendaId
+    schedule_id: ScheduleId
+    author_id: UserId
 
 
 # ------------------------------------------------------------------

--- a/backend/contexts/preparation/domain/schedule_group.py
+++ b/backend/contexts/preparation/domain/schedule_group.py
@@ -20,6 +20,7 @@ from contexts.preparation.domain.schedule import Schedule
 from contexts.preparation.domain.schedule_title import ScheduleTitle
 from contexts.preparation.domain.topic import Topic
 from contexts.preparation.domain.value_objects import (
+    AddedByTag,
     AgendaId,
     ScheduleGroupId,
     ScheduleId,
@@ -238,6 +239,7 @@ class ScheduleGroup:
                 schedule_id=schedule_id,
                 topic=agenda_template.topic,
                 added_by=actor_id,
+                added_by_tag=AddedByTag.TEMPLATE,
                 now=now,
             )
             new_agendas.append(agenda)

--- a/backend/contexts/preparation/domain/value_objects.py
+++ b/backend/contexts/preparation/domain/value_objects.py
@@ -43,6 +43,19 @@ class ScheduleStatus(Enum):
     CANCELLED = "cancelled"
 
 
+class AddedByTag(Enum):
+    """Tag indicating who added an agenda item.
+
+    - TEMPLATE: expanded from a schedule group's agenda template.
+    - ORGANIZER: added directly by the organizer.
+    - COUNTERPART: added directly by the counterpart.
+    """
+
+    TEMPLATE = "template"
+    ORGANIZER = "organizer"
+    COUNTERPART = "counterpart"
+
+
 class ConfirmationRequestType(Enum):
     """Type of confirmation request."""
 

--- a/backend/tests/contexts/preparation/application/test_add_agenda_comment_service.py
+++ b/backend/tests/contexts/preparation/application/test_add_agenda_comment_service.py
@@ -1,0 +1,250 @@
+"""Tests for AddAgendaCommentService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.add_agenda_comment_service import (
+    AddAgendaCommentInput,
+    AddAgendaCommentOutput,
+    AddAgendaCommentService,
+    AgendaNotFoundError,
+    UnauthorizedAgendaCommentError,
+)
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.events import AgendaCommentAdded
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.topic import Topic
+from contexts.preparation.domain.value_objects import AddedByTag, AgendaId
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryAgendaRepository,
+    InMemoryScheduleRepository,
+    StubUnitOfWork,
+)
+
+
+def _create_confirmed_schedule(
+    organizer: UserId,
+    counterpart: UserId,
+    now: datetime,
+) -> Schedule:
+    """Helper: create and auto-confirm a schedule."""
+    schedule = Schedule.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        scheduled_at=now + timedelta(days=1),
+        requested_by=organizer,
+        title=ScheduleTitle("Test Schedule"),
+        now=now,
+    )
+    schedule.auto_confirm(now=now)
+    schedule.collect_events()  # Drain factory events
+    return schedule
+
+
+def _create_agenda(
+    schedule: Schedule,
+    organizer: UserId,
+    now: datetime,
+) -> Agenda:
+    """Helper: create an agenda for the given schedule."""
+    return Agenda.create(
+        schedule_id=schedule.id,
+        topic=Topic("Test topic"),
+        added_by=organizer,
+        added_by_tag=AddedByTag.ORGANIZER,
+        now=now,
+    )
+
+
+class TestAddAgendaComment:
+    """Add a comment to an agenda topic."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> AddAgendaCommentService:
+        return AddAgendaCommentService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_organizer_adds_comment(
+        self,
+        service: AddAgendaCommentService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Organizer can add a comment to an agenda."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        output = await service.execute(
+            AddAgendaCommentInput(
+                agenda_id=agenda.id,
+                body="Let's focus on timeline",
+                actor_id=organizer,
+            )
+        )
+
+        assert isinstance(output, AddAgendaCommentOutput)
+        updated = await agenda_repo.get_by_id(agenda.id)
+        assert updated is not None
+        assert len(updated.comments) == 1
+        assert updated.comments[0].author_id == organizer
+        assert updated.comments[0].body.value == "Let's focus on timeline"
+
+    async def test_counterpart_adds_comment(
+        self,
+        service: AddAgendaCommentService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Counterpart can add a comment to an agenda."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        output = await service.execute(
+            AddAgendaCommentInput(
+                agenda_id=agenda.id,
+                body="I have a question",
+                actor_id=counterpart,
+            )
+        )
+
+        updated = await agenda_repo.get_by_id(agenda.id)
+        assert updated is not None
+        assert len(updated.comments) == 1
+        assert updated.comments[0].id == output.comment_id
+        assert updated.comments[0].author_id == counterpart
+
+    async def test_dispatches_agenda_comment_added_event(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Dispatches AgendaCommentAdded event after commit."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(AgendaCommentAdded, capture)  # type: ignore[arg-type]
+
+        service = AddAgendaCommentService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        output = await service.execute(
+            AddAgendaCommentInput(
+                agenda_id=agenda.id,
+                body="Event test comment",
+                actor_id=organizer,
+            )
+        )
+
+        assert len(dispatched) == 1
+        event = dispatched[0]
+        assert isinstance(event, AgendaCommentAdded)
+        assert event.comment_id == output.comment_id
+        assert event.agenda_id == agenda.id
+        assert event.schedule_id == schedule.id
+        assert event.author_id == organizer
+
+    async def test_rejects_non_participant(
+        self,
+        service: AddAgendaCommentService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Raises UnauthorizedAgendaCommentError for non-participant."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        with pytest.raises(UnauthorizedAgendaCommentError):
+            await service.execute(
+                AddAgendaCommentInput(
+                    agenda_id=agenda.id,
+                    body="Should fail",
+                    actor_id=outsider,
+                )
+            )
+
+    async def test_raises_agenda_not_found(
+        self,
+        service: AddAgendaCommentService,
+    ) -> None:
+        """Raises AgendaNotFoundError for nonexistent agenda."""
+        with pytest.raises(AgendaNotFoundError):
+            await service.execute(
+                AddAgendaCommentInput(
+                    agenda_id=AgendaId.generate(),
+                    body="No agenda",
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: AddAgendaCommentService,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        await service.execute(
+            AddAgendaCommentInput(
+                agenda_id=agenda.id,
+                body="Commit test",
+                actor_id=organizer,
+            )
+        )
+        assert uow.committed is True

--- a/backend/tests/contexts/preparation/application/test_add_agenda_service.py
+++ b/backend/tests/contexts/preparation/application/test_add_agenda_service.py
@@ -1,0 +1,217 @@
+"""Tests for AddAgendaService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.add_agenda_service import (
+    AddAgendaInput,
+    AddAgendaService,
+    ScheduleNotFoundError,
+    UnauthorizedAgendaOperationError,
+)
+from contexts.preparation.domain.events import AgendaAdded
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import AddedByTag, ScheduleId
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryAgendaRepository,
+    InMemoryScheduleRepository,
+    StubUnitOfWork,
+)
+
+
+def _create_confirmed_schedule(
+    organizer: UserId,
+    counterpart: UserId,
+    now: datetime,
+) -> Schedule:
+    """Helper: create and auto-confirm a schedule."""
+    schedule = Schedule.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        scheduled_at=now + timedelta(days=1),
+        requested_by=organizer,
+        title=ScheduleTitle("Test Schedule"),
+        now=now,
+    )
+    schedule.auto_confirm(now=now)
+    schedule.collect_events()  # Drain factory events
+    return schedule
+
+
+class TestAddAgenda:
+    """Add an agenda topic to a schedule."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> AddAgendaService:
+        return AddAgendaService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_organizer_adds_agenda(
+        self,
+        service: AddAgendaService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Organizer can add an agenda topic."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(
+            AddAgendaInput(
+                schedule_id=schedule.id,
+                topic="Discuss project status",
+                actor_id=organizer,
+            )
+        )
+
+        agenda = await agenda_repo.get_by_id(output.agenda_id)
+        assert agenda is not None
+        assert agenda.topic.value == "Discuss project status"
+        assert agenda.added_by == organizer
+        assert agenda.added_by_tag == AddedByTag.ORGANIZER
+
+    async def test_counterpart_adds_agenda(
+        self,
+        service: AddAgendaService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Counterpart can add an agenda topic."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(
+            AddAgendaInput(
+                schedule_id=schedule.id,
+                topic="My topic",
+                actor_id=counterpart,
+            )
+        )
+
+        agenda = await agenda_repo.get_by_id(output.agenda_id)
+        assert agenda is not None
+        assert agenda.added_by == counterpart
+        assert agenda.added_by_tag == AddedByTag.COUNTERPART
+
+    async def test_dispatches_agenda_added_event(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Dispatches AgendaAdded event after commit."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(AgendaAdded, capture)  # type: ignore[arg-type]
+
+        service = AddAgendaService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(
+            AddAgendaInput(
+                schedule_id=schedule.id,
+                topic="Event test",
+                actor_id=organizer,
+            )
+        )
+
+        assert len(dispatched) == 1
+        event = dispatched[0]
+        assert isinstance(event, AgendaAdded)
+        assert event.agenda_id == output.agenda_id
+        assert event.schedule_id == schedule.id
+        assert event.added_by == organizer
+
+    async def test_rejects_non_participant(
+        self,
+        service: AddAgendaService,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Raises UnauthorizedAgendaOperationError for non-participant."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+
+        with pytest.raises(UnauthorizedAgendaOperationError):
+            await service.execute(
+                AddAgendaInput(
+                    schedule_id=schedule.id,
+                    topic="Should fail",
+                    actor_id=outsider,
+                )
+            )
+
+    async def test_raises_schedule_not_found(
+        self,
+        service: AddAgendaService,
+    ) -> None:
+        """Raises ScheduleNotFoundError for nonexistent schedule."""
+        with pytest.raises(ScheduleNotFoundError):
+            await service.execute(
+                AddAgendaInput(
+                    schedule_id=ScheduleId.generate(),
+                    topic="No schedule",
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: AddAgendaService,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+
+        await service.execute(
+            AddAgendaInput(
+                schedule_id=schedule.id,
+                topic="Commit test",
+                actor_id=organizer,
+            )
+        )
+        assert uow.committed is True

--- a/backend/tests/contexts/preparation/application/test_delete_agenda_service.py
+++ b/backend/tests/contexts/preparation/application/test_delete_agenda_service.py
@@ -1,0 +1,218 @@
+"""Tests for DeleteAgendaService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.delete_agenda_service import (
+    AgendaNotFoundError,
+    DeleteAgendaInput,
+    DeleteAgendaService,
+    UnauthorizedAgendaOperationError,
+)
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.events import AgendaDeleted
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.topic import Topic
+from contexts.preparation.domain.value_objects import AddedByTag, AgendaId
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryAgendaRepository,
+    InMemoryScheduleRepository,
+    StubUnitOfWork,
+)
+
+
+def _create_confirmed_schedule(
+    organizer: UserId,
+    counterpart: UserId,
+    now: datetime,
+) -> Schedule:
+    """Helper: create and auto-confirm a schedule."""
+    schedule = Schedule.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        scheduled_at=now + timedelta(days=1),
+        requested_by=organizer,
+        title=ScheduleTitle("Test Schedule"),
+        now=now,
+    )
+    schedule.auto_confirm(now=now)
+    schedule.collect_events()  # Drain factory events
+    return schedule
+
+
+def _create_agenda(
+    schedule: Schedule,
+    organizer: UserId,
+    now: datetime,
+) -> Agenda:
+    """Helper: create an agenda for the given schedule."""
+    return Agenda.create(
+        schedule_id=schedule.id,
+        topic=Topic("Test topic"),
+        added_by=organizer,
+        added_by_tag=AddedByTag.ORGANIZER,
+        now=now,
+    )
+
+
+class TestDeleteAgenda:
+    """Delete an agenda topic from a schedule."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> DeleteAgendaService:
+        return DeleteAgendaService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_organizer_deletes_agenda(
+        self,
+        service: DeleteAgendaService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Organizer can delete an agenda topic."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        await service.execute(
+            DeleteAgendaInput(agenda_id=agenda.id, actor_id=organizer)
+        )
+
+        assert await agenda_repo.get_by_id(agenda.id) is None
+
+    async def test_counterpart_deletes_agenda(
+        self,
+        service: DeleteAgendaService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Counterpart can also delete an agenda topic."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        await service.execute(
+            DeleteAgendaInput(agenda_id=agenda.id, actor_id=counterpart)
+        )
+
+        assert await agenda_repo.get_by_id(agenda.id) is None
+
+    async def test_dispatches_agenda_deleted_event(
+        self,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Dispatches AgendaDeleted event after commit."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(AgendaDeleted, capture)  # type: ignore[arg-type]
+
+        service = DeleteAgendaService(
+            uow=uow,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        await service.execute(
+            DeleteAgendaInput(agenda_id=agenda.id, actor_id=organizer)
+        )
+
+        assert len(dispatched) == 1
+        event = dispatched[0]
+        assert isinstance(event, AgendaDeleted)
+        assert event.agenda_id == agenda.id
+        assert event.schedule_id == schedule.id
+        assert event.deleted_by == organizer
+
+    async def test_rejects_non_participant(
+        self,
+        service: DeleteAgendaService,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Raises UnauthorizedAgendaOperationError for non-participant."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        with pytest.raises(UnauthorizedAgendaOperationError):
+            await service.execute(
+                DeleteAgendaInput(agenda_id=agenda.id, actor_id=outsider)
+            )
+
+    async def test_raises_agenda_not_found(
+        self,
+        service: DeleteAgendaService,
+    ) -> None:
+        """Raises AgendaNotFoundError for nonexistent agenda."""
+        with pytest.raises(AgendaNotFoundError):
+            await service.execute(
+                DeleteAgendaInput(
+                    agenda_id=AgendaId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: DeleteAgendaService,
+        uow: StubUnitOfWork,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        now = datetime.now(UTC)
+        schedule = _create_confirmed_schedule(organizer, counterpart, now)
+        await schedule_repo.save(schedule)
+        agenda = _create_agenda(schedule, organizer, now)
+        await agenda_repo.save(agenda)
+
+        await service.execute(
+            DeleteAgendaInput(agenda_id=agenda.id, actor_id=organizer)
+        )
+        assert uow.committed is True

--- a/backend/tests/contexts/preparation/application/test_remove_agenda_from_group_service.py
+++ b/backend/tests/contexts/preparation/application/test_remove_agenda_from_group_service.py
@@ -21,7 +21,7 @@ from contexts.preparation.domain.schedule import Schedule
 from contexts.preparation.domain.schedule_group import ScheduleGroup
 from contexts.preparation.domain.schedule_title import ScheduleTitle
 from contexts.preparation.domain.topic import Topic
-from contexts.preparation.domain.value_objects import ScheduleGroupId
+from contexts.preparation.domain.value_objects import AddedByTag, ScheduleGroupId
 from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
 from shared.domain.value_objects import UserId
 from tests.contexts.preparation.application.conftest import (
@@ -68,6 +68,7 @@ async def _setup_group_with_agendas(
                 schedule_id=schedule.id,
                 topic=Topic(t),
                 added_by=organizer,
+                added_by_tag=AddedByTag.TEMPLATE,
                 now=now,
             )
             await agenda_repo.save(agenda)

--- a/backend/tests/contexts/preparation/domain/test_agenda.py
+++ b/backend/tests/contexts/preparation/domain/test_agenda.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from contexts.preparation.domain.agenda import Agenda
 from contexts.preparation.domain.comment_body import CommentBody
 from contexts.preparation.domain.topic import Topic
-from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.preparation.domain.value_objects import AddedByTag, ScheduleId
 from shared.domain.value_objects import UserId
 
 _NOW = datetime(2026, 3, 20, 10, 0)
@@ -16,12 +16,14 @@ def _make_agenda(
     schedule_id: ScheduleId | None = None,
     topic: Topic = _DEFAULT_TOPIC,
     added_by: UserId | None = None,
+    added_by_tag: AddedByTag = AddedByTag.ORGANIZER,
     now: datetime = _NOW,
 ) -> Agenda:
     return Agenda.create(
         schedule_id=schedule_id or ScheduleId.generate(),
         topic=topic,
         added_by=added_by or UserId.generate(),
+        added_by_tag=added_by_tag,
         now=now,
     )
 


### PR DESCRIPTION
## Summary
- アジェンダ追加・削除・コメント追加の3つのユースケースを application 層に実装
- AddedByTag enum（TEMPLATE / ORGANIZER / COUNTERPART）を追加し、誰が追加したかのタグを記録
- AgendaAdded / AgendaDeleted / AgendaCommentAdded ドメインイベントを追加
- 権限チェック（オーガナイザー or カウンターパートのみ操作可能）
- commit 後にドメインイベントをディスパッチ

## 変更内容

### ドメイン層
- `value_objects.py`: `AddedByTag` enum 追加
- `agenda.py`: `added_by_tag` フィールド追加、`create()` ファクトリメソッド更新
- `events.py`: `AgendaAdded`, `AgendaDeleted`, `AgendaCommentAdded` イベント追加
- 既存の `Agenda.create()` 呼び出し元（schedule_group, create_schedule_group_service, テスト）を更新

### アプリケーション層
- `add_agenda_service.py`: アジェンダ追加ユースケース
- `delete_agenda_service.py`: アジェンダ削除ユースケース
- `add_agenda_comment_service.py`: アジェンダコメント追加ユースケース

### テスト
- 各ユースケースのユニットテスト（権限チェック、イベント発行、UoW commit、エラーハンドリング）

## Test plan
- [x] `uv run pytest -m 'not integration'` -- 579 passed
- [x] `uv run ruff check . && uv run ruff format --check .` -- All checks passed
- [x] `uv run pyright` -- 0 errors

Closes #80

Generated with [Claude Code](https://claude.com/claude-code)
