### PR TITLE
feat(record): アクションアイテム完了ユースケース

### DIFF
--- a/backend/contexts/record/application/complete_action_item.py
+++ b/backend/contexts/record/application/complete_action_item.py
@@ -1,0 +1,86 @@
+"""Use case: Complete an ActionItem.
+
+The counterpart marks an action item as completed.
+Action items are tied to the counterpart (person), not to a record.
+After a successful commit the ActionItemCompleted domain event is dispatched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.value_objects import ActionItemId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class ActionItemNotFoundError(Exception):
+    """Raised when the specified action item does not exist."""
+
+    def __init__(self, action_item_id: ActionItemId) -> None:
+        self.action_item_id = action_item_id
+        super().__init__(f"Action item not found: {action_item_id.value}")
+
+
+@dataclass(frozen=True)
+class CompleteActionItemInput:
+    """Input DTO for CompleteActionItemUseCase."""
+
+    action_item_id: ActionItemId
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class CompleteActionItemOutput:
+    """Output DTO for CompleteActionItemUseCase."""
+
+    action_item_id: ActionItemId
+
+
+class CompleteActionItemUseCase:
+    """Complete an action item.
+
+    Workflow:
+    1. Load the action item and verify it exists.
+    2. Complete (counterpart check delegated to ActionItem.complete).
+    3. Save within a transaction.
+    4. Dispatch domain events after commit.
+    """
+
+    def __init__(
+        self,
+        *,
+        action_item_repository: ActionItemRepository,
+        unit_of_work: UnitOfWork,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._action_item_repository = action_item_repository
+        self._unit_of_work = unit_of_work
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self, input_dto: CompleteActionItemInput
+    ) -> CompleteActionItemOutput:
+        now = datetime.now(UTC)
+
+        async with self._unit_of_work:
+            action_item = await self._action_item_repository.get_by_id(
+                input_dto.action_item_id
+            )
+            if action_item is None:
+                raise ActionItemNotFoundError(input_dto.action_item_id)
+
+            action_item.complete(actor_id=input_dto.actor_id, now=now)
+
+            await self._action_item_repository.save(action_item)
+            await self._unit_of_work.commit()
+
+        # Dispatch events after successful commit
+        events: list[DomainEvent] = list(action_item.collect_events())
+        await self._event_dispatcher.dispatch(events)
+
+        return CompleteActionItemOutput(action_item_id=action_item.id)

--- a/backend/tests/contexts/record/application/test_complete_action_item.py
+++ b/backend/tests/contexts/record/application/test_complete_action_item.py
@@ -1,0 +1,217 @@
+"""Tests for CompleteActionItemUseCase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from contexts.record.application.complete_action_item import (
+    ActionItemNotFoundError,
+    CompleteActionItemInput,
+    CompleteActionItemOutput,
+    CompleteActionItemUseCase,
+)
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.events import ActionItemCompleted
+from contexts.record.domain.exceptions import (
+    ActionItemAlreadyCompletedError,
+    UnauthorizedOperationError,
+)
+from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle, RecordId
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    FakeUnitOfWork,
+    InMemoryActionItemRepository,
+    SpyEventDispatcher,
+)
+
+
+def _make_action_item(
+    *,
+    organizer_id: UserId | None = None,
+    counterpart_id: UserId | None = None,
+    record_id: RecordId | None = None,
+) -> ActionItem:
+    org = organizer_id or UserId.generate()
+    return ActionItem.create(
+        counterpart_id=counterpart_id or UserId.generate(),
+        record_id=record_id or RecordId.generate(),
+        title=ActionItemTitle("Follow up on project status"),
+        actor_id=org,
+        organizer_id=org,
+        now=datetime(2026, 3, 20, 10, 30),
+    )
+
+
+def _build_use_case(
+    *,
+    action_item_repo: InMemoryActionItemRepository | None = None,
+    uow: FakeUnitOfWork | None = None,
+    event_dispatcher: SpyEventDispatcher | None = None,
+) -> tuple[
+    CompleteActionItemUseCase,
+    InMemoryActionItemRepository,
+    FakeUnitOfWork,
+    SpyEventDispatcher,
+]:
+    air = action_item_repo or InMemoryActionItemRepository()
+    u = uow or FakeUnitOfWork()
+    ed = event_dispatcher or SpyEventDispatcher()
+    uc = CompleteActionItemUseCase(
+        action_item_repository=air,
+        unit_of_work=u,
+        event_dispatcher=ed,
+    )
+    return uc, air, u, ed
+
+
+class TestCompleteActionItem:
+    """Tests for successful action item completion."""
+
+    async def test_counterpart_can_complete_action_item(self) -> None:
+        counterpart = UserId.generate()
+        item = _make_action_item(counterpart_id=counterpart)
+        uc, air, _uow, _ed = _build_use_case()
+        await air.save(item)
+        item.collect_events()  # clear creation event
+
+        output = await uc.execute(
+            CompleteActionItemInput(
+                action_item_id=item.id,
+                actor_id=counterpart,
+            )
+        )
+
+        assert isinstance(output, CompleteActionItemOutput)
+        assert output.action_item_id == item.id
+        saved = await air.get_by_id(item.id)
+        assert saved is not None
+        assert saved.is_completed is True
+
+    async def test_commits_transaction(self) -> None:
+        counterpart = UserId.generate()
+        item = _make_action_item(counterpart_id=counterpart)
+        uc, air, uow, _ed = _build_use_case()
+        await air.save(item)
+        item.collect_events()
+
+        await uc.execute(
+            CompleteActionItemInput(
+                action_item_id=item.id,
+                actor_id=counterpart,
+            )
+        )
+
+        assert uow.committed is True
+
+    async def test_dispatches_action_item_completed_event(self) -> None:
+        counterpart = UserId.generate()
+        item = _make_action_item(counterpart_id=counterpart)
+        uc, air, _uow, ed = _build_use_case()
+        await air.save(item)
+        item.collect_events()  # clear creation event
+
+        await uc.execute(
+            CompleteActionItemInput(
+                action_item_id=item.id,
+                actor_id=counterpart,
+            )
+        )
+
+        completed_events = [
+            e for e in ed.dispatched_events if isinstance(e, ActionItemCompleted)
+        ]
+        assert len(completed_events) == 1
+        event = completed_events[0]
+        assert event.action_item_id == item.id
+        assert event.counterpart_id == counterpart
+
+
+class TestCompleteActionItemErrors:
+    """Tests for error conditions."""
+
+    async def test_raises_when_action_item_not_found(self) -> None:
+        uc, _air, _uow, _ed = _build_use_case()
+
+        with pytest.raises(ActionItemNotFoundError):
+            await uc.execute(
+                CompleteActionItemInput(
+                    action_item_id=ActionItemId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_raises_when_actor_is_not_counterpart(self) -> None:
+        counterpart = UserId.generate()
+        organizer = UserId.generate()
+        item = _make_action_item(organizer_id=organizer, counterpart_id=counterpart)
+        uc, air, _uow, _ed = _build_use_case()
+        await air.save(item)
+        item.collect_events()
+
+        with pytest.raises(UnauthorizedOperationError, match="Only the counterpart"):
+            await uc.execute(
+                CompleteActionItemInput(
+                    action_item_id=item.id,
+                    actor_id=organizer,
+                )
+            )
+
+    async def test_raises_when_already_completed(self) -> None:
+        counterpart = UserId.generate()
+        item = _make_action_item(counterpart_id=counterpart)
+        item.complete(actor_id=counterpart, now=datetime(2026, 3, 21, 9, 0))
+        uc, air, _uow, _ed = _build_use_case()
+        await air.save(item)
+        item.collect_events()
+
+        with pytest.raises(ActionItemAlreadyCompletedError, match="already completed"):
+            await uc.execute(
+                CompleteActionItemInput(
+                    action_item_id=item.id,
+                    actor_id=counterpart,
+                )
+            )
+
+    async def test_raises_when_third_party_tries_to_complete(self) -> None:
+        counterpart = UserId.generate()
+        third_party = UserId.generate()
+        item = _make_action_item(counterpart_id=counterpart)
+        uc, air, _uow, _ed = _build_use_case()
+        await air.save(item)
+        item.collect_events()
+
+        with pytest.raises(UnauthorizedOperationError):
+            await uc.execute(
+                CompleteActionItemInput(
+                    action_item_id=item.id,
+                    actor_id=third_party,
+                )
+            )
+
+    async def test_does_not_commit_on_error(self) -> None:
+        uc, _air, uow, _ed = _build_use_case()
+
+        with pytest.raises(ActionItemNotFoundError):
+            await uc.execute(
+                CompleteActionItemInput(
+                    action_item_id=ActionItemId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+        assert uow.committed is False
+
+    async def test_does_not_dispatch_events_on_error(self) -> None:
+        uc, _air, _uow, ed = _build_use_case()
+
+        with pytest.raises(ActionItemNotFoundError):
+            await uc.execute(
+                CompleteActionItemInput(
+                    action_item_id=ActionItemId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+        assert ed.dispatched_events == []


### PR DESCRIPTION
Closes #85

## Summary
- カウンターパートのみがアクションアイテムを完了にできるユースケースを実装
- 権限チェック・完了済み再完了のドメイン例外・ActionItemCompleted イベント発行
- ユニットテスト9件（正常系3件、異常系6件）

## Test plan
- [x] ruff check / format OK
- [x] pyright 0 errors
- [x] pytest unit 621 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)