### PR TITLE
feat(preparation): テンプレート運用ユースケース

### DIFF
--- a/backend/contexts/preparation/application/create_schedule_group_from_past_service.py
+++ b/backend/contexts/preparation/application/create_schedule_group_from_past_service.py
@@ -1,0 +1,173 @@
+"""Use case: Create a ScheduleGroup by copying from a past ScheduleGroup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.agenda_repository import AgendaRepository
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.schedule_group_repository import (
+    ScheduleGroupRepository,
+)
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import AddedByTag, ScheduleGroupId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class PastCounterpartSchedule:
+    """Per-counterpart scheduling parameters when copying from past."""
+
+    counterpart_id: UserId
+    scheduled_at: datetime
+
+
+@dataclass(frozen=True)
+class CreateScheduleGroupFromPastInput:
+    """Input DTO for CreateScheduleGroupFromPastService.
+
+    The organizer references a past ScheduleGroup whose agenda structure
+    will be copied into a new ScheduleGroup.
+    """
+
+    organizer_id: UserId
+    source_schedule_group_id: ScheduleGroupId
+    title: str
+    counterpart_schedules: list[PastCounterpartSchedule]
+
+
+@dataclass(frozen=True)
+class CreateScheduleGroupFromPastOutput:
+    """Output DTO for CreateScheduleGroupFromPastService."""
+
+    schedule_group_id: ScheduleGroupId
+
+
+class SourceScheduleGroupNotFoundError(Exception):
+    """Raised when the source schedule group does not exist."""
+
+    def __init__(self, message: str = "Source schedule group not found.") -> None:
+        super().__init__(message)
+
+
+class UnauthorizedCopyError(Exception):
+    """Raised when the actor is not the organizer of the source group."""
+
+    def __init__(
+        self,
+        message: str = "Only the organizer of the source group can copy it.",
+    ) -> None:
+        super().__init__(message)
+
+
+class CreateScheduleGroupFromPastService:
+    """Application service that creates a ScheduleGroup by copying a past one.
+
+    The source group's agenda templates are copied into the new group.
+    The organizer provides new counterparts and schedules.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        schedule_group_repo: ScheduleGroupRepository,
+        schedule_repo: ScheduleRepository,
+        agenda_repo: AgendaRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._schedule_group_repo = schedule_group_repo
+        self._schedule_repo = schedule_repo
+        self._agenda_repo = agenda_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: CreateScheduleGroupFromPastInput,
+    ) -> CreateScheduleGroupFromPastOutput:
+        """Create a schedule group by copying from a past group.
+
+        Args:
+            input_dto: Input parameters for copying a schedule group.
+
+        Returns:
+            Output containing the id of the newly created schedule group.
+
+        Raises:
+            SourceScheduleGroupNotFoundError: If the source group does
+                not exist.
+            UnauthorizedCopyError: If the actor is not the organizer of
+                the source group.
+        """
+        now = datetime.now(UTC)
+
+        source = await self._schedule_group_repo.get_by_id(
+            input_dto.source_schedule_group_id
+        )
+        if source is None:
+            raise SourceScheduleGroupNotFoundError()
+
+        if source.organizer_id != input_dto.organizer_id:
+            raise UnauthorizedCopyError()
+
+        schedule_title = ScheduleTitle(input_dto.title)
+
+        group = ScheduleGroup.create(
+            organizer_id=input_dto.organizer_id,
+            title=schedule_title,
+            agenda_templates=list(source.agenda_templates),
+            template_id=None,
+            now=now,
+        )
+
+        all_events: list[DomainEvent] = []
+        all_agendas: list[Agenda] = []
+        schedules: list[Schedule] = []
+
+        for cs in input_dto.counterpart_schedules:
+            schedule = Schedule.create(
+                organizer_id=input_dto.organizer_id,
+                counterpart_id=cs.counterpart_id,
+                scheduled_at=cs.scheduled_at,
+                requested_by=input_dto.organizer_id,
+                title=schedule_title,
+                schedule_group_id=group.id,
+                now=now,
+            )
+            group.register_schedule(schedule.id)
+            schedules.append(schedule)
+
+            for tmpl in group.agenda_templates:
+                agenda = Agenda.create(
+                    schedule_id=schedule.id,
+                    topic=tmpl.topic,
+                    added_by=input_dto.organizer_id,
+                    added_by_tag=AddedByTag.TEMPLATE,
+                    now=now,
+                )
+                all_agendas.append(agenda)
+
+        for schedule in schedules:
+            all_events.extend(schedule.collect_events())
+        all_events.extend(group.collect_events())
+
+        async with self._uow:
+            await self._schedule_group_repo.save(group)
+            for schedule in schedules:
+                await self._schedule_repo.save(schedule)
+            if all_agendas:
+                await self._agenda_repo.save_all(all_agendas)
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(all_events)
+
+        return CreateScheduleGroupFromPastOutput(
+            schedule_group_id=group.id,
+        )

--- a/backend/contexts/preparation/application/create_schedule_group_from_template_service.py
+++ b/backend/contexts/preparation/application/create_schedule_group_from_template_service.py
@@ -1,0 +1,179 @@
+"""Use case: Create a ScheduleGroup from a saved template."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.agenda_repository import AgendaRepository
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.schedule_group_repository import (
+    ScheduleGroupRepository,
+)
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.template_repository import TemplateRepository
+from contexts.preparation.domain.value_objects import (
+    AddedByTag,
+    ScheduleGroupId,
+    TemplateId,
+)
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class TemplateCounterpartSchedule:
+    """Per-counterpart scheduling parameters when creating from a template."""
+
+    counterpart_id: UserId
+    scheduled_at: datetime
+
+
+@dataclass(frozen=True)
+class CreateScheduleGroupFromTemplateInput:
+    """Input DTO for CreateScheduleGroupFromTemplateService.
+
+    The organizer can override counterparts from the template defaults,
+    but must provide scheduled_at for each counterpart.
+    """
+
+    organizer_id: UserId
+    template_id: TemplateId
+    title: str
+    counterpart_schedules: list[TemplateCounterpartSchedule]
+
+
+@dataclass(frozen=True)
+class CreateScheduleGroupFromTemplateOutput:
+    """Output DTO for CreateScheduleGroupFromTemplateService."""
+
+    schedule_group_id: ScheduleGroupId
+
+
+class TemplateNotFoundError(Exception):
+    """Raised when the referenced template does not exist."""
+
+    def __init__(self, message: str = "Template not found.") -> None:
+        super().__init__(message)
+
+
+class UnauthorizedTemplateUseError(Exception):
+    """Raised when the actor is not the template owner."""
+
+    def __init__(
+        self,
+        message: str = "Only the template owner can create a group from this template.",
+    ) -> None:
+        super().__init__(message)
+
+
+class CreateScheduleGroupFromTemplateService:
+    """Application service that creates a ScheduleGroup from a saved template.
+
+    The template's agenda topics are expanded into Agenda entities for
+    each Schedule. The organizer provides counterpart schedules (which
+    may differ from template defaults).
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        template_repo: TemplateRepository,
+        schedule_group_repo: ScheduleGroupRepository,
+        schedule_repo: ScheduleRepository,
+        agenda_repo: AgendaRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._template_repo = template_repo
+        self._schedule_group_repo = schedule_group_repo
+        self._schedule_repo = schedule_repo
+        self._agenda_repo = agenda_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: CreateScheduleGroupFromTemplateInput,
+    ) -> CreateScheduleGroupFromTemplateOutput:
+        """Create a schedule group from a template.
+
+        Args:
+            input_dto: Input parameters for creating a schedule group
+                from a template.
+
+        Returns:
+            Output containing the id of the newly created schedule group.
+
+        Raises:
+            TemplateNotFoundError: If the template does not exist.
+            UnauthorizedTemplateUseError: If the actor is not the
+                template owner.
+        """
+        now = datetime.now(UTC)
+
+        template = await self._template_repo.get_by_id(input_dto.template_id)
+        if template is None:
+            raise TemplateNotFoundError()
+
+        if template.organizer_id != input_dto.organizer_id:
+            raise UnauthorizedTemplateUseError()
+
+        schedule_title = ScheduleTitle(input_dto.title)
+
+        group = ScheduleGroup.create(
+            organizer_id=input_dto.organizer_id,
+            title=schedule_title,
+            agenda_templates=list(template.agenda_templates),
+            template_id=template.id,
+            now=now,
+        )
+
+        all_events: list[DomainEvent] = []
+        all_agendas: list[Agenda] = []
+        schedules: list[Schedule] = []
+
+        for cs in input_dto.counterpart_schedules:
+            schedule = Schedule.create(
+                organizer_id=input_dto.organizer_id,
+                counterpart_id=cs.counterpart_id,
+                scheduled_at=cs.scheduled_at,
+                requested_by=input_dto.organizer_id,
+                title=schedule_title,
+                schedule_group_id=group.id,
+                now=now,
+            )
+            group.register_schedule(schedule.id)
+            schedules.append(schedule)
+
+            for tmpl in group.agenda_templates:
+                agenda = Agenda.create(
+                    schedule_id=schedule.id,
+                    topic=tmpl.topic,
+                    added_by=input_dto.organizer_id,
+                    added_by_tag=AddedByTag.TEMPLATE,
+                    now=now,
+                )
+                all_agendas.append(agenda)
+
+        for schedule in schedules:
+            all_events.extend(schedule.collect_events())
+        all_events.extend(group.collect_events())
+
+        async with self._uow:
+            await self._schedule_group_repo.save(group)
+            for schedule in schedules:
+                await self._schedule_repo.save(schedule)
+            if all_agendas:
+                await self._agenda_repo.save_all(all_agendas)
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(all_events)
+
+        return CreateScheduleGroupFromTemplateOutput(
+            schedule_group_id=group.id,
+        )

--- a/backend/contexts/preparation/application/get_template_service.py
+++ b/backend/contexts/preparation/application/get_template_service.py
@@ -1,0 +1,94 @@
+"""Use case: Get a specific template by ID."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.preparation.domain.template_repository import TemplateRepository
+from contexts.preparation.domain.value_objects import TemplateId
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class GetTemplateInput:
+    """Input DTO for GetTemplateService."""
+
+    template_id: TemplateId
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class GetTemplateOutput:
+    """Output DTO for GetTemplateService."""
+
+    template_id: TemplateId
+    organizer_id: UserId
+    name: str
+    default_counterpart_ids: list[UserId]
+    agenda_topics: list[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+class TemplateNotFoundError(Exception):
+    """Raised when the requested template does not exist."""
+
+    def __init__(self, message: str = "Template not found.") -> None:
+        super().__init__(message)
+
+
+class UnauthorizedTemplateAccessError(Exception):
+    """Raised when the actor is not the template owner."""
+
+    def __init__(
+        self, message: str = "Only the template owner can access this template."
+    ) -> None:
+        super().__init__(message)
+
+
+class GetTemplateService:
+    """Application service that retrieves a single template.
+
+    Only the owning organizer can retrieve a template.
+    """
+
+    def __init__(
+        self,
+        template_repo: TemplateRepository,
+    ) -> None:
+        self._template_repo = template_repo
+
+    async def execute(
+        self,
+        input_dto: GetTemplateInput,
+    ) -> GetTemplateOutput:
+        """Get a template by ID.
+
+        Args:
+            input_dto: Input containing the template ID and actor.
+
+        Returns:
+            Output containing the template details.
+
+        Raises:
+            TemplateNotFoundError: If the template does not exist.
+            UnauthorizedTemplateAccessError: If the actor is not the
+                template owner.
+        """
+        template = await self._template_repo.get_by_id(input_dto.template_id)
+        if template is None:
+            raise TemplateNotFoundError()
+
+        if template.organizer_id != input_dto.actor_id:
+            raise UnauthorizedTemplateAccessError()
+
+        return GetTemplateOutput(
+            template_id=template.id,
+            organizer_id=template.organizer_id,
+            name=template.name.value,
+            default_counterpart_ids=template.default_counterparts,
+            agenda_topics=[at.topic.value for at in template.agenda_templates],
+            created_at=template.created_at,
+            updated_at=template.updated_at,
+        )

--- a/backend/contexts/preparation/application/list_templates_service.py
+++ b/backend/contexts/preparation/application/list_templates_service.py
@@ -26,7 +26,7 @@ class TemplateListItem:
 class ListTemplatesInput:
     """Input DTO for ListTemplatesService."""
 
-    organizer_id: UserId
+    actor_id: UserId
 
 
 @dataclass(frozen=True)
@@ -52,15 +52,17 @@ class ListTemplatesService:
         self,
         input_dto: ListTemplatesInput,
     ) -> ListTemplatesOutput:
-        """List all templates for the given organizer.
+        """List all templates owned by the actor.
+
+        The actor can only list their own templates.
 
         Args:
-            input_dto: Input containing the organizer ID.
+            input_dto: Input containing the actor ID.
 
         Returns:
             Output containing the list of templates.
         """
-        templates = await self._template_repo.list_by_organizer(input_dto.organizer_id)
+        templates = await self._template_repo.list_by_organizer(input_dto.actor_id)
 
         items = [
             TemplateListItem(

--- a/backend/contexts/preparation/application/list_templates_service.py
+++ b/backend/contexts/preparation/application/list_templates_service.py
@@ -1,0 +1,77 @@
+"""Use case: List all templates owned by an organizer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.preparation.domain.template_repository import TemplateRepository
+from contexts.preparation.domain.value_objects import TemplateId
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class TemplateListItem:
+    """A single item in the template list."""
+
+    template_id: TemplateId
+    name: str
+    default_counterpart_ids: list[UserId]
+    agenda_topics: list[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class ListTemplatesInput:
+    """Input DTO for ListTemplatesService."""
+
+    organizer_id: UserId
+
+
+@dataclass(frozen=True)
+class ListTemplatesOutput:
+    """Output DTO for ListTemplatesService."""
+
+    templates: list[TemplateListItem]
+
+
+class ListTemplatesService:
+    """Application service that lists all templates for an organizer.
+
+    This is a read-only operation; no UoW or event dispatching is needed.
+    """
+
+    def __init__(
+        self,
+        template_repo: TemplateRepository,
+    ) -> None:
+        self._template_repo = template_repo
+
+    async def execute(
+        self,
+        input_dto: ListTemplatesInput,
+    ) -> ListTemplatesOutput:
+        """List all templates for the given organizer.
+
+        Args:
+            input_dto: Input containing the organizer ID.
+
+        Returns:
+            Output containing the list of templates.
+        """
+        templates = await self._template_repo.list_by_organizer(input_dto.organizer_id)
+
+        items = [
+            TemplateListItem(
+                template_id=t.id,
+                name=t.name.value,
+                default_counterpart_ids=t.default_counterparts,
+                agenda_topics=[at.topic.value for at in t.agenda_templates],
+                created_at=t.created_at,
+                updated_at=t.updated_at,
+            )
+            for t in templates
+        ]
+
+        return ListTemplatesOutput(templates=items)

--- a/backend/contexts/preparation/application/save_template_service.py
+++ b/backend/contexts/preparation/application/save_template_service.py
@@ -1,0 +1,87 @@
+"""Use case: Save a ScheduleGroup's settings as a reusable template."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_name import TemplateName
+from contexts.preparation.domain.template_repository import TemplateRepository
+from contexts.preparation.domain.value_objects import TemplateId
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class SaveTemplateInput:
+    """Input DTO for SaveTemplateService."""
+
+    organizer_id: UserId
+    name: str
+    default_counterpart_ids: list[UserId]
+    agenda_topics: list[str]
+
+
+@dataclass(frozen=True)
+class SaveTemplateOutput:
+    """Output DTO for SaveTemplateService."""
+
+    template_id: TemplateId
+
+
+class SaveTemplateService:
+    """Application service that saves a template for reuse.
+
+    The organizer provides a name, default counterparts, and agenda topics.
+    A new Template aggregate is created and persisted, then a TemplateSaved
+    domain event is dispatched after commit.
+    """
+
+    def __init__(
+        self,
+        uow: UnitOfWork,
+        template_repo: TemplateRepository,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._uow = uow
+        self._template_repo = template_repo
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self,
+        input_dto: SaveTemplateInput,
+    ) -> SaveTemplateOutput:
+        """Create and persist a new template.
+
+        Args:
+            input_dto: Input parameters for saving a template.
+
+        Returns:
+            Output containing the id of the newly created template.
+        """
+        now = datetime.now(UTC)
+        template_name = TemplateName(input_dto.name)
+        agenda_templates = [AgendaTemplate(t) for t in input_dto.agenda_topics]
+
+        template = Template.create(
+            organizer_id=input_dto.organizer_id,
+            name=template_name,
+            default_counterparts=input_dto.default_counterpart_ids,
+            agenda_templates=agenda_templates,
+            now=now,
+        )
+
+        events: list[DomainEvent] = []
+
+        async with self._uow:
+            await self._template_repo.save(template)
+            events = list(template.collect_events())
+            await self._uow.commit()
+
+        await self._event_dispatcher.dispatch(events)
+
+        return SaveTemplateOutput(template_id=template.id)

--- a/backend/contexts/preparation/domain/template_repository.py
+++ b/backend/contexts/preparation/domain/template_repository.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from abc import abstractmethod
+
 from contexts.preparation.domain.template import Template
 from contexts.preparation.domain.value_objects import TemplateId
 from foundation.domain.base_repository import BaseRepository
+from shared.domain.value_objects import UserId
 
 
 class TemplateRepository(BaseRepository[Template, TemplateId]):
     """Repository interface for Template aggregates."""
 
-    pass
+    @abstractmethod
+    async def list_by_organizer(self, organizer_id: UserId) -> list[Template]:
+        """Return all templates owned by the given organizer."""

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_template_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_template_repository.py
@@ -33,6 +33,14 @@ class SqlAlchemyTemplateRepository(TemplateRepository):
             return None
         return self._to_entity(row)
 
+    async def list_by_organizer(self, organizer_id: UserId) -> list[Template]:
+        stmt = select(TemplateTable).where(
+            TemplateTable.organizer_id == str(organizer_id.value)
+        )
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [self._to_entity(row) for row in rows]
+
     async def save(self, entity: Template) -> None:
         existing = await self._session.get(TemplateTable, str(entity.id.value))
         if existing is None:

--- a/backend/tests/contexts/preparation/application/conftest.py
+++ b/backend/tests/contexts/preparation/application/conftest.py
@@ -14,13 +14,17 @@ from contexts.preparation.domain.schedule_group_repository import (
     ScheduleGroupRepository,
 )
 from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_repository import TemplateRepository
 from contexts.preparation.domain.value_objects import (
     AgendaId,
     ScheduleGroupId,
     ScheduleId,
+    TemplateId,
 )
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
 
 
 class StubUnitOfWork(UnitOfWork):
@@ -125,6 +129,31 @@ class InMemoryAgendaRepository(AgendaRepository):
     @property
     def agendas(self) -> dict[AgendaId, Agenda]:
         return dict(self._store)
+
+
+class InMemoryTemplateRepository(TemplateRepository):
+    """In-memory template repository for unit testing."""
+
+    def __init__(self) -> None:
+        self._store: dict[TemplateId, Template] = {}
+
+    async def get_by_id(self, entity_id: TemplateId) -> Template | None:
+        return self._store.get(entity_id)
+
+    async def save(self, entity: Template) -> None:
+        self._store[entity.id] = entity
+
+    async def list_by_organizer(self, organizer_id: UserId) -> list[Template]:
+        return [t for t in self._store.values() if t.organizer_id == organizer_id]
+
+    @property
+    def templates(self) -> dict[TemplateId, Template]:
+        return dict(self._store)
+
+
+@pytest.fixture
+def template_repo() -> InMemoryTemplateRepository:
+    return InMemoryTemplateRepository()
 
 
 @pytest.fixture

--- a/backend/tests/contexts/preparation/application/test_create_schedule_group_from_past_service.py
+++ b/backend/tests/contexts/preparation/application/test_create_schedule_group_from_past_service.py
@@ -1,0 +1,282 @@
+"""Tests for CreateScheduleGroupFromPastService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.create_schedule_group_from_past_service import (
+    CreateScheduleGroupFromPastInput,
+    CreateScheduleGroupFromPastOutput,
+    CreateScheduleGroupFromPastService,
+    PastCounterpartSchedule,
+    SourceScheduleGroupNotFoundError,
+    UnauthorizedCopyError,
+)
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.events import ScheduleCreated, ScheduleGroupCreated
+from contexts.preparation.domain.schedule_group import ScheduleGroup
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import ScheduleGroupId, ScheduleStatus
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryAgendaRepository,
+    InMemoryScheduleGroupRepository,
+    InMemoryScheduleRepository,
+    StubUnitOfWork,
+)
+
+
+class TestCreateScheduleGroupFromPast:
+    """ScheduleGroup creation by copying a past group."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        schedule_group_repo: InMemoryScheduleGroupRepository,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> CreateScheduleGroupFromPastService:
+        return CreateScheduleGroupFromPastService(
+            uow=uow,
+            schedule_group_repo=schedule_group_repo,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    @pytest.fixture
+    def organizer(self) -> UserId:
+        return UserId.generate()
+
+    @pytest.fixture
+    async def source_group(
+        self,
+        organizer: UserId,
+        schedule_group_repo: InMemoryScheduleGroupRepository,
+    ) -> ScheduleGroup:
+        """A past ScheduleGroup with 2 agenda templates."""
+        group = ScheduleGroup.create(
+            organizer_id=organizer,
+            title=ScheduleTitle("Past Weekly"),
+            agenda_templates=[
+                AgendaTemplate("Progress update"),
+                AgendaTemplate("Action items"),
+            ],
+        )
+        group.collect_events()
+        await schedule_group_repo.save(group)
+        return group
+
+    async def test_creates_group_from_past(
+        self,
+        service: CreateScheduleGroupFromPastService,
+        source_group: ScheduleGroup,
+        organizer: UserId,
+        schedule_group_repo: InMemoryScheduleGroupRepository,
+    ) -> None:
+        """Creates a new ScheduleGroup copying agenda structure from source."""
+        cp = UserId.generate()
+        future = datetime.now(UTC) + timedelta(days=1)
+
+        output = await service.execute(
+            CreateScheduleGroupFromPastInput(
+                organizer_id=organizer,
+                source_schedule_group_id=source_group.id,
+                title="New Weekly",
+                counterpart_schedules=[
+                    PastCounterpartSchedule(counterpart_id=cp, scheduled_at=future),
+                ],
+            )
+        )
+
+        assert isinstance(output, CreateScheduleGroupFromPastOutput)
+        group = await schedule_group_repo.get_by_id(output.schedule_group_id)
+        assert group is not None
+        assert group.title.value == "New Weekly"
+        assert group.template_id is None
+        assert len(group.schedule_ids) == 1
+
+    async def test_copies_agenda_templates(
+        self,
+        service: CreateScheduleGroupFromPastService,
+        source_group: ScheduleGroup,
+        organizer: UserId,
+        agenda_repo: InMemoryAgendaRepository,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Agenda templates from source are expanded to new schedules."""
+        cp1 = UserId.generate()
+        cp2 = UserId.generate()
+        future = datetime.now(UTC) + timedelta(days=1)
+
+        await service.execute(
+            CreateScheduleGroupFromPastInput(
+                organizer_id=organizer,
+                source_schedule_group_id=source_group.id,
+                title="Copied",
+                counterpart_schedules=[
+                    PastCounterpartSchedule(counterpart_id=cp1, scheduled_at=future),
+                    PastCounterpartSchedule(
+                        counterpart_id=cp2,
+                        scheduled_at=future + timedelta(hours=1),
+                    ),
+                ],
+            )
+        )
+
+        # 2 counterparts * 2 topics = 4 agendas
+        assert len(agenda_repo.agendas) == 4
+
+        for schedule in schedule_repo.schedules.values():
+            schedule_agendas = await agenda_repo.get_by_schedule_id(schedule.id)
+            topics = {a.topic.value for a in schedule_agendas}
+            assert topics == {"Progress update", "Action items"}
+
+    async def test_raises_not_found_for_missing_source(
+        self,
+        service: CreateScheduleGroupFromPastService,
+        organizer: UserId,
+    ) -> None:
+        """Raises SourceScheduleGroupNotFoundError when source does not exist."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        with pytest.raises(SourceScheduleGroupNotFoundError):
+            await service.execute(
+                CreateScheduleGroupFromPastInput(
+                    organizer_id=organizer,
+                    source_schedule_group_id=ScheduleGroupId.generate(),
+                    title="Missing",
+                    counterpart_schedules=[
+                        PastCounterpartSchedule(
+                            counterpart_id=UserId.generate(),
+                            scheduled_at=future,
+                        ),
+                    ],
+                )
+            )
+
+    async def test_raises_unauthorized_for_non_organizer(
+        self,
+        service: CreateScheduleGroupFromPastService,
+        source_group: ScheduleGroup,
+    ) -> None:
+        """Raises UnauthorizedCopyError for non-organizer of source."""
+        other_user = UserId.generate()
+        future = datetime.now(UTC) + timedelta(days=1)
+
+        with pytest.raises(UnauthorizedCopyError):
+            await service.execute(
+                CreateScheduleGroupFromPastInput(
+                    organizer_id=other_user,
+                    source_schedule_group_id=source_group.id,
+                    title="Unauthorized",
+                    counterpart_schedules=[
+                        PastCounterpartSchedule(
+                            counterpart_id=UserId.generate(),
+                            scheduled_at=future,
+                        ),
+                    ],
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: CreateScheduleGroupFromPastService,
+        source_group: ScheduleGroup,
+        organizer: UserId,
+        uow: StubUnitOfWork,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        await service.execute(
+            CreateScheduleGroupFromPastInput(
+                organizer_id=organizer,
+                source_schedule_group_id=source_group.id,
+                title="Commit Test",
+                counterpart_schedules=[
+                    PastCounterpartSchedule(
+                        counterpart_id=UserId.generate(), scheduled_at=future
+                    ),
+                ],
+            )
+        )
+        assert uow.committed is True
+
+    async def test_dispatches_events(
+        self,
+        uow: StubUnitOfWork,
+        schedule_group_repo: InMemoryScheduleGroupRepository,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        source_group: ScheduleGroup,
+        organizer: UserId,
+    ) -> None:
+        """Dispatches ScheduleCreated and ScheduleGroupCreated events."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(ScheduleCreated, capture)  # type: ignore[arg-type]
+        dispatcher.register(ScheduleGroupCreated, capture)  # type: ignore[arg-type]
+
+        svc = CreateScheduleGroupFromPastService(
+            uow=uow,
+            schedule_group_repo=schedule_group_repo,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        future = datetime.now(UTC) + timedelta(days=1)
+        await svc.execute(
+            CreateScheduleGroupFromPastInput(
+                organizer_id=organizer,
+                source_schedule_group_id=source_group.id,
+                title="Events Test",
+                counterpart_schedules=[
+                    PastCounterpartSchedule(
+                        counterpart_id=UserId.generate(), scheduled_at=future
+                    ),
+                    PastCounterpartSchedule(
+                        counterpart_id=UserId.generate(),
+                        scheduled_at=future + timedelta(hours=1),
+                    ),
+                ],
+            )
+        )
+
+        schedule_created = [e for e in dispatched if isinstance(e, ScheduleCreated)]
+        group_created = [e for e in dispatched if isinstance(e, ScheduleGroupCreated)]
+        assert len(schedule_created) == 2
+        assert len(group_created) == 1
+
+    async def test_schedules_in_requested_status(
+        self,
+        service: CreateScheduleGroupFromPastService,
+        source_group: ScheduleGroup,
+        organizer: UserId,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Created schedules start in REQUESTED status."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        await service.execute(
+            CreateScheduleGroupFromPastInput(
+                organizer_id=organizer,
+                source_schedule_group_id=source_group.id,
+                title="Status Test",
+                counterpart_schedules=[
+                    PastCounterpartSchedule(
+                        counterpart_id=UserId.generate(), scheduled_at=future
+                    ),
+                ],
+            )
+        )
+
+        for schedule in schedule_repo.schedules.values():
+            assert schedule.status == ScheduleStatus.REQUESTED

--- a/backend/tests/contexts/preparation/application/test_create_schedule_group_from_template_service.py
+++ b/backend/tests/contexts/preparation/application/test_create_schedule_group_from_template_service.py
@@ -1,0 +1,287 @@
+"""Tests for CreateScheduleGroupFromTemplateService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.create_schedule_group_from_template_service import (  # noqa: E501
+    CreateScheduleGroupFromTemplateInput,
+    CreateScheduleGroupFromTemplateOutput,
+    CreateScheduleGroupFromTemplateService,
+    TemplateCounterpartSchedule,
+    TemplateNotFoundError,
+    UnauthorizedTemplateUseError,
+)
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.events import ScheduleCreated, ScheduleGroupCreated
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_name import TemplateName
+from contexts.preparation.domain.value_objects import ScheduleStatus, TemplateId
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryAgendaRepository,
+    InMemoryScheduleGroupRepository,
+    InMemoryScheduleRepository,
+    InMemoryTemplateRepository,
+    StubUnitOfWork,
+)
+
+
+class TestCreateScheduleGroupFromTemplate:
+    """ScheduleGroup creation from a saved template."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        template_repo: InMemoryTemplateRepository,
+        schedule_group_repo: InMemoryScheduleGroupRepository,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> CreateScheduleGroupFromTemplateService:
+        return CreateScheduleGroupFromTemplateService(
+            uow=uow,
+            template_repo=template_repo,
+            schedule_group_repo=schedule_group_repo,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    @pytest.fixture
+    def organizer(self) -> UserId:
+        return UserId.generate()
+
+    @pytest.fixture
+    async def template_with_agendas(
+        self,
+        organizer: UserId,
+        template_repo: InMemoryTemplateRepository,
+    ) -> Template:
+        """A template with 2 agenda topics and 1 default counterpart."""
+        cp = UserId.generate()
+        t = Template.create(
+            organizer_id=organizer,
+            name=TemplateName("Weekly Template"),
+            default_counterparts=[cp],
+            agenda_templates=[AgendaTemplate("Progress"), AgendaTemplate("Blockers")],
+        )
+        t.collect_events()
+        await template_repo.save(t)
+        return t
+
+    async def test_creates_group_from_template(
+        self,
+        service: CreateScheduleGroupFromTemplateService,
+        template_with_agendas: Template,
+        organizer: UserId,
+        schedule_group_repo: InMemoryScheduleGroupRepository,
+    ) -> None:
+        """Creates a ScheduleGroup referencing the template."""
+        cp1 = UserId.generate()
+        future = datetime.now(UTC) + timedelta(days=1)
+
+        output = await service.execute(
+            CreateScheduleGroupFromTemplateInput(
+                organizer_id=organizer,
+                template_id=template_with_agendas.id,
+                title="From Template",
+                counterpart_schedules=[
+                    TemplateCounterpartSchedule(
+                        counterpart_id=cp1, scheduled_at=future
+                    ),
+                ],
+            )
+        )
+
+        assert isinstance(output, CreateScheduleGroupFromTemplateOutput)
+        group = await schedule_group_repo.get_by_id(output.schedule_group_id)
+        assert group is not None
+        assert group.title.value == "From Template"
+        assert group.template_id == template_with_agendas.id
+        assert len(group.schedule_ids) == 1
+
+    async def test_expands_template_agendas(
+        self,
+        service: CreateScheduleGroupFromTemplateService,
+        template_with_agendas: Template,
+        organizer: UserId,
+        agenda_repo: InMemoryAgendaRepository,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Template agenda topics are expanded into Agenda entities."""
+        cp1 = UserId.generate()
+        cp2 = UserId.generate()
+        future = datetime.now(UTC) + timedelta(days=1)
+
+        await service.execute(
+            CreateScheduleGroupFromTemplateInput(
+                organizer_id=organizer,
+                template_id=template_with_agendas.id,
+                title="With Agendas",
+                counterpart_schedules=[
+                    TemplateCounterpartSchedule(
+                        counterpart_id=cp1, scheduled_at=future
+                    ),
+                    TemplateCounterpartSchedule(
+                        counterpart_id=cp2,
+                        scheduled_at=future + timedelta(hours=1),
+                    ),
+                ],
+            )
+        )
+
+        # 2 counterparts * 2 topics = 4 agendas
+        assert len(agenda_repo.agendas) == 4
+
+        for schedule in schedule_repo.schedules.values():
+            schedule_agendas = await agenda_repo.get_by_schedule_id(schedule.id)
+            assert len(schedule_agendas) == 2
+            topics = {a.topic.value for a in schedule_agendas}
+            assert topics == {"Progress", "Blockers"}
+
+    async def test_raises_not_found_for_missing_template(
+        self,
+        service: CreateScheduleGroupFromTemplateService,
+        organizer: UserId,
+    ) -> None:
+        """Raises TemplateNotFoundError when template does not exist."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        with pytest.raises(TemplateNotFoundError):
+            await service.execute(
+                CreateScheduleGroupFromTemplateInput(
+                    organizer_id=organizer,
+                    template_id=TemplateId.generate(),
+                    title="Missing",
+                    counterpart_schedules=[
+                        TemplateCounterpartSchedule(
+                            counterpart_id=UserId.generate(),
+                            scheduled_at=future,
+                        ),
+                    ],
+                )
+            )
+
+    async def test_raises_unauthorized_for_non_owner(
+        self,
+        service: CreateScheduleGroupFromTemplateService,
+        template_with_agendas: Template,
+    ) -> None:
+        """Raises UnauthorizedTemplateUseError for non-owner."""
+        other_user = UserId.generate()
+        future = datetime.now(UTC) + timedelta(days=1)
+
+        with pytest.raises(UnauthorizedTemplateUseError):
+            await service.execute(
+                CreateScheduleGroupFromTemplateInput(
+                    organizer_id=other_user,
+                    template_id=template_with_agendas.id,
+                    title="Unauthorized",
+                    counterpart_schedules=[
+                        TemplateCounterpartSchedule(
+                            counterpart_id=UserId.generate(),
+                            scheduled_at=future,
+                        ),
+                    ],
+                )
+            )
+
+    async def test_commits_via_uow(
+        self,
+        service: CreateScheduleGroupFromTemplateService,
+        template_with_agendas: Template,
+        organizer: UserId,
+        uow: StubUnitOfWork,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        await service.execute(
+            CreateScheduleGroupFromTemplateInput(
+                organizer_id=organizer,
+                template_id=template_with_agendas.id,
+                title="Commit Test",
+                counterpart_schedules=[
+                    TemplateCounterpartSchedule(
+                        counterpart_id=UserId.generate(), scheduled_at=future
+                    ),
+                ],
+            )
+        )
+        assert uow.committed is True
+
+    async def test_dispatches_events(
+        self,
+        uow: StubUnitOfWork,
+        template_repo: InMemoryTemplateRepository,
+        schedule_group_repo: InMemoryScheduleGroupRepository,
+        schedule_repo: InMemoryScheduleRepository,
+        agenda_repo: InMemoryAgendaRepository,
+        template_with_agendas: Template,
+        organizer: UserId,
+    ) -> None:
+        """Dispatches ScheduleCreated and ScheduleGroupCreated events."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(ScheduleCreated, capture)  # type: ignore[arg-type]
+        dispatcher.register(ScheduleGroupCreated, capture)  # type: ignore[arg-type]
+
+        svc = CreateScheduleGroupFromTemplateService(
+            uow=uow,
+            template_repo=template_repo,
+            schedule_group_repo=schedule_group_repo,
+            schedule_repo=schedule_repo,
+            agenda_repo=agenda_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        future = datetime.now(UTC) + timedelta(days=1)
+        await svc.execute(
+            CreateScheduleGroupFromTemplateInput(
+                organizer_id=organizer,
+                template_id=template_with_agendas.id,
+                title="Events Test",
+                counterpart_schedules=[
+                    TemplateCounterpartSchedule(
+                        counterpart_id=UserId.generate(), scheduled_at=future
+                    ),
+                ],
+            )
+        )
+
+        schedule_created = [e for e in dispatched if isinstance(e, ScheduleCreated)]
+        group_created = [e for e in dispatched if isinstance(e, ScheduleGroupCreated)]
+        assert len(schedule_created) == 1
+        assert len(group_created) == 1
+
+    async def test_schedules_in_requested_status(
+        self,
+        service: CreateScheduleGroupFromTemplateService,
+        template_with_agendas: Template,
+        organizer: UserId,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> None:
+        """Created schedules start in REQUESTED status."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        await service.execute(
+            CreateScheduleGroupFromTemplateInput(
+                organizer_id=organizer,
+                template_id=template_with_agendas.id,
+                title="Status Test",
+                counterpart_schedules=[
+                    TemplateCounterpartSchedule(
+                        counterpart_id=UserId.generate(), scheduled_at=future
+                    ),
+                ],
+            )
+        )
+
+        for schedule in schedule_repo.schedules.values():
+            assert schedule.status == ScheduleStatus.REQUESTED

--- a/backend/tests/contexts/preparation/application/test_get_template_service.py
+++ b/backend/tests/contexts/preparation/application/test_get_template_service.py
@@ -1,0 +1,96 @@
+"""Tests for GetTemplateService."""
+
+from __future__ import annotations
+
+import pytest
+
+from contexts.preparation.application.get_template_service import (
+    GetTemplateInput,
+    GetTemplateOutput,
+    GetTemplateService,
+    TemplateNotFoundError,
+    UnauthorizedTemplateAccessError,
+)
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_name import TemplateName
+from contexts.preparation.domain.value_objects import TemplateId
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryTemplateRepository,
+)
+
+
+class TestGetTemplate:
+    """Template retrieval use case."""
+
+    @pytest.fixture
+    def service(
+        self,
+        template_repo: InMemoryTemplateRepository,
+    ) -> GetTemplateService:
+        return GetTemplateService(template_repo=template_repo)
+
+    async def test_returns_template_for_owner(
+        self,
+        service: GetTemplateService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Returns template details when requested by the owner."""
+        organizer = UserId.generate()
+        cp = UserId.generate()
+
+        t = Template.create(
+            organizer_id=organizer,
+            name=TemplateName("My Template"),
+            default_counterparts=[cp],
+            agenda_templates=[AgendaTemplate("Topic A")],
+        )
+        # Drain events from create to avoid side effects in assertion
+        t.collect_events()
+        await template_repo.save(t)
+
+        output = await service.execute(
+            GetTemplateInput(template_id=t.id, actor_id=organizer)
+        )
+
+        assert isinstance(output, GetTemplateOutput)
+        assert output.template_id == t.id
+        assert output.organizer_id == organizer
+        assert output.name == "My Template"
+        assert output.default_counterpart_ids == [cp]
+        assert output.agenda_topics == ["Topic A"]
+
+    async def test_raises_not_found_for_missing_template(
+        self,
+        service: GetTemplateService,
+    ) -> None:
+        """Raises TemplateNotFoundError for non-existent template."""
+        with pytest.raises(TemplateNotFoundError):
+            await service.execute(
+                GetTemplateInput(
+                    template_id=TemplateId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_raises_unauthorized_for_non_owner(
+        self,
+        service: GetTemplateService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Raises UnauthorizedTemplateAccessError for non-owner."""
+        organizer = UserId.generate()
+        other_user = UserId.generate()
+
+        t = Template.create(
+            organizer_id=organizer,
+            name=TemplateName("Private Template"),
+        )
+        t.collect_events()
+        await template_repo.save(t)
+
+        with pytest.raises(UnauthorizedTemplateAccessError):
+            await service.execute(
+                GetTemplateInput(template_id=t.id, actor_id=other_user)
+            )

--- a/backend/tests/contexts/preparation/application/test_list_templates_service.py
+++ b/backend/tests/contexts/preparation/application/test_list_templates_service.py
@@ -1,0 +1,118 @@
+"""Tests for ListTemplatesService."""
+
+from __future__ import annotations
+
+import pytest
+
+from contexts.preparation.application.list_templates_service import (
+    ListTemplatesInput,
+    ListTemplatesService,
+)
+from contexts.preparation.domain.agenda_template import AgendaTemplate
+from contexts.preparation.domain.template import Template
+from contexts.preparation.domain.template_name import TemplateName
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryTemplateRepository,
+)
+
+
+class TestListTemplates:
+    """Template listing use case."""
+
+    @pytest.fixture
+    def service(
+        self,
+        template_repo: InMemoryTemplateRepository,
+    ) -> ListTemplatesService:
+        return ListTemplatesService(template_repo=template_repo)
+
+    async def test_returns_templates_for_organizer(
+        self,
+        service: ListTemplatesService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Returns all templates owned by the given organizer."""
+        organizer = UserId.generate()
+        cp = UserId.generate()
+
+        t1 = Template.create(
+            organizer_id=organizer,
+            name=TemplateName("Template A"),
+            default_counterparts=[cp],
+            agenda_templates=[AgendaTemplate("Topic 1")],
+        )
+        t2 = Template.create(
+            organizer_id=organizer,
+            name=TemplateName("Template B"),
+        )
+        await template_repo.save(t1)
+        await template_repo.save(t2)
+
+        output = await service.execute(ListTemplatesInput(organizer_id=organizer))
+
+        assert len(output.templates) == 2
+        names = {t.name for t in output.templates}
+        assert names == {"Template A", "Template B"}
+
+    async def test_does_not_return_other_organizers_templates(
+        self,
+        service: ListTemplatesService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Does not return templates owned by a different organizer."""
+        organizer1 = UserId.generate()
+        organizer2 = UserId.generate()
+
+        t1 = Template.create(
+            organizer_id=organizer1,
+            name=TemplateName("Org1 Template"),
+        )
+        t2 = Template.create(
+            organizer_id=organizer2,
+            name=TemplateName("Org2 Template"),
+        )
+        await template_repo.save(t1)
+        await template_repo.save(t2)
+
+        output = await service.execute(ListTemplatesInput(organizer_id=organizer1))
+
+        assert len(output.templates) == 1
+        assert output.templates[0].name == "Org1 Template"
+
+    async def test_returns_empty_list_when_no_templates(
+        self,
+        service: ListTemplatesService,
+    ) -> None:
+        """Returns an empty list when the organizer has no templates."""
+        output = await service.execute(
+            ListTemplatesInput(organizer_id=UserId.generate())
+        )
+        assert output.templates == []
+
+    async def test_includes_template_details(
+        self,
+        service: ListTemplatesService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Each list item includes counterparts and agenda topics."""
+        organizer = UserId.generate()
+        cp = UserId.generate()
+
+        t = Template.create(
+            organizer_id=organizer,
+            name=TemplateName("Detailed"),
+            default_counterparts=[cp],
+            agenda_templates=[AgendaTemplate("Topic A"), AgendaTemplate("Topic B")],
+        )
+        await template_repo.save(t)
+
+        output = await service.execute(ListTemplatesInput(organizer_id=organizer))
+
+        item = output.templates[0]
+        assert item.name == "Detailed"
+        assert item.default_counterpart_ids == [cp]
+        assert item.agenda_topics == ["Topic A", "Topic B"]
+        assert item.template_id == t.id
+        assert item.created_at == t.created_at
+        assert item.updated_at == t.updated_at

--- a/backend/tests/contexts/preparation/application/test_list_templates_service.py
+++ b/backend/tests/contexts/preparation/application/test_list_templates_service.py
@@ -49,7 +49,7 @@ class TestListTemplates:
         await template_repo.save(t1)
         await template_repo.save(t2)
 
-        output = await service.execute(ListTemplatesInput(organizer_id=organizer))
+        output = await service.execute(ListTemplatesInput(actor_id=organizer))
 
         assert len(output.templates) == 2
         names = {t.name for t in output.templates}
@@ -75,7 +75,7 @@ class TestListTemplates:
         await template_repo.save(t1)
         await template_repo.save(t2)
 
-        output = await service.execute(ListTemplatesInput(organizer_id=organizer1))
+        output = await service.execute(ListTemplatesInput(actor_id=organizer1))
 
         assert len(output.templates) == 1
         assert output.templates[0].name == "Org1 Template"
@@ -85,9 +85,7 @@ class TestListTemplates:
         service: ListTemplatesService,
     ) -> None:
         """Returns an empty list when the organizer has no templates."""
-        output = await service.execute(
-            ListTemplatesInput(organizer_id=UserId.generate())
-        )
+        output = await service.execute(ListTemplatesInput(actor_id=UserId.generate()))
         assert output.templates == []
 
     async def test_includes_template_details(
@@ -107,7 +105,7 @@ class TestListTemplates:
         )
         await template_repo.save(t)
 
-        output = await service.execute(ListTemplatesInput(organizer_id=organizer))
+        output = await service.execute(ListTemplatesInput(actor_id=organizer))
 
         item = output.templates[0]
         assert item.name == "Detailed"
@@ -116,3 +114,22 @@ class TestListTemplates:
         assert item.template_id == t.id
         assert item.created_at == t.created_at
         assert item.updated_at == t.updated_at
+
+    async def test_actor_cannot_list_other_users_templates(
+        self,
+        service: ListTemplatesService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """An actor cannot retrieve templates owned by another user."""
+        owner = UserId.generate()
+        other = UserId.generate()
+
+        t = Template.create(
+            organizer_id=owner,
+            name=TemplateName("Owner Template"),
+        )
+        await template_repo.save(t)
+
+        output = await service.execute(ListTemplatesInput(actor_id=other))
+
+        assert output.templates == []

--- a/backend/tests/contexts/preparation/application/test_save_template_service.py
+++ b/backend/tests/contexts/preparation/application/test_save_template_service.py
@@ -1,0 +1,154 @@
+"""Tests for SaveTemplateService."""
+
+from __future__ import annotations
+
+import pytest
+
+from contexts.preparation.application.save_template_service import (
+    SaveTemplateInput,
+    SaveTemplateOutput,
+    SaveTemplateService,
+)
+from contexts.preparation.domain.events import TemplateSaved
+from contexts.preparation.domain.exceptions import InvalidTemplateNameError
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import (
+    InMemoryTemplateRepository,
+    StubUnitOfWork,
+)
+
+
+class TestSaveTemplate:
+    """Template saving use case."""
+
+    @pytest.fixture
+    def service(
+        self,
+        uow: StubUnitOfWork,
+        template_repo: InMemoryTemplateRepository,
+        dispatcher: InMemoryEventDispatcher,
+    ) -> SaveTemplateService:
+        return SaveTemplateService(
+            uow=uow,
+            template_repo=template_repo,
+            event_dispatcher=dispatcher,
+        )
+
+    async def test_saves_template_with_all_fields(
+        self,
+        service: SaveTemplateService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Creates a template with name, counterparts, and agenda topics."""
+        organizer = UserId.generate()
+        cp1 = UserId.generate()
+        cp2 = UserId.generate()
+
+        output = await service.execute(
+            SaveTemplateInput(
+                organizer_id=organizer,
+                name="Weekly 1on1 Template",
+                default_counterpart_ids=[cp1, cp2],
+                agenda_topics=["Progress update", "Blockers"],
+            )
+        )
+
+        assert isinstance(output, SaveTemplateOutput)
+        template = await template_repo.get_by_id(output.template_id)
+        assert template is not None
+        assert template.name.value == "Weekly 1on1 Template"
+        assert template.organizer_id == organizer
+        assert template.default_counterparts == [cp1, cp2]
+        assert len(template.agenda_templates) == 2
+        topics = [at.topic.value for at in template.agenda_templates]
+        assert topics == ["Progress update", "Blockers"]
+
+    async def test_saves_template_without_optional_fields(
+        self,
+        service: SaveTemplateService,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Creates a template with empty counterparts and agenda topics."""
+        organizer = UserId.generate()
+
+        output = await service.execute(
+            SaveTemplateInput(
+                organizer_id=organizer,
+                name="Minimal Template",
+                default_counterpart_ids=[],
+                agenda_topics=[],
+            )
+        )
+
+        template = await template_repo.get_by_id(output.template_id)
+        assert template is not None
+        assert template.default_counterparts == []
+        assert template.agenda_templates == []
+
+    async def test_commits_via_uow(
+        self,
+        service: SaveTemplateService,
+        uow: StubUnitOfWork,
+    ) -> None:
+        """Verifies that the service commits the transaction."""
+        await service.execute(
+            SaveTemplateInput(
+                organizer_id=UserId.generate(),
+                name="Test",
+                default_counterpart_ids=[],
+                agenda_topics=[],
+            )
+        )
+        assert uow.committed is True
+
+    async def test_dispatches_template_saved_event(
+        self,
+        uow: StubUnitOfWork,
+        template_repo: InMemoryTemplateRepository,
+    ) -> None:
+        """Dispatches TemplateSaved event after commit."""
+        dispatched: list[object] = []
+
+        async def capture(event: object) -> None:
+            dispatched.append(event)
+
+        dispatcher = InMemoryEventDispatcher()
+        dispatcher.register(TemplateSaved, capture)  # type: ignore[arg-type]
+
+        svc = SaveTemplateService(
+            uow=uow,
+            template_repo=template_repo,
+            event_dispatcher=dispatcher,
+        )
+
+        organizer = UserId.generate()
+        await svc.execute(
+            SaveTemplateInput(
+                organizer_id=organizer,
+                name="Event Test",
+                default_counterpart_ids=[],
+                agenda_topics=[],
+            )
+        )
+
+        assert len(dispatched) == 1
+        event = dispatched[0]
+        assert isinstance(event, TemplateSaved)
+        assert event.name == "Event Test"
+        assert event.organizer_id == organizer
+
+    async def test_rejects_invalid_template_name(
+        self,
+        service: SaveTemplateService,
+    ) -> None:
+        """Raises InvalidTemplateNameError for empty name."""
+        with pytest.raises(InvalidTemplateNameError):
+            await service.execute(
+                SaveTemplateInput(
+                    organizer_id=UserId.generate(),
+                    name="   ",
+                    default_counterpart_ids=[],
+                    agenda_topics=[],
+                )
+            )

--- a/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_template_repository.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_template_repository.py
@@ -212,3 +212,65 @@ class TestPositionOrdering:
         assert loaded is not None
         loaded_topics = [at.topic.value for at in loaded.agenda_templates]
         assert loaded_topics == topics
+
+
+class TestListByOrganizer:
+    """list_by_organizer() query tests."""
+
+    async def test_returns_only_templates_for_given_organizer(
+        self, session: AsyncSession
+    ) -> None:
+        """Filters templates by organizer_id, excluding other users' templates."""
+        repo = SqlAlchemyTemplateRepository(session)
+        org1 = await _create_user(session)
+        org2 = await _create_user(session)
+
+        t1 = _make_template(organizer_id=org1, name="Org1 A")
+        t2 = _make_template(organizer_id=org1, name="Org1 B")
+        t3 = _make_template(organizer_id=org2, name="Org2 A")
+        await repo.save(t1)
+        await repo.save(t2)
+        await repo.save(t3)
+        await session.commit()
+
+        result = await repo.list_by_organizer(org1)
+
+        assert len(result) == 2
+        names = {t.name.value for t in result}
+        assert names == {"Org1 A", "Org1 B"}
+
+    async def test_returns_multiple_templates_with_children(
+        self, session: AsyncSession
+    ) -> None:
+        """Returned templates include counterparts and agenda templates."""
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+        cp = await _create_user(session)
+
+        t1 = _make_template(
+            organizer_id=org,
+            name="With Children",
+            default_counterparts=[cp],
+            agenda_templates=[AgendaTemplate("Topic X")],
+        )
+        await repo.save(t1)
+        await session.commit()
+
+        result = await repo.list_by_organizer(org)
+
+        assert len(result) == 1
+        loaded = result[0]
+        assert loaded.default_counterparts == [cp]
+        assert len(loaded.agenda_templates) == 1
+        assert loaded.agenda_templates[0].topic.value == "Topic X"
+
+    async def test_returns_empty_list_when_no_templates(
+        self, session: AsyncSession
+    ) -> None:
+        """Returns an empty list for an organizer with no templates."""
+        repo = SqlAlchemyTemplateRepository(session)
+        org = await _create_user(session)
+
+        result = await repo.list_by_organizer(org)
+
+        assert result == []


### PR DESCRIPTION
Closes #88

## Summary
- テンプレート保存・一覧取得・個別取得のユースケースを実装
- テンプレートから ScheduleGroup を作成するユースケースを実装
- 過去の1on1からコピーして ScheduleGroup を作成するユースケースを実装
- ユニットテスト26件

## Test plan
- [x] ruff check / format OK
- [x] pyright 0 errors
- [x] pytest unit passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)