### PR TITLE
Read Model: 未完了アクションアイテム一覧クエリサービス

### DIFF
--- a/backend/contexts/record/application/list_pending_action_items.py
+++ b/backend/contexts/record/application/list_pending_action_items.py
@@ -1,0 +1,117 @@
+"""Read-only query service: list pending action items for a counterpart.
+
+Returns all incomplete action items tied to a specific counterpart,
+along with their originating Record information. This is used by
+organizers preparing for a 1-on-1 or by the counterpart themselves.
+
+No UoW or EventDispatcher needed (read-only).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.exceptions import UnauthorizedOperationError
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import ActionItemId, RecordId
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class PendingActionItemDTO:
+    """Single pending action item with its originating Record info."""
+
+    action_item_id: ActionItemId
+    content: str
+    created_at: datetime
+    record_id: RecordId
+    organizer_id: UserId
+    conducted_at: datetime
+
+
+@dataclass(frozen=True)
+class ListPendingActionItemsInput:
+    """Input DTO for ListPendingActionItemsService."""
+
+    actor_id: UserId
+    counterpart_id: UserId
+    limit: int = 50
+
+
+@dataclass(frozen=True)
+class ListPendingActionItemsOutput:
+    """Output DTO for ListPendingActionItemsService."""
+
+    items: list[PendingActionItemDTO]
+
+
+class ListPendingActionItemsService:
+    """Query pending (not completed) action items for a counterpart.
+
+    Authorization: the actor must have participated in at least one
+    Record where counterpart_id is the counterpart (as organizer or
+    as the counterpart themselves).
+
+    Results are ordered by created_at ascending (oldest first),
+    limited to ``limit`` items (default 50).
+
+    This is a read-only query service; no UoW or EventDispatcher is needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        action_item_repository: ActionItemRepository,
+        record_repository: RecordRepository,
+    ) -> None:
+        self._action_item_repository = action_item_repository
+        self._record_repository = record_repository
+
+    async def execute(
+        self, input_dto: ListPendingActionItemsInput
+    ) -> ListPendingActionItemsOutput:
+        # 1. Authorization: actor must be involved in records with this counterpart
+        has_access = await self._record_repository.exists_by_participant(
+            user_id=input_dto.actor_id,
+            counterpart_id=input_dto.counterpart_id,
+        )
+        if not has_access:
+            raise UnauthorizedOperationError(
+                "Actor is not involved in any records with this counterpart."
+            )
+
+        # 2. Fetch pending action items
+        pending_items = await self._action_item_repository.list_pending_by_counterpart(
+            input_dto.counterpart_id,
+            limit=input_dto.limit,
+        )
+
+        # 3. Collect record IDs to look up Record info
+        record_ids = {item.record_id for item in pending_items}
+        records_by_id: dict[RecordId, tuple[UserId, datetime]] = {}
+        for rid in record_ids:
+            record = await self._record_repository.get_by_id(rid)
+            if record is not None:
+                records_by_id[rid] = (record.organizer_id, record.conducted_at)
+
+        # 4. Build output DTOs
+        result_items: list[PendingActionItemDTO] = []
+        for item in pending_items:
+            record_info = records_by_id.get(item.record_id)
+            if record_info is None:
+                continue  # skip orphaned items (should not happen in practice)
+            organizer_id, conducted_at = record_info
+            result_items.append(
+                PendingActionItemDTO(
+                    action_item_id=item.id,
+                    content=item.title.value,
+                    created_at=item.created_at,
+                    record_id=item.record_id,
+                    organizer_id=organizer_id,
+                    conducted_at=conducted_at,
+                )
+            )
+
+        return ListPendingActionItemsOutput(items=result_items)

--- a/backend/contexts/record/application/list_pending_action_items.py
+++ b/backend/contexts/record/application/list_pending_action_items.py
@@ -47,6 +47,16 @@ class ListPendingActionItemsOutput:
     items: list[PendingActionItemDTO]
 
 
+MAX_LIMIT = 200
+
+
+class InvalidLimitError(Exception):
+    """limit must be between 1 and MAX_LIMIT (inclusive)."""
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(f"limit must be between 1 and {MAX_LIMIT}, got {limit}")
+
+
 class ListPendingActionItemsService:
     """Query pending (not completed) action items for a counterpart.
 
@@ -72,6 +82,10 @@ class ListPendingActionItemsService:
     async def execute(
         self, input_dto: ListPendingActionItemsInput
     ) -> ListPendingActionItemsOutput:
+        # 0. Validate limit
+        if not (1 <= input_dto.limit <= MAX_LIMIT):
+            raise InvalidLimitError(input_dto.limit)
+
         # 1. Authorization: actor must be involved in records with this counterpart
         has_access = await self._record_repository.exists_by_participant(
             user_id=input_dto.actor_id,

--- a/backend/contexts/record/domain/action_item_repository.py
+++ b/backend/contexts/record/domain/action_item_repository.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+from abc import abstractmethod
+
 from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.value_objects import ActionItemId
 from foundation.domain.base_repository import BaseRepository
+from shared.domain.value_objects import UserId
 
 
 class ActionItemRepository(BaseRepository[ActionItem, ActionItemId]):
     """Repository interface for ActionItem aggregates."""
 
-    pass  # get_by_id + save (insert or update)
+    # get_by_id + save (insert or update) inherited from BaseRepository
+
+    @abstractmethod
+    async def list_pending_by_counterpart(
+        self, counterpart_id: UserId, *, limit: int = 50
+    ) -> list[ActionItem]:
+        """Return pending (not completed) action items for a counterpart.
+
+        Results are ordered by created_at ascending (oldest first).
+        """

--- a/backend/contexts/record/domain/record_repository.py
+++ b/backend/contexts/record/domain/record_repository.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
+from abc import abstractmethod
+
 from contexts.record.domain.record import Record
 from contexts.record.domain.value_objects import RecordId
 from foundation.domain.base_repository import BaseRepository
+from shared.domain.value_objects import UserId
 
 
 class RecordRepository(BaseRepository[Record, RecordId]):
     """Repository interface for Record aggregates."""
 
-    pass  # get_by_id + save only
+    # get_by_id + save inherited from BaseRepository
+
+    @abstractmethod
+    async def exists_by_participant(
+        self, user_id: UserId, counterpart_id: UserId
+    ) -> bool:
+        """Check if user_id has participated in any Record with counterpart_id.
+
+        A participant is either the organizer or the counterpart of a Record
+        where counterpart_id is the counterpart.
+        """

--- a/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
@@ -9,6 +9,8 @@ from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle, 
 from contexts.record.infrastructure.tables import ActionItemTable
 from shared.domain.value_objects import UserId
 
+_DEFAULT_PENDING_LIMIT = 50
+
 
 class SqlAlchemyActionItemRepository(ActionItemRepository):
     """SQLAlchemy-based implementation of ActionItemRepository."""
@@ -30,6 +32,21 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
             await self._insert(entity)
         else:
             await self._update(entity, existing)
+
+    async def list_pending_by_counterpart(
+        self, counterpart_id: UserId, *, limit: int = _DEFAULT_PENDING_LIMIT
+    ) -> list[ActionItem]:
+        stmt = (
+            select(ActionItemTable)
+            .where(
+                ActionItemTable.counterpart_id == str(counterpart_id.value),
+                ActionItemTable.is_completed.is_(False),
+            )
+            .order_by(ActionItemTable.created_at.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [self._to_entity(row) for row in result.scalars().all()]
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
@@ -38,6 +38,21 @@ class SqlAlchemyRecordRepository(RecordRepository):
             await self._insert(entity)
         else:
             await self._update(entity, existing)
+
+    async def exists_by_participant(
+        self, user_id: UserId, counterpart_id: UserId
+    ) -> bool:
+        stmt = select(
+            exists().where(
+                RecordTable.counterpart_id == str(counterpart_id.value),
+                or_(
+                    RecordTable.organizer_id == str(user_id.value),
+                    RecordTable.counterpart_id == str(user_id.value),
+                ),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return bool(result.scalar())
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -71,7 +71,7 @@ class InMemoryActionItemRepository(ActionItemRepository):
             if item.counterpart_id == counterpart_id and not item.is_completed
         ]
         pending.sort(key=lambda item: item.created_at)
-        return pending[:limit]
+        return pending[: max(0, limit)]
 
     @property
     def saved_items(self) -> list[ActionItem]:

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -21,6 +21,7 @@ from contexts.record.domain.value_objects import (
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
 from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
 
 
 class InMemoryRecordRepository(RecordRepository):
@@ -34,6 +35,15 @@ class InMemoryRecordRepository(RecordRepository):
 
     async def save(self, entity: Record) -> None:
         self._records[entity.id] = entity
+
+    async def exists_by_participant(
+        self, user_id: UserId, counterpart_id: UserId
+    ) -> bool:
+        return any(
+            r.counterpart_id == counterpart_id
+            and (r.organizer_id == user_id or r.counterpart_id == user_id)
+            for r in self._records.values()
+        )
 
     @property
     def saved_records(self) -> list[Record]:
@@ -51,6 +61,17 @@ class InMemoryActionItemRepository(ActionItemRepository):
 
     async def save(self, entity: ActionItem) -> None:
         self._items[entity.id] = entity
+
+    async def list_pending_by_counterpart(
+        self, counterpart_id: UserId, *, limit: int = 50
+    ) -> list[ActionItem]:
+        pending = [
+            item
+            for item in self._items.values()
+            if item.counterpart_id == counterpart_id and not item.is_completed
+        ]
+        pending.sort(key=lambda item: item.created_at)
+        return pending[:limit]
 
     @property
     def saved_items(self) -> list[ActionItem]:

--- a/backend/tests/contexts/record/application/test_list_pending_action_items.py
+++ b/backend/tests/contexts/record/application/test_list_pending_action_items.py
@@ -1,0 +1,415 @@
+"""Tests for ListPendingActionItemsService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from contexts.record.application.list_pending_action_items import (
+    ListPendingActionItemsInput,
+    ListPendingActionItemsOutput,
+    ListPendingActionItemsService,
+)
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.exceptions import UnauthorizedOperationError
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import ActionItemTitle, RecordId
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    InMemoryActionItemRepository,
+    InMemoryRecordRepository,
+)
+
+
+def _make_record(
+    *,
+    organizer: UserId | None = None,
+    counterpart: UserId | None = None,
+    conducted_at: datetime | None = None,
+    now: datetime | None = None,
+) -> Record:
+    record = Record.create(
+        organizer_id=organizer or UserId.generate(),
+        counterpart_id=counterpart or UserId.generate(),
+        conducted_at=conducted_at or datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        now=now,
+    )
+    record.collect_events()
+    return record
+
+
+def _make_action_item(
+    *,
+    counterpart: UserId,
+    record_id: RecordId,
+    organizer: UserId,
+    title: str = "Follow up",
+    now: datetime | None = None,
+) -> ActionItem:
+    item = ActionItem.create(
+        counterpart_id=counterpart,
+        record_id=record_id,
+        title=ActionItemTitle(title),
+        actor_id=organizer,
+        organizer_id=organizer,
+        now=now,
+    )
+    item.collect_events()
+    return item
+
+
+def _build_service(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+    action_item_repo: InMemoryActionItemRepository | None = None,
+) -> tuple[
+    ListPendingActionItemsService,
+    InMemoryRecordRepository,
+    InMemoryActionItemRepository,
+]:
+    rr = record_repo or InMemoryRecordRepository()
+    air = action_item_repo or InMemoryActionItemRepository()
+    svc = ListPendingActionItemsService(
+        action_item_repository=air,
+        record_repository=rr,
+    )
+    return svc, rr, air
+
+
+class TestListPendingActionItems:
+    """Tests for successful pending action item retrieval."""
+
+    async def test_returns_pending_items_for_counterpart(self) -> None:
+        """Basic retrieval of pending action items."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+        item = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Review document",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        await air.save(item)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert isinstance(output, ListPendingActionItemsOutput)
+        assert len(output.items) == 1
+        dto = output.items[0]
+        assert dto.action_item_id == item.id
+        assert dto.content == "Review document"
+        assert dto.record_id == record.id
+        assert dto.organizer_id == organizer
+        assert dto.conducted_at == record.conducted_at
+
+    async def test_excludes_completed_items(self) -> None:
+        """Completed action items are not returned."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        pending = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Pending task",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+        completed = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Done task",
+            now=datetime(2026, 3, 1, 12, 0, tzinfo=UTC),
+        )
+        completed.complete(
+            actor_id=counterpart,
+            now=datetime(2026, 3, 2, 10, 0, tzinfo=UTC),
+        )
+        completed.collect_events()
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        await air.save(pending)
+        await air.save(completed)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert len(output.items) == 1
+        assert output.items[0].content == "Pending task"
+
+    async def test_returns_items_ordered_by_created_at_ascending(self) -> None:
+        """Items are returned oldest first."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        item_old = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Old task",
+            now=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        item_new = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="New task",
+            now=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        # Save in reverse order to verify sorting
+        await air.save(item_new)
+        await air.save(item_old)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert len(output.items) == 2
+        assert output.items[0].content == "Old task"
+        assert output.items[1].content == "New task"
+
+    async def test_respects_limit(self) -> None:
+        """Only up to limit items are returned."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+
+        for i in range(5):
+            item = _make_action_item(
+                counterpart=counterpart,
+                record_id=record.id,
+                organizer=organizer,
+                title=f"Task {i}",
+                now=datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC),
+            )
+            await air.save(item)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+                limit=3,
+            )
+        )
+
+        assert len(output.items) == 3
+        # Should be the 3 oldest
+        assert output.items[0].content == "Task 0"
+        assert output.items[1].content == "Task 1"
+        assert output.items[2].content == "Task 2"
+
+    async def test_default_limit_is_50(self) -> None:
+        """Default limit should be 50."""
+        input_dto = ListPendingActionItemsInput(
+            actor_id=UserId.generate(),
+            counterpart_id=UserId.generate(),
+        )
+        assert input_dto.limit == 50
+
+    async def test_counterpart_can_query_own_items(self) -> None:
+        """The counterpart themselves can query their own pending items."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+        item = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Self check",
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        await air.save(item)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=counterpart,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert len(output.items) == 1
+        assert output.items[0].content == "Self check"
+
+    async def test_includes_items_from_multiple_records(self) -> None:
+        """Items from different records with the same counterpart are aggregated."""
+        organizer_a = UserId.generate()
+        organizer_b = UserId.generate()
+        counterpart = UserId.generate()
+
+        record_a = _make_record(
+            organizer=organizer_a,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 2, 1, 10, 0, tzinfo=UTC),
+        )
+        record_b = _make_record(
+            organizer=organizer_b,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        )
+
+        item_a = _make_action_item(
+            counterpart=counterpart,
+            record_id=record_a.id,
+            organizer=organizer_a,
+            title="From record A",
+            now=datetime(2026, 2, 1, 11, 0, tzinfo=UTC),
+        )
+        item_b = _make_action_item(
+            counterpart=counterpart,
+            record_id=record_b.id,
+            organizer=organizer_b,
+            title="From record B",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record_a)
+        await rr.save(record_b)
+        await air.save(item_a)
+        await air.save(item_b)
+
+        # organizer_a can see all items for this counterpart
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer_a,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert len(output.items) == 2
+        contents = {dto.content for dto in output.items}
+        assert contents == {"From record A", "From record B"}
+
+    async def test_each_item_includes_record_info(self) -> None:
+        """Each DTO contains the originating Record's info."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        conducted = datetime(2026, 3, 15, 14, 0, tzinfo=UTC)
+        record = _make_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=conducted,
+        )
+        item = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Check status",
+            now=datetime(2026, 3, 15, 15, 0, tzinfo=UTC),
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        await air.save(item)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        dto = output.items[0]
+        assert dto.record_id == record.id
+        assert dto.organizer_id == organizer
+        assert dto.conducted_at == conducted
+        assert dto.created_at == datetime(2026, 3, 15, 15, 0, tzinfo=UTC)
+
+    async def test_returns_empty_when_no_pending_items(self) -> None:
+        """Returns empty list when counterpart has no pending items."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.items == []
+
+
+class TestListPendingActionItemsAuthorization:
+    """Tests for authorization checks."""
+
+    async def test_raises_when_actor_not_involved(self) -> None:
+        """Unrelated user cannot query pending items."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        with pytest.raises(UnauthorizedOperationError):
+            await svc.execute(
+                ListPendingActionItemsInput(
+                    actor_id=outsider,
+                    counterpart_id=counterpart,
+                )
+            )
+
+    async def test_raises_when_no_records_exist(self) -> None:
+        """No records at all means no access."""
+        svc, _rr, _air = _build_service()
+
+        with pytest.raises(UnauthorizedOperationError):
+            await svc.execute(
+                ListPendingActionItemsInput(
+                    actor_id=UserId.generate(),
+                    counterpart_id=UserId.generate(),
+                )
+            )
+
+    async def test_organizer_of_different_counterpart_cannot_access(self) -> None:
+        """An organizer with records for a different counterpart is denied."""
+        organizer = UserId.generate()
+        counterpart_a = UserId.generate()
+        counterpart_b = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart_a)
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        with pytest.raises(UnauthorizedOperationError):
+            await svc.execute(
+                ListPendingActionItemsInput(
+                    actor_id=organizer,
+                    counterpart_id=counterpart_b,
+                )
+            )

--- a/backend/tests/contexts/record/application/test_list_pending_action_items.py
+++ b/backend/tests/contexts/record/application/test_list_pending_action_items.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 import pytest
 
 from contexts.record.application.list_pending_action_items import (
+    MAX_LIMIT,
+    InvalidLimitError,
     ListPendingActionItemsInput,
     ListPendingActionItemsOutput,
     ListPendingActionItemsService,
@@ -413,3 +415,91 @@ class TestListPendingActionItemsAuthorization:
                     counterpart_id=counterpart_b,
                 )
             )
+
+
+class TestListPendingActionItemsLimitValidation:
+    """Tests for limit parameter validation."""
+
+    async def test_limit_zero_raises(self) -> None:
+        """limit=0 is rejected before any repository call."""
+        svc, _rr, _air = _build_service()
+
+        with pytest.raises(InvalidLimitError):
+            await svc.execute(
+                ListPendingActionItemsInput(
+                    actor_id=UserId.generate(),
+                    counterpart_id=UserId.generate(),
+                    limit=0,
+                )
+            )
+
+    async def test_limit_negative_raises(self) -> None:
+        """limit=-1 is rejected."""
+        svc, _rr, _air = _build_service()
+
+        with pytest.raises(InvalidLimitError):
+            await svc.execute(
+                ListPendingActionItemsInput(
+                    actor_id=UserId.generate(),
+                    counterpart_id=UserId.generate(),
+                    limit=-1,
+                )
+            )
+
+    async def test_limit_exceeds_max_raises(self) -> None:
+        """limit above MAX_LIMIT is rejected."""
+        svc, _rr, _air = _build_service()
+
+        with pytest.raises(InvalidLimitError):
+            await svc.execute(
+                ListPendingActionItemsInput(
+                    actor_id=UserId.generate(),
+                    counterpart_id=UserId.generate(),
+                    limit=MAX_LIMIT + 1,
+                )
+            )
+
+    async def test_limit_at_max_is_accepted(self) -> None:
+        """limit=MAX_LIMIT is valid (boundary)."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+                limit=MAX_LIMIT,
+            )
+        )
+
+        assert output.items == []
+
+    async def test_limit_one_is_accepted(self) -> None:
+        """limit=1 is the minimum valid value."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+        item = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Single item",
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        await air.save(item)
+
+        output = await svc.execute(
+            ListPendingActionItemsInput(
+                actor_id=organizer,
+                counterpart_id=counterpart,
+                limit=1,
+            )
+        )
+
+        assert len(output.items) == 1


### PR DESCRIPTION
## Summary
- ListPendingActionItemsService を Record コンテキストの application 層に追加。カウンターパート単位で未完了アクションアイテムを取得する read-only クエリサービス
- ActionItemRepository に list_pending_by_counterpart()、RecordRepository に exists_by_participant() を追加し、SQLAlchemy 実装も対応
- 権限チェック（actor が該当カウンターパートとの Record に関与していること）を実装
- ユニットテスト 12 件を追加（取得・ソート順・上限・権限チェック等）

## Test plan
- [x] 未完了アクションアイテムの基本取得
- [x] 完了済みアイテムの除外
- [x] created_at 昇順のソート
- [x] limit パラメータの適用（デフォルト50）
- [x] 各アイテムに Record 情報（record_id, organizer_id, conducted_at）が含まれる
- [x] カウンターパート自身がクエリ可能
- [x] 複数 Record からのアイテム集約
- [x] 無関係ユーザーからのアクセス拒否
- [x] Record が存在しない場合のアクセス拒否
- [x] 異なるカウンターパートの Record では権限なし

Closes #103
