### PR TITLE
Read Model: 1on1履歴一覧・前回サマリークエリサービス

### DIFF
--- a/backend/contexts/record/application/get_last_session_summary.py
+++ b/backend/contexts/record/application/get_last_session_summary.py
@@ -1,0 +1,104 @@
+"""Read-only query service: get last session summary for a pair.
+
+Returns the most recent published Record's summary (memo excerpt +
+action items) for a given organizer-counterpart pair.
+
+No UoW or EventDispatcher needed (read-only).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import ActionItemId, RecordId
+from shared.domain.value_objects import UserId
+
+_SUMMARY_MEMO_EXCERPT_LENGTH = 200
+
+
+@dataclass(frozen=True)
+class ActionItemSummaryDTO:
+    """Single action item in the session summary."""
+
+    action_item_id: ActionItemId
+    content: str
+    is_completed: bool
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class GetLastSessionSummaryInput:
+    """Input DTO for GetLastSessionSummaryService."""
+
+    actor_id: UserId
+    organizer_id: UserId
+    counterpart_id: UserId
+
+
+@dataclass(frozen=True)
+class GetLastSessionSummaryOutput:
+    """Output DTO for GetLastSessionSummaryService.
+
+    None is returned by execute() when no matching Record exists.
+    """
+
+    record_id: RecordId
+    conducted_at: datetime
+    memo_excerpt: str
+    action_items: list[ActionItemSummaryDTO]
+
+
+class GetLastSessionSummaryService:
+    """Query the last session summary for a pair.
+
+    Returns the most recent published Record visible to actor,
+    including all action items (completed and pending) for that Record.
+
+    Returns None when no matching Record exists.
+
+    This is a read-only query service; no UoW or EventDispatcher is needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        action_item_repository: ActionItemRepository,
+    ) -> None:
+        self._record_repository = record_repository
+        self._action_item_repository = action_item_repository
+
+    async def execute(
+        self, input_dto: GetLastSessionSummaryInput
+    ) -> GetLastSessionSummaryOutput | None:
+        # 1. Get the latest visible published record for the pair
+        record = await self._record_repository.get_latest_visible_published_by_pair(
+            actor_id=input_dto.actor_id,
+            organizer_id=input_dto.organizer_id,
+            counterpart_id=input_dto.counterpart_id,
+        )
+
+        if record is None:
+            return None
+
+        # 2. Fetch all action items for that record (created_at asc)
+        action_items = await self._action_item_repository.list_by_record_id(record.id)
+
+        # 3. Build output
+        return GetLastSessionSummaryOutput(
+            record_id=record.id,
+            conducted_at=record.conducted_at,
+            memo_excerpt=record.memo.value[:_SUMMARY_MEMO_EXCERPT_LENGTH],
+            action_items=[
+                ActionItemSummaryDTO(
+                    action_item_id=ai.id,
+                    content=ai.title.value,
+                    is_completed=ai.is_completed,
+                    created_at=ai.created_at,
+                )
+                for ai in action_items
+            ],
+        )

--- a/backend/contexts/record/application/list_oneonone_history.py
+++ b/backend/contexts/record/application/list_oneonone_history.py
@@ -1,0 +1,118 @@
+"""Read-only query service: list 1-on-1 history for a pair.
+
+Returns published Records for a given organizer-counterpart pair,
+visible to the requesting actor, with offset-based pagination.
+
+No UoW or EventDispatcher needed (read-only).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import RecordId
+from shared.domain.value_objects import UserId
+
+_DEFAULT_MEMO_EXCERPT_LENGTH = 100
+_DEFAULT_LIMIT = 20
+_MAX_LIMIT = 200
+
+
+@dataclass(frozen=True)
+class OneOnOneHistoryItemDTO:
+    """Single history item with excerpt."""
+
+    record_id: RecordId
+    organizer_id: UserId
+    counterpart_id: UserId
+    conducted_at: datetime
+    memo_excerpt: str
+    schedule_id: ScheduleId | None
+
+
+@dataclass(frozen=True)
+class ListOneOnOneHistoryInput:
+    """Input DTO for ListOneOnOneHistoryService."""
+
+    actor_id: UserId
+    organizer_id: UserId
+    counterpart_id: UserId
+    offset: int = 0
+    limit: int = _DEFAULT_LIMIT
+
+
+@dataclass(frozen=True)
+class ListOneOnOneHistoryOutput:
+    """Output DTO for ListOneOnOneHistoryService."""
+
+    items: list[OneOnOneHistoryItemDTO]
+    total_count: int
+
+
+class InvalidPaginationError(Exception):
+    """offset or limit is out of valid range."""
+
+
+class ListOneOnOneHistoryService:
+    """Query published 1-on-1 history for a pair, visible to actor.
+
+    Authorization:
+    - Organizer / counterpart: can see all published Records for the pair.
+    - Viewer: can see only published Records where they are in the viewers list.
+
+    Visibility filtering is delegated to the repository.
+
+    This is a read-only query service; no UoW or EventDispatcher is needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+    ) -> None:
+        self._record_repository = record_repository
+
+    async def execute(
+        self, input_dto: ListOneOnOneHistoryInput
+    ) -> ListOneOnOneHistoryOutput:
+        # 0. Validate pagination params
+        if input_dto.offset < 0:
+            raise InvalidPaginationError(f"offset must be >= 0, got {input_dto.offset}")
+        if not (1 <= input_dto.limit <= _MAX_LIMIT):
+            raise InvalidPaginationError(
+                f"limit must be between 1 and {_MAX_LIMIT}, got {input_dto.limit}"
+            )
+
+        # 1. Fetch visible published records for the pair
+        records = await self._record_repository.list_visible_published_by_pair(
+            actor_id=input_dto.actor_id,
+            organizer_id=input_dto.organizer_id,
+            counterpart_id=input_dto.counterpart_id,
+            offset=input_dto.offset,
+            limit=input_dto.limit,
+        )
+
+        # 2. Count total visible published records
+        total_count = await self._record_repository.count_visible_published_by_pair(
+            actor_id=input_dto.actor_id,
+            organizer_id=input_dto.organizer_id,
+            counterpart_id=input_dto.counterpart_id,
+        )
+
+        # 3. Build output DTOs
+        items = [
+            OneOnOneHistoryItemDTO(
+                record_id=r.id,
+                organizer_id=r.organizer_id,
+                counterpart_id=r.counterpart_id,
+                conducted_at=r.conducted_at,
+                memo_excerpt=r.memo.value[:_DEFAULT_MEMO_EXCERPT_LENGTH],
+                schedule_id=r.schedule_id,
+            )
+            for r in records
+        ]
+
+        return ListOneOnOneHistoryOutput(items=items, total_count=total_count)

--- a/backend/contexts/record/domain/action_item_repository.py
+++ b/backend/contexts/record/domain/action_item_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 
 from contexts.record.domain.action_item import ActionItem
-from contexts.record.domain.value_objects import ActionItemId
+from contexts.record.domain.value_objects import ActionItemId, RecordId
 from foundation.domain.base_repository import BaseRepository
 from shared.domain.value_objects import UserId
 
@@ -18,6 +18,13 @@ class ActionItemRepository(BaseRepository[ActionItem, ActionItemId]):
         self, counterpart_id: UserId, *, limit: int = 50
     ) -> list[ActionItem]:
         """Return pending (not completed) action items for a counterpart.
+
+        Results are ordered by created_at ascending (oldest first).
+        """
+
+    @abstractmethod
+    async def list_by_record_id(self, record_id: RecordId) -> list[ActionItem]:
+        """Return all action items for a given Record.
 
         Results are ordered by created_at ascending (oldest first).
         """

--- a/backend/contexts/record/domain/record_repository.py
+++ b/backend/contexts/record/domain/record_repository.py
@@ -22,3 +22,39 @@ class RecordRepository(BaseRepository[Record, RecordId]):
         A participant is either the organizer or the counterpart of a Record
         where counterpart_id is the counterpart.
         """
+
+    @abstractmethod
+    async def list_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+        offset: int,
+        limit: int,
+    ) -> list[Record]:
+        """Return published Records for a pair, visible to actor.
+
+        Visibility: actor is organizer, counterpart, or in viewers list.
+        Ordered by conducted_at DESC, then created_at DESC.
+        """
+
+    @abstractmethod
+    async def count_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> int:
+        """Count published Records for a pair, visible to actor."""
+
+    @abstractmethod
+    async def get_latest_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> Record | None:
+        """Return the latest published Record for a pair, visible to actor.
+
+        Latest = highest conducted_at (then created_at as tiebreaker).
+        """

--- a/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
@@ -48,6 +48,15 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
         result = await self._session.execute(stmt)
         return [self._to_entity(row) for row in result.scalars().all()]
 
+    async def list_by_record_id(self, record_id: RecordId) -> list[ActionItem]:
+        stmt = (
+            select(ActionItemTable)
+            .where(ActionItemTable.record_id == str(record_id.value))
+            .order_by(ActionItemTable.created_at.asc())
+        )
+        result = await self._session.execute(stmt)
+        return [self._to_entity(row) for row in result.scalars().all()]
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import exists, or_, select
+from sqlalchemy import exists, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
@@ -62,11 +62,13 @@ class SqlAlchemyRecordRepository(RecordRepository):
         offset: int,
         limit: int,
     ) -> list[Record]:
-        stmt = self._visible_published_by_pair_stmt(
+        id_subq = self._visible_record_ids_subquery(
             actor_id, organizer_id, counterpart_id
         )
         stmt = (
-            stmt.order_by(
+            select(RecordTable)
+            .where(RecordTable.id.in_(id_subq))
+            .order_by(
                 RecordTable.conducted_at.desc(),
                 RecordTable.created_at.desc(),
             )
@@ -74,7 +76,7 @@ class SqlAlchemyRecordRepository(RecordRepository):
             .limit(limit)
         )
         result = await self._session.execute(stmt)
-        return [self._to_entity(row) for row in result.unique().scalars().all()]
+        return [self._to_entity(row) for row in result.scalars().all()]
 
     async def count_visible_published_by_pair(
         self,
@@ -82,12 +84,13 @@ class SqlAlchemyRecordRepository(RecordRepository):
         organizer_id: UserId,
         counterpart_id: UserId,
     ) -> int:
-        from sqlalchemy import func
-
-        base = self._visible_published_by_pair_stmt(
+        id_subq = self._visible_record_ids_subquery(
             actor_id, organizer_id, counterpart_id
-        ).with_only_columns(func.count(RecordTable.id))
-        result = await self._session.execute(base)
+        )
+        stmt = select(func.count()).select_from(
+            select(RecordTable.id).where(RecordTable.id.in_(id_subq)).subquery()
+        )
+        result = await self._session.execute(stmt)
         return int(result.scalar() or 0)
 
     async def get_latest_visible_published_by_pair(
@@ -106,19 +109,23 @@ class SqlAlchemyRecordRepository(RecordRepository):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _visible_published_by_pair_stmt(
+    def _visible_record_ids_subquery(
         actor_id: UserId,
         organizer_id: UserId,
         counterpart_id: UserId,
-    ) -> select:  # type: ignore[type-arg]
-        """Build base SELECT for published records visible to actor."""
+    ):  # type: ignore[no-untyped-def]
+        """Build a subquery returning record IDs visible to actor.
+
+        Uses EXISTS subquery for viewer check instead of JOIN to avoid
+        row duplication that breaks offset/limit and count.
+        """
         actor_str = str(actor_id.value)
+        viewer_exists = exists().where(
+            RecordViewerTable.record_id == RecordTable.id,
+            RecordViewerTable.user_id == actor_str,
+        )
         return (
-            select(RecordTable)
-            .outerjoin(
-                RecordViewerTable,
-                RecordTable.id == RecordViewerTable.record_id,
-            )
+            select(RecordTable.id)
             .where(
                 RecordTable.organizer_id == str(organizer_id.value),
                 RecordTable.counterpart_id == str(counterpart_id.value),
@@ -126,9 +133,10 @@ class SqlAlchemyRecordRepository(RecordRepository):
                 or_(
                     RecordTable.organizer_id == actor_str,
                     RecordTable.counterpart_id == actor_str,
-                    RecordViewerTable.user_id == actor_str,
+                    viewer_exists,
                 ),
             )
+            .subquery()
         )
 
     async def _insert(self, entity: Record) -> None:

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -67,7 +67,7 @@ class SqlAlchemyRecordRepository(RecordRepository):
         )
         stmt = (
             select(RecordTable)
-            .where(RecordTable.id.in_(id_subq))
+            .where(RecordTable.id.in_(select(id_subq.c.id)))
             .order_by(
                 RecordTable.conducted_at.desc(),
                 RecordTable.created_at.desc(),
@@ -87,9 +87,7 @@ class SqlAlchemyRecordRepository(RecordRepository):
         id_subq = self._visible_record_ids_subquery(
             actor_id, organizer_id, counterpart_id
         )
-        stmt = select(func.count()).select_from(
-            select(RecordTable.id).where(RecordTable.id.in_(id_subq)).subquery()
-        )
+        stmt = select(func.count()).select_from(id_subq)
         result = await self._session.execute(stmt)
         return int(result.scalar() or 0)
 

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -54,9 +54,82 @@ class SqlAlchemyRecordRepository(RecordRepository):
         result = await self._session.execute(stmt)
         return bool(result.scalar())
 
+    async def list_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+        offset: int,
+        limit: int,
+    ) -> list[Record]:
+        stmt = self._visible_published_by_pair_stmt(
+            actor_id, organizer_id, counterpart_id
+        )
+        stmt = (
+            stmt.order_by(
+                RecordTable.conducted_at.desc(),
+                RecordTable.created_at.desc(),
+            )
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [self._to_entity(row) for row in result.unique().scalars().all()]
+
+    async def count_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> int:
+        from sqlalchemy import func
+
+        base = self._visible_published_by_pair_stmt(
+            actor_id, organizer_id, counterpart_id
+        ).with_only_columns(func.count(RecordTable.id))
+        result = await self._session.execute(base)
+        return int(result.scalar() or 0)
+
+    async def get_latest_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> Record | None:
+        records = await self.list_visible_published_by_pair(
+            actor_id, organizer_id, counterpart_id, offset=0, limit=1
+        )
+        return records[0] if records else None
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _visible_published_by_pair_stmt(
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> select:  # type: ignore[type-arg]
+        """Build base SELECT for published records visible to actor."""
+        actor_str = str(actor_id.value)
+        return (
+            select(RecordTable)
+            .outerjoin(
+                RecordViewerTable,
+                RecordTable.id == RecordViewerTable.record_id,
+            )
+            .where(
+                RecordTable.organizer_id == str(organizer_id.value),
+                RecordTable.counterpart_id == str(counterpart_id.value),
+                RecordTable.status == RecordStatus.PUBLISHED.value,
+                or_(
+                    RecordTable.organizer_id == actor_str,
+                    RecordTable.counterpart_id == actor_str,
+                    RecordViewerTable.user_id == actor_str,
+                ),
+            )
+        )
 
     async def _insert(self, entity: Record) -> None:
         record_row = RecordTable(

--- a/backend/tests/contexts/notification/application/handlers/conftest.py
+++ b/backend/tests/contexts/notification/application/handlers/conftest.py
@@ -107,6 +107,32 @@ class InMemoryRecordRepository(RecordRepository):
             for r in self._records.values()
         )
 
+    async def list_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+        offset: int,
+        limit: int,
+    ) -> list[Record]:
+        return []  # not needed for handler tests
+
+    async def count_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> int:
+        return 0  # not needed for handler tests
+
+    async def get_latest_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> Record | None:
+        return None  # not needed for handler tests
+
     def add(self, record: Record) -> None:
         """Pre-populate a record for testing."""
         self._records[record.id] = record

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -45,6 +45,61 @@ class InMemoryRecordRepository(RecordRepository):
             for r in self._records.values()
         )
 
+    async def list_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+        offset: int,
+        limit: int,
+    ) -> list[Record]:
+        visible = self._visible_published_for_pair(
+            actor_id, organizer_id, counterpart_id
+        )
+        visible.sort(key=lambda r: (r.conducted_at, r.created_at), reverse=True)
+        return visible[offset : offset + limit]
+
+    async def count_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> int:
+        return len(
+            self._visible_published_for_pair(actor_id, organizer_id, counterpart_id)
+        )
+
+    async def get_latest_visible_published_by_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> Record | None:
+        visible = self._visible_published_for_pair(
+            actor_id, organizer_id, counterpart_id
+        )
+        if not visible:
+            return None
+        visible.sort(key=lambda r: (r.conducted_at, r.created_at), reverse=True)
+        return visible[0]
+
+    def _visible_published_for_pair(
+        self,
+        actor_id: UserId,
+        organizer_id: UserId,
+        counterpart_id: UserId,
+    ) -> list[Record]:
+        from contexts.record.domain.value_objects import RecordStatus
+
+        return [
+            r
+            for r in self._records.values()
+            if r.organizer_id == organizer_id
+            and r.counterpart_id == counterpart_id
+            and r.status == RecordStatus.PUBLISHED
+            and r.is_visible_to(actor_id)
+        ]
+
     @property
     def saved_records(self) -> list[Record]:
         return list(self._records.values())
@@ -72,6 +127,11 @@ class InMemoryActionItemRepository(ActionItemRepository):
         ]
         pending.sort(key=lambda item: item.created_at)
         return pending[: max(0, limit)]
+
+    async def list_by_record_id(self, record_id: RecordId) -> list[ActionItem]:
+        items = [item for item in self._items.values() if item.record_id == record_id]
+        items.sort(key=lambda item: item.created_at)
+        return items
 
     @property
     def saved_items(self) -> list[ActionItem]:

--- a/backend/tests/contexts/record/application/test_get_last_session_summary.py
+++ b/backend/tests/contexts/record/application/test_get_last_session_summary.py
@@ -1,0 +1,414 @@
+"""Tests for GetLastSessionSummaryService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from contexts.record.application.get_last_session_summary import (
+    GetLastSessionSummaryInput,
+    GetLastSessionSummaryOutput,
+    GetLastSessionSummaryService,
+)
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.memo import Memo
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import ActionItemTitle, RecordId
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    InMemoryActionItemRepository,
+    InMemoryRecordRepository,
+)
+
+
+def _make_published_record(
+    *,
+    organizer: UserId,
+    counterpart: UserId,
+    conducted_at: datetime | None = None,
+    memo: str = "",
+    viewers: list[UserId] | None = None,
+    now: datetime | None = None,
+) -> Record:
+    """Create a published Record for testing."""
+    ts = now or datetime(2026, 3, 1, 10, 0, tzinfo=UTC)
+    record = Record.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        conducted_at=conducted_at or ts,
+        now=ts,
+    )
+    if memo:
+        record.update_memo(memo=Memo(memo), actor_id=organizer, now=ts)
+    if viewers:
+        record.set_viewers(viewer_ids=viewers, actor_id=organizer, now=ts)
+    record.publish(actor_id=organizer, now=ts)
+    record.collect_events()
+    return record
+
+
+def _make_action_item(
+    *,
+    counterpart: UserId,
+    record_id: RecordId,
+    organizer: UserId,
+    title: str = "Follow up",
+    now: datetime | None = None,
+) -> ActionItem:
+    item = ActionItem.create(
+        counterpart_id=counterpart,
+        record_id=record_id,
+        title=ActionItemTitle(title),
+        actor_id=organizer,
+        organizer_id=organizer,
+        now=now,
+    )
+    item.collect_events()
+    return item
+
+
+def _build_service(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+    action_item_repo: InMemoryActionItemRepository | None = None,
+) -> tuple[
+    GetLastSessionSummaryService,
+    InMemoryRecordRepository,
+    InMemoryActionItemRepository,
+]:
+    rr = record_repo or InMemoryRecordRepository()
+    air = action_item_repo or InMemoryActionItemRepository()
+    svc = GetLastSessionSummaryService(
+        record_repository=rr,
+        action_item_repository=air,
+    )
+    return svc, rr, air
+
+
+class TestGetLastSessionSummary:
+    """Tests for successful summary retrieval."""
+
+    async def test_returns_latest_record_summary(self) -> None:
+        """Returns the most recent published record for the pair."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        old_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+            memo="old memo",
+            now=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        new_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+            memo="new memo",
+            now=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        )
+
+        svc, rr, _air = _build_service()
+        await rr.save(old_record)
+        await rr.save(new_record)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert isinstance(output, GetLastSessionSummaryOutput)
+        assert output.record_id == new_record.id
+        assert output.conducted_at == datetime(2026, 3, 1, 10, 0, tzinfo=UTC)
+        assert output.memo_excerpt == "new memo"
+
+    async def test_returns_none_when_no_records(self) -> None:
+        """Returns None when no matching record exists."""
+        svc, _rr, _air = _build_service()
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=UserId.generate(),
+                organizer_id=UserId.generate(),
+                counterpart_id=UserId.generate(),
+            )
+        )
+
+        assert output is None
+
+    async def test_memo_excerpt_truncated_to_200(self) -> None:
+        """Memo excerpt in summary is truncated to 200 characters."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        long_memo = "x" * 300
+        record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            memo=long_memo,
+        )
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert len(output.memo_excerpt) == 200
+
+    async def test_includes_all_action_items(self) -> None:
+        """All action items (completed and pending) are included."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        pending = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Pending task",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+        completed = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Done task",
+            now=datetime(2026, 3, 1, 12, 0, tzinfo=UTC),
+        )
+        completed.complete(
+            actor_id=counterpart,
+            now=datetime(2026, 3, 2, 10, 0, tzinfo=UTC),
+        )
+        completed.collect_events()
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        await air.save(pending)
+        await air.save(completed)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert len(output.action_items) == 2
+
+        # Verify completed status
+        items_by_content = {ai.content: ai for ai in output.action_items}
+        assert not items_by_content["Pending task"].is_completed
+        assert items_by_content["Done task"].is_completed
+
+    async def test_action_items_ordered_by_created_at_ascending(self) -> None:
+        """Action items are returned oldest-first."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        item_old = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Old item",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+        item_new = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="New item",
+            now=datetime(2026, 3, 1, 14, 0, tzinfo=UTC),
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        # Save in reverse order
+        await air.save(item_new)
+        await air.save(item_old)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert len(output.action_items) == 2
+        assert output.action_items[0].content == "Old item"
+        assert output.action_items[1].content == "New item"
+
+    async def test_action_item_dto_fields(self) -> None:
+        """Each action item DTO has the correct fields."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+        item_ts = datetime(2026, 3, 1, 11, 30, tzinfo=UTC)
+        item = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Check status",
+            now=item_ts,
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        await air.save(item)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert len(output.action_items) == 1
+        ai_dto = output.action_items[0]
+        assert ai_dto.action_item_id == item.id
+        assert ai_dto.content == "Check status"
+        assert ai_dto.is_completed is False
+        assert ai_dto.created_at == item_ts
+
+    async def test_no_action_items_returns_empty_list(self) -> None:
+        """When the record has no action items, returns empty list."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert output.action_items == []
+
+
+class TestGetLastSessionSummaryVisibility:
+    """Tests for viewer-based visibility in summary."""
+
+    async def test_counterpart_can_get_summary(self) -> None:
+        """The counterpart can get the last session summary."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=counterpart,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert output.record_id == record.id
+
+    async def test_viewer_gets_visible_record(self) -> None:
+        """A viewer gets the latest record they can see."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        viewer = UserId.generate()
+
+        # Older record visible to viewer
+        visible_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            viewers=[viewer],
+            conducted_at=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        # Newer record NOT visible to viewer
+        _invisible_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        )
+
+        svc, rr, _air = _build_service()
+        await rr.save(visible_record)
+        await rr.save(_invisible_record)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=viewer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is not None
+        assert output.record_id == visible_record.id
+
+    async def test_outsider_gets_none(self) -> None:
+        """A user not in organizer/counterpart/viewers gets None."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, _air = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=outsider,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is None
+
+    async def test_excludes_draft_records(self) -> None:
+        """Draft records are not returned even for organizer."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        draft = Record.create(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            conducted_at=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        )
+        draft.collect_events()
+
+        svc, rr, _air = _build_service()
+        await rr.save(draft)
+
+        output = await svc.execute(
+            GetLastSessionSummaryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output is None

--- a/backend/tests/contexts/record/application/test_list_oneonone_history.py
+++ b/backend/tests/contexts/record/application/test_list_oneonone_history.py
@@ -1,0 +1,532 @@
+"""Tests for ListOneOnOneHistoryService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from contexts.record.application.list_oneonone_history import (
+    InvalidPaginationError,
+    ListOneOnOneHistoryInput,
+    ListOneOnOneHistoryOutput,
+    ListOneOnOneHistoryService,
+)
+from contexts.record.domain.memo import Memo
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import RecordStatus
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import InMemoryRecordRepository
+
+
+def _make_published_record(
+    *,
+    organizer: UserId,
+    counterpart: UserId,
+    conducted_at: datetime | None = None,
+    memo: str = "",
+    viewers: list[UserId] | None = None,
+    now: datetime | None = None,
+) -> Record:
+    """Create a published Record for testing."""
+    ts = now or datetime(2026, 3, 1, 10, 0, tzinfo=UTC)
+    record = Record.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        conducted_at=conducted_at or ts,
+        now=ts,
+    )
+    if memo:
+        record.update_memo(memo=Memo(memo), actor_id=organizer, now=ts)
+    if viewers:
+        record.set_viewers(viewer_ids=viewers, actor_id=organizer, now=ts)
+    record.publish(actor_id=organizer, now=ts)
+    record.collect_events()
+    return record
+
+
+def _build_service(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+) -> tuple[ListOneOnOneHistoryService, InMemoryRecordRepository]:
+    rr = record_repo or InMemoryRecordRepository()
+    svc = ListOneOnOneHistoryService(record_repository=rr)
+    return svc, rr
+
+
+class TestListOneOnOneHistory:
+    """Tests for successful history retrieval."""
+
+    async def test_returns_published_records_for_pair(self) -> None:
+        """Basic retrieval of published records for a pair."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert isinstance(output, ListOneOnOneHistoryOutput)
+        assert len(output.items) == 1
+        assert output.total_count == 1
+        assert output.items[0].record_id == record.id
+        assert output.items[0].organizer_id == organizer
+        assert output.items[0].counterpart_id == counterpart
+
+    async def test_excludes_draft_records(self) -> None:
+        """Draft records are not included in history."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        published = _make_published_record(organizer=organizer, counterpart=counterpart)
+        draft = Record.create(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            conducted_at=datetime(2026, 4, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 4, 1, 10, 0, tzinfo=UTC),
+        )
+        draft.collect_events()
+        assert draft.status == RecordStatus.DRAFT
+
+        svc, rr = _build_service()
+        await rr.save(published)
+        await rr.save(draft)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.total_count == 1
+        assert len(output.items) == 1
+
+    async def test_ordered_by_conducted_at_descending(self) -> None:
+        """Records are returned newest-first by conducted_at."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        old_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+            memo="old",
+            now=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        new_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+            memo="new",
+            now=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        )
+
+        svc, rr = _build_service()
+        # Save in wrong order to verify sorting
+        await rr.save(old_record)
+        await rr.save(new_record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert len(output.items) == 2
+        assert output.items[0].memo_excerpt == "new"
+        assert output.items[1].memo_excerpt == "old"
+
+    async def test_memo_excerpt_truncated(self) -> None:
+        """Memo excerpt is truncated to 100 characters."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        long_memo = "a" * 200
+        record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            memo=long_memo,
+        )
+
+        svc, rr = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert len(output.items[0].memo_excerpt) == 100
+
+    async def test_memo_excerpt_short_memo_not_padded(self) -> None:
+        """Short memos are returned as-is without padding."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            memo="short",
+        )
+
+        svc, rr = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.items[0].memo_excerpt == "short"
+
+    async def test_includes_schedule_id(self) -> None:
+        """Schedule ID is included when the record was created from a schedule."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        # Post-hoc records have no schedule_id
+        assert output.items[0].schedule_id is None
+
+    async def test_returns_empty_when_no_records(self) -> None:
+        """Returns empty list and zero count when no matching records exist."""
+        svc, _rr = _build_service()
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=UserId.generate(),
+                organizer_id=UserId.generate(),
+                counterpart_id=UserId.generate(),
+            )
+        )
+
+        assert output.items == []
+        assert output.total_count == 0
+
+    async def test_excludes_records_for_different_pair(self) -> None:
+        """Records for a different pair are not returned."""
+        organizer = UserId.generate()
+        counterpart_a = UserId.generate()
+        counterpart_b = UserId.generate()
+
+        record_a = _make_published_record(
+            organizer=organizer, counterpart=counterpart_a
+        )
+        record_b = _make_published_record(
+            organizer=organizer, counterpart=counterpart_b
+        )
+
+        svc, rr = _build_service()
+        await rr.save(record_a)
+        await rr.save(record_b)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart_a,
+            )
+        )
+
+        assert output.total_count == 1
+        assert output.items[0].counterpart_id == counterpart_a
+
+
+class TestListOneOnOneHistoryPagination:
+    """Tests for offset-based pagination."""
+
+    async def test_offset_skips_records(self) -> None:
+        """Offset skips the first N records."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        svc, rr = _build_service()
+        for i in range(5):
+            record = _make_published_record(
+                organizer=organizer,
+                counterpart=counterpart,
+                conducted_at=datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC),
+                memo=f"record-{i}",
+                now=datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC),
+            )
+            await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                offset=2,
+                limit=2,
+            )
+        )
+
+        assert output.total_count == 5
+        assert len(output.items) == 2
+        # Descending order: records 4,3,2,1,0 -> offset 2 gives records 2,1
+        assert output.items[0].memo_excerpt == "record-2"
+        assert output.items[1].memo_excerpt == "record-1"
+
+    async def test_limit_restricts_results(self) -> None:
+        """Limit caps the number of returned records."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        svc, rr = _build_service()
+        for i in range(5):
+            record = _make_published_record(
+                organizer=organizer,
+                counterpart=counterpart,
+                conducted_at=datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC),
+                now=datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC),
+            )
+            await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+                limit=3,
+            )
+        )
+
+        assert output.total_count == 5
+        assert len(output.items) == 3
+
+    async def test_total_count_consistent_with_visibility(self) -> None:
+        """total_count matches the number of visible records, not all records."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        viewer = UserId.generate()
+
+        # Record visible to viewer
+        visible_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            viewers=[viewer],
+            conducted_at=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        # Record NOT visible to viewer
+        invisible_record = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 2, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 2, 1, 10, 0, tzinfo=UTC),
+        )
+
+        svc, rr = _build_service()
+        await rr.save(visible_record)
+        await rr.save(invisible_record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=viewer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.total_count == 1
+        assert len(output.items) == 1
+
+    async def test_default_offset_and_limit(self) -> None:
+        """Default offset is 0 and default limit is 20."""
+        input_dto = ListOneOnOneHistoryInput(
+            actor_id=UserId.generate(),
+            organizer_id=UserId.generate(),
+            counterpart_id=UserId.generate(),
+        )
+        assert input_dto.offset == 0
+        assert input_dto.limit == 20
+
+
+class TestListOneOnOneHistoryVisibility:
+    """Tests for viewer-based visibility filtering."""
+
+    async def test_organizer_sees_all_published(self) -> None:
+        """The organizer can see all published records for the pair."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=organizer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.total_count == 1
+
+    async def test_counterpart_sees_all_published(self) -> None:
+        """The counterpart can see all published records for the pair."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=counterpart,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.total_count == 1
+
+    async def test_viewer_sees_only_records_with_viewer_access(self) -> None:
+        """A viewer only sees records where they are in the viewers list."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        viewer = UserId.generate()
+
+        record_with_viewer = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            viewers=[viewer],
+            conducted_at=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        )
+        record_without_viewer = _make_published_record(
+            organizer=organizer,
+            counterpart=counterpart,
+            conducted_at=datetime(2026, 2, 1, 10, 0, tzinfo=UTC),
+            now=datetime(2026, 2, 1, 10, 0, tzinfo=UTC),
+        )
+
+        svc, rr = _build_service()
+        await rr.save(record_with_viewer)
+        await rr.save(record_without_viewer)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=viewer,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.total_count == 1
+        assert output.items[0].record_id == record_with_viewer.id
+
+    async def test_outsider_sees_nothing(self) -> None:
+        """A user not in organizer/counterpart/viewers sees nothing."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        outsider = UserId.generate()
+
+        record = _make_published_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr = _build_service()
+        await rr.save(record)
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=outsider,
+                organizer_id=organizer,
+                counterpart_id=counterpart,
+            )
+        )
+
+        assert output.total_count == 0
+        assert output.items == []
+
+
+class TestListOneOnOneHistoryValidation:
+    """Tests for input validation."""
+
+    async def test_negative_offset_raises(self) -> None:
+        """Negative offset is rejected."""
+        svc, _rr = _build_service()
+
+        with pytest.raises(InvalidPaginationError):
+            await svc.execute(
+                ListOneOnOneHistoryInput(
+                    actor_id=UserId.generate(),
+                    organizer_id=UserId.generate(),
+                    counterpart_id=UserId.generate(),
+                    offset=-1,
+                )
+            )
+
+    async def test_zero_limit_raises(self) -> None:
+        """limit=0 is rejected."""
+        svc, _rr = _build_service()
+
+        with pytest.raises(InvalidPaginationError):
+            await svc.execute(
+                ListOneOnOneHistoryInput(
+                    actor_id=UserId.generate(),
+                    organizer_id=UserId.generate(),
+                    counterpart_id=UserId.generate(),
+                    limit=0,
+                )
+            )
+
+    async def test_limit_exceeds_max_raises(self) -> None:
+        """limit above 200 is rejected."""
+        svc, _rr = _build_service()
+
+        with pytest.raises(InvalidPaginationError):
+            await svc.execute(
+                ListOneOnOneHistoryInput(
+                    actor_id=UserId.generate(),
+                    organizer_id=UserId.generate(),
+                    counterpart_id=UserId.generate(),
+                    limit=201,
+                )
+            )
+
+    async def test_limit_at_max_is_accepted(self) -> None:
+        """limit=200 is valid (boundary)."""
+        svc, _rr = _build_service()
+
+        output = await svc.execute(
+            ListOneOnOneHistoryInput(
+                actor_id=UserId.generate(),
+                organizer_id=UserId.generate(),
+                counterpart_id=UserId.generate(),
+                limit=200,
+            )
+        )
+
+        assert output.items == []
+        assert output.total_count == 0


### PR DESCRIPTION
## Summary
- ペアごとの1on1履歴一覧クエリサービス(ListOneOnOneHistoryService)を Record コンテキストの application 層に追加
- 前回サマリークエリサービス(GetLastSessionSummaryService)を追加
- RecordRepository に可視性を考慮した3メソッドを追加
- ActionItemRepository に list_by_record_id を追加
- SQLAlchemy 実装を追加
- ユニットテスト 31 件

Closes #104