### PR TITLE
feat(preparation): 直近1on1一覧クエリサービス

### DIFF
--- a/backend/contexts/preparation/application/list_upcoming_schedules_service.py
+++ b/backend/contexts/preparation/application/list_upcoming_schedules_service.py
@@ -1,0 +1,98 @@
+"""Use case: List upcoming schedules for a participant."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.domain.value_objects import (
+    ScheduleGroupId,
+    ScheduleId,
+    ScheduleStatus,
+)
+from shared.domain.value_objects import UserId
+
+_DEFAULT_LIMIT = 20
+
+_UPCOMING_STATUSES = [ScheduleStatus.REQUESTED, ScheduleStatus.CONFIRMED]
+
+
+@dataclass(frozen=True)
+class UpcomingScheduleItem:
+    """A single item in the upcoming schedules list."""
+
+    schedule_id: ScheduleId
+    organizer_id: UserId
+    counterpart_id: UserId
+    scheduled_at: datetime
+    status: ScheduleStatus
+    title: str
+    schedule_group_id: ScheduleGroupId | None
+
+
+@dataclass(frozen=True)
+class ListUpcomingSchedulesInput:
+    """Input DTO for ListUpcomingSchedulesService."""
+
+    actor_id: UserId
+    limit: int = _DEFAULT_LIMIT
+
+
+@dataclass(frozen=True)
+class ListUpcomingSchedulesOutput:
+    """Output DTO for ListUpcomingSchedulesService."""
+
+    schedules: list[UpcomingScheduleItem]
+
+
+class ListUpcomingSchedulesService:
+    """Application service that lists upcoming schedules for a participant.
+
+    This is a read-only operation; no UoW or event dispatching is needed.
+    """
+
+    def __init__(
+        self,
+        schedule_repo: ScheduleRepository,
+    ) -> None:
+        self._schedule_repo = schedule_repo
+
+    async def execute(
+        self,
+        input_dto: ListUpcomingSchedulesInput,
+    ) -> ListUpcomingSchedulesOutput:
+        """List upcoming schedules where the actor is organizer or counterpart.
+
+        Returns schedules with scheduled_at >= now, excluding CANCELLED,
+        sorted by scheduled_at ascending.
+
+        Args:
+            input_dto: Input containing the actor ID and optional limit.
+
+        Returns:
+            Output containing the list of upcoming schedules.
+        """
+        now = datetime.now(UTC)
+
+        schedules = await self._schedule_repo.list_upcoming_by_participant(
+            user_id=input_dto.actor_id,
+            now=now,
+            statuses=_UPCOMING_STATUSES,
+            limit=input_dto.limit,
+        )
+
+        items = [
+            UpcomingScheduleItem(
+                schedule_id=s.id,
+                organizer_id=s.organizer_id,
+                counterpart_id=s.counterpart_id,
+                scheduled_at=s.scheduled_at,
+                status=s.status,
+                title=s.title.value,
+                schedule_group_id=s.schedule_group_id,
+            )
+            for s in schedules
+        ]
+
+        return ListUpcomingSchedulesOutput(schedules=items)

--- a/backend/contexts/preparation/domain/schedule_repository.py
+++ b/backend/contexts/preparation/domain/schedule_repository.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from datetime import datetime
 
 from contexts.preparation.domain.schedule import Schedule
-from contexts.preparation.domain.value_objects import ScheduleGroupId, ScheduleId
+from contexts.preparation.domain.value_objects import (
+    ScheduleGroupId,
+    ScheduleId,
+    ScheduleStatus,
+)
 from foundation.domain.base_repository import BaseRepository
+from shared.domain.value_objects import UserId
 
 
 class ScheduleRepository(BaseRepository[Schedule, ScheduleId]):
@@ -15,3 +21,17 @@ class ScheduleRepository(BaseRepository[Schedule, ScheduleId]):
         self, schedule_group_id: ScheduleGroupId
     ) -> list[Schedule]:
         """Return all schedules belonging to the given schedule group."""
+
+    @abstractmethod
+    async def list_upcoming_by_participant(
+        self,
+        user_id: UserId,
+        now: datetime,
+        statuses: list[ScheduleStatus],
+        limit: int,
+    ) -> list[Schedule]:
+        """Return upcoming schedules where the user is organizer or counterpart.
+
+        Only schedules with ``scheduled_at >= now`` and matching one of the
+        given *statuses* are returned, ordered by ``scheduled_at`` ascending.
+        """

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from contexts.preparation.domain.confirmation_request import ConfirmationRequest
@@ -43,6 +43,32 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
     ) -> list[Schedule]:
         stmt = select(ScheduleTable).where(
             ScheduleTable.schedule_group_id == str(schedule_group_id.value)
+        )
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [self._to_entity(row) for row in rows]
+
+    async def list_upcoming_by_participant(
+        self,
+        user_id: UserId,
+        now: datetime,
+        statuses: list[ScheduleStatus],
+        limit: int,
+    ) -> list[Schedule]:
+        user_id_str = str(user_id.value)
+        status_values = [s.value for s in statuses]
+        stmt = (
+            select(ScheduleTable)
+            .where(
+                or_(
+                    ScheduleTable.organizer_id == user_id_str,
+                    ScheduleTable.counterpart_id == user_id_str,
+                ),
+                ScheduleTable.status.in_(status_values),
+                ScheduleTable.scheduled_at >= now,
+            )
+            .order_by(ScheduleTable.scheduled_at.asc())
+            .limit(limit)
         )
         result = await self._session.execute(stmt)
         rows = result.scalars().all()

--- a/backend/tests/contexts/notification/application/handlers/conftest.py
+++ b/backend/tests/contexts/notification/application/handlers/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from contexts.notification.domain.notification_message import NotificationMessage
 from contexts.notification.domain.notification_sender import NotificationSender
 from contexts.notification.domain.notification_setting import NotificationSetting
@@ -10,7 +12,11 @@ from contexts.notification.domain.notification_setting_repository import (
 )
 from contexts.preparation.domain.schedule import Schedule
 from contexts.preparation.domain.schedule_repository import ScheduleRepository
-from contexts.preparation.domain.value_objects import ScheduleGroupId, ScheduleId
+from contexts.preparation.domain.value_objects import (
+    ScheduleGroupId,
+    ScheduleId,
+    ScheduleStatus,
+)
 from contexts.record.domain.record import Record
 from contexts.record.domain.record_repository import RecordRepository
 from contexts.record.domain.value_objects import RecordId
@@ -80,6 +86,15 @@ class InMemoryScheduleRepository(ScheduleRepository):
             for s in self._schedules.values()
             if getattr(s, "schedule_group_id", None) == schedule_group_id
         ]
+
+    async def list_upcoming_by_participant(
+        self,
+        user_id: UserId,
+        now: datetime,
+        statuses: list[ScheduleStatus],
+        limit: int,
+    ) -> list[Schedule]:
+        return []  # not needed for notification handler tests
 
     def add(self, schedule: Schedule) -> None:
         """Pre-populate a schedule for testing."""

--- a/backend/tests/contexts/preparation/application/conftest.py
+++ b/backend/tests/contexts/preparation/application/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from types import TracebackType
 
 import pytest
@@ -20,6 +21,7 @@ from contexts.preparation.domain.value_objects import (
     AgendaId,
     ScheduleGroupId,
     ScheduleId,
+    ScheduleStatus,
     TemplateId,
 )
 from foundation.application.unit_of_work import UnitOfWork
@@ -88,6 +90,23 @@ class InMemoryScheduleRepository(ScheduleRepository):
         return [
             s for s in self._store.values() if s.schedule_group_id == schedule_group_id
         ]
+
+    async def list_upcoming_by_participant(
+        self,
+        user_id: UserId,
+        now: datetime,
+        statuses: list[ScheduleStatus],
+        limit: int,
+    ) -> list[Schedule]:
+        matching = [
+            s
+            for s in self._store.values()
+            if (s.organizer_id == user_id or s.counterpart_id == user_id)
+            and s.status in statuses
+            and s.scheduled_at >= now
+        ]
+        matching.sort(key=lambda s: s.scheduled_at)
+        return matching[:limit]
 
     @property
     def schedules(self) -> dict[ScheduleId, Schedule]:

--- a/backend/tests/contexts/preparation/application/test_list_upcoming_schedules_service.py
+++ b/backend/tests/contexts/preparation/application/test_list_upcoming_schedules_service.py
@@ -1,0 +1,310 @@
+"""Tests for ListUpcomingSchedulesService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from contexts.preparation.application.list_upcoming_schedules_service import (
+    ListUpcomingSchedulesInput,
+    ListUpcomingSchedulesOutput,
+    ListUpcomingSchedulesService,
+)
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import ScheduleStatus
+from shared.domain.value_objects import UserId
+from tests.contexts.preparation.application.conftest import InMemoryScheduleRepository
+
+
+def _create_schedule(
+    *,
+    organizer_id: UserId,
+    counterpart_id: UserId,
+    scheduled_at: datetime,
+    title: str = "1-on-1",
+) -> Schedule:
+    """Helper to create a Schedule via the domain factory."""
+    return Schedule.create(
+        organizer_id=organizer_id,
+        counterpart_id=counterpart_id,
+        scheduled_at=scheduled_at,
+        requested_by=organizer_id,
+        title=ScheduleTitle(title),
+        now=datetime.now(UTC),
+    )
+
+
+class TestListUpcomingSchedules:
+    """List upcoming schedules for a participant."""
+
+    @pytest.fixture
+    def actor(self) -> UserId:
+        return UserId.generate()
+
+    @pytest.fixture
+    def other_user(self) -> UserId:
+        return UserId.generate()
+
+    @pytest.fixture
+    def third_user(self) -> UserId:
+        return UserId.generate()
+
+    @pytest.fixture
+    def service(
+        self,
+        schedule_repo: InMemoryScheduleRepository,
+    ) -> ListUpcomingSchedulesService:
+        return ListUpcomingSchedulesService(schedule_repo=schedule_repo)
+
+    async def test_returns_future_schedules_as_organizer(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Actor's schedules as organizer are included."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        schedule = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=future,
+        )
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert isinstance(output, ListUpcomingSchedulesOutput)
+        assert len(output.schedules) == 1
+        assert output.schedules[0].schedule_id == schedule.id
+        assert output.schedules[0].organizer_id == actor
+        assert output.schedules[0].counterpart_id == other_user
+
+    async def test_returns_future_schedules_as_counterpart(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Actor's schedules as counterpart are included."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        schedule = _create_schedule(
+            organizer_id=other_user,
+            counterpart_id=actor,
+            scheduled_at=future,
+        )
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 1
+        assert output.schedules[0].schedule_id == schedule.id
+
+    async def test_excludes_cancelled_schedules(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Cancelled schedules are excluded from results."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        schedule = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=future,
+        )
+        schedule.cancel(actor_id=actor, now=datetime.now(UTC))
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 0
+
+    async def test_excludes_past_schedules(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Past schedules (scheduled_at < now) are excluded."""
+        past = datetime.now(UTC) - timedelta(days=1)
+        # Create with a future date, then manipulate scheduled_at to past
+        # to simulate a schedule whose time has passed.
+        future = datetime.now(UTC) + timedelta(days=1)
+        schedule = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=future,
+        )
+        # Directly set _scheduled_at to past for testing purposes
+        schedule._scheduled_at = past  # noqa: SLF001
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 0
+
+    async def test_excludes_unrelated_schedules(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+        third_user: UserId,
+    ) -> None:
+        """Unrelated schedules are excluded."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        schedule = _create_schedule(
+            organizer_id=other_user,
+            counterpart_id=third_user,
+            scheduled_at=future,
+        )
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 0
+
+    async def test_sorted_by_scheduled_at_ascending(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Results are sorted by scheduled_at ascending (nearest first)."""
+        now = datetime.now(UTC)
+        far_future = now + timedelta(days=10)
+        near_future = now + timedelta(days=1)
+        mid_future = now + timedelta(days=5)
+
+        s1 = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=far_future,
+            title="Far",
+        )
+        s2 = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=near_future,
+            title="Near",
+        )
+        s3 = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=mid_future,
+            title="Mid",
+        )
+        await schedule_repo.save(s1)
+        await schedule_repo.save(s2)
+        await schedule_repo.save(s3)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 3
+        assert output.schedules[0].title == "Near"
+        assert output.schedules[1].title == "Mid"
+        assert output.schedules[2].title == "Far"
+
+    async def test_respects_limit(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Only up to limit schedules are returned."""
+        now = datetime.now(UTC)
+        for i in range(5):
+            s = _create_schedule(
+                organizer_id=actor,
+                counterpart_id=other_user,
+                scheduled_at=now + timedelta(days=i + 1),
+                title=f"Schedule {i}",
+            )
+            await schedule_repo.save(s)
+
+        output = await service.execute(
+            ListUpcomingSchedulesInput(actor_id=actor, limit=3)
+        )
+
+        assert len(output.schedules) == 3
+
+    async def test_includes_requested_and_confirmed(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Both REQUESTED and CONFIRMED schedules are included."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        future2 = datetime.now(UTC) + timedelta(days=2)
+
+        requested = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=future,
+            title="Requested",
+        )
+        confirmed = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=future2,
+            title="Confirmed",
+        )
+        confirmed.confirm(actor_id=other_user, now=datetime.now(UTC))
+
+        await schedule_repo.save(requested)
+        await schedule_repo.save(confirmed)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 2
+        statuses = {s.status for s in output.schedules}
+        assert statuses == {ScheduleStatus.REQUESTED, ScheduleStatus.CONFIRMED}
+
+    async def test_output_contains_all_required_fields(
+        self,
+        service: ListUpcomingSchedulesService,
+        schedule_repo: InMemoryScheduleRepository,
+        actor: UserId,
+        other_user: UserId,
+    ) -> None:
+        """Each item contains all required fields."""
+        future = datetime.now(UTC) + timedelta(days=1)
+        schedule = _create_schedule(
+            organizer_id=actor,
+            counterpart_id=other_user,
+            scheduled_at=future,
+            title="Check fields",
+        )
+        await schedule_repo.save(schedule)
+
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 1
+        item = output.schedules[0]
+        assert item.schedule_id == schedule.id
+        assert item.organizer_id == actor
+        assert item.counterpart_id == other_user
+        assert item.scheduled_at == schedule.scheduled_at
+        assert item.status == ScheduleStatus.REQUESTED
+        assert item.title == "Check fields"
+        assert item.schedule_group_id is None
+
+    async def test_empty_result_when_no_schedules(
+        self,
+        service: ListUpcomingSchedulesService,
+        actor: UserId,
+    ) -> None:
+        """Returns empty list when no matching schedules exist."""
+        output = await service.execute(ListUpcomingSchedulesInput(actor_id=actor))
+
+        assert len(output.schedules) == 0

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from types import TracebackType
 
 from contexts.preparation.domain.schedule import Schedule
 from contexts.preparation.domain.schedule_repository import ScheduleRepository
-from contexts.preparation.domain.value_objects import ScheduleGroupId, ScheduleId
+from contexts.preparation.domain.value_objects import (
+    ScheduleGroupId,
+    ScheduleId,
+    ScheduleStatus,
+)
 from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.action_item_repository import ActionItemRepository
 from contexts.record.domain.comment import Comment
@@ -175,6 +180,15 @@ class InMemoryScheduleRepository(ScheduleRepository):
             for s in self._schedules.values()
             if getattr(s, "schedule_group_id", None) == schedule_group_id
         ]
+
+    async def list_upcoming_by_participant(
+        self,
+        user_id: UserId,
+        now: datetime,
+        statuses: list[ScheduleStatus],
+        limit: int,
+    ) -> list[Schedule]:
+        return []  # not needed for record tests
 
     def add(self, schedule: Schedule) -> None:
         """Pre-populate a schedule for testing."""


### PR DESCRIPTION
Closes #109

## Summary
- `ListUpcomingSchedulesService` を Preparation コンテキストに追加
- `ScheduleRepository` に `list_upcoming_by_participant` メソッドを追加（SQLAlchemy + InMemory 実装）
- 未来の REQUESTED/CONFIRMED Schedule を scheduled_at 昇順で取得
- ユニットテスト 10件

## Test plan
- [x] ruff check / format OK
- [x] pyright 0 errors
- [x] pytest unit 766 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)