### PR TITLE
feat(notification): リマインド機能の実装

### DIFF
--- a/backend/contexts/notification/application/send_reminder_service.py
+++ b/backend/contexts/notification/application/send_reminder_service.py
@@ -1,0 +1,117 @@
+"""Application service: send reminder notifications for upcoming 1-on-1s.
+
+Called periodically by the scheduler. For each CONFIRMED schedule whose
+reminder window has opened, sends a notification to eligible participants
+and records a ReminderLog to prevent duplicates.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from contexts.notification.domain.notification_message import NotificationMessage
+from contexts.notification.domain.notification_sender import NotificationSender
+from contexts.notification.domain.notification_setting import NotificationSetting
+from contexts.notification.domain.notification_setting_repository import (
+    NotificationSettingRepository,
+)
+from contexts.notification.domain.reminder_log import ReminderLog
+from contexts.notification.domain.reminder_log_repository import ReminderLogRepository
+from contexts.notification.domain.value_objects import NotificationType
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from shared.domain.value_objects import UserId
+
+logger = logging.getLogger(__name__)
+
+_MAX_REMINDER_MINUTES = 1440
+
+
+class SendReminderService:
+    """Send reminder notifications for upcoming confirmed schedules.
+
+    Processing flow:
+    1. Fetch CONFIRMED schedules in the lookahead window.
+    2. For each participant (organizer + counterpart):
+       a. Check notification is enabled.
+       b. Check reminder window: scheduled_at - reminder_minutes <= now.
+       c. Check ReminderLog does not already exist.
+       d. Send notification and save ReminderLog.
+
+    Note: The caller is responsible for providing repositories that share
+    the same DB session, and for committing after each save if needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        schedule_repository: ScheduleRepository,
+        notification_setting_repository: NotificationSettingRepository,
+        reminder_log_repository: ReminderLogRepository,
+        notification_sender: NotificationSender,
+    ) -> None:
+        self._schedule_repo = schedule_repository
+        self._setting_repo = notification_setting_repository
+        self._reminder_log_repo = reminder_log_repository
+        self._sender = notification_sender
+
+    async def execute(self, now: datetime) -> None:
+        """Run one cycle of reminder checks and sends."""
+        schedules = await self._schedule_repo.list_confirmed_upcoming(
+            now, _MAX_REMINDER_MINUTES
+        )
+
+        for schedule in schedules:
+            participants = [schedule.organizer_id, schedule.counterpart_id]
+            for user_id in participants:
+                try:
+                    await self._process_participant(schedule, user_id, now)
+                except Exception:
+                    logger.exception(
+                        "Failed to process reminder for schedule=%s user=%s",
+                        schedule.id,
+                        user_id,
+                    )
+
+    async def _process_participant(
+        self, schedule: Schedule, user_id: UserId, now: datetime
+    ) -> None:
+        """Check and send reminder for a single participant."""
+        setting = await self._setting_repo.get_by_user_id(user_id)
+        if setting is None:
+            setting = NotificationSetting.create_default(user_id)
+
+        if not setting.is_enabled:
+            return
+
+        reminder_minutes = setting.reminder_minutes_before
+        reminder_threshold = schedule.scheduled_at - timedelta(minutes=reminder_minutes)
+        if reminder_threshold > now:
+            return
+
+        already_sent = await self._reminder_log_repo.exists(
+            schedule.id, user_id, schedule.scheduled_at
+        )
+        if already_sent:
+            return
+
+        message = NotificationMessage(
+            notification_type=NotificationType.REMINDER,
+            title="1-on-1 reminder",
+            body=(
+                f"Your 1-on-1 '{schedule.title.value}' is scheduled "
+                f"in {reminder_minutes} minutes."
+            ),
+        )
+
+        await self._sender.send(user_id, message)
+
+        log = ReminderLog.create(
+            schedule_id=schedule.id,
+            user_id=user_id,
+            scheduled_at=schedule.scheduled_at,
+            reminder_minutes_before=reminder_minutes,
+            now=now,
+        )
+        await self._reminder_log_repo.save(log)

--- a/backend/contexts/notification/application/send_reminder_service.py
+++ b/backend/contexts/notification/application/send_reminder_service.py
@@ -86,8 +86,19 @@ class SendReminderService:
             return
 
         reminder_minutes = setting.reminder_minutes_before
-        reminder_threshold = schedule.scheduled_at - timedelta(minutes=reminder_minutes)
-        if reminder_threshold > now:
+        # Normalize tz-aware/naive: scheduled_at from DB is tz-naive (UTC),
+        # while now may be tz-aware. Strip tzinfo to compare consistently.
+        scheduled_at = schedule.scheduled_at
+        comparable_now = now.replace(tzinfo=None) if now.tzinfo is not None else now
+        comparable_scheduled_at = (
+            scheduled_at.replace(tzinfo=None)
+            if scheduled_at.tzinfo is not None
+            else scheduled_at
+        )
+        reminder_threshold = comparable_scheduled_at - timedelta(
+            minutes=reminder_minutes
+        )
+        if reminder_threshold > comparable_now:
             return
 
         already_sent = await self._reminder_log_repo.exists(

--- a/backend/contexts/notification/domain/reminder_log.py
+++ b/backend/contexts/notification/domain/reminder_log.py
@@ -1,0 +1,55 @@
+"""ReminderLog entity for tracking sent reminders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.notification.domain.value_objects import ReminderLogId
+from contexts.preparation.domain.value_objects import ScheduleId
+from shared.domain.value_objects import UserId
+
+
+@dataclass
+class ReminderLog:
+    """Entity: records that a reminder was sent for a specific schedule/user/time.
+
+    The composite key (schedule_id, user_id, scheduled_at) prevents duplicate
+    reminders. Including scheduled_at allows re-sending reminders when a
+    schedule is rescheduled to a new datetime.
+    """
+
+    id: ReminderLogId
+    schedule_id: ScheduleId
+    user_id: UserId
+    scheduled_at: datetime
+    _sent_at: datetime
+    _reminder_minutes_before: int
+
+    @property
+    def sent_at(self) -> datetime:
+        return self._sent_at
+
+    @property
+    def reminder_minutes_before(self) -> int:
+        return self._reminder_minutes_before
+
+    @staticmethod
+    def create(
+        *,
+        schedule_id: ScheduleId,
+        user_id: UserId,
+        scheduled_at: datetime,
+        reminder_minutes_before: int,
+        now: datetime | None = None,
+    ) -> ReminderLog:
+        """Create a new reminder log entry."""
+        ts = now or datetime.now(UTC)
+        return ReminderLog(
+            id=ReminderLogId.generate(),
+            schedule_id=schedule_id,
+            user_id=user_id,
+            scheduled_at=scheduled_at,
+            _sent_at=ts,
+            _reminder_minutes_before=reminder_minutes_before,
+        )

--- a/backend/contexts/notification/domain/reminder_log_repository.py
+++ b/backend/contexts/notification/domain/reminder_log_repository.py
@@ -1,0 +1,32 @@
+"""ReminderLogRepository abstract interface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from contexts.notification.domain.reminder_log import ReminderLog
+from contexts.preparation.domain.value_objects import ScheduleId
+from shared.domain.value_objects import UserId
+
+
+class ReminderLogRepository(ABC):
+    """Repository interface for ReminderLog.
+
+    Does not extend BaseRepository because the primary lookup
+    is by composite key (schedule_id, user_id, scheduled_at),
+    not by a single entity id.
+    """
+
+    @abstractmethod
+    async def exists(
+        self,
+        schedule_id: ScheduleId,
+        user_id: UserId,
+        scheduled_at: datetime,
+    ) -> bool:
+        """Check if a reminder has already been sent for this combination."""
+
+    @abstractmethod
+    async def save(self, log: ReminderLog) -> None:
+        """Persist the reminder log entry."""

--- a/backend/contexts/notification/domain/value_objects.py
+++ b/backend/contexts/notification/domain/value_objects.py
@@ -16,6 +16,7 @@ class NotificationType(Enum):
     RECORD_PUBLISHED = "record_published"
     AGENDA_COMMENT_ADDED = "agenda_comment_added"
     RECORD_COMMENT_ADDED = "record_comment_added"
+    REMINDER = "reminder"
 
 
 @dataclass(frozen=True)
@@ -31,3 +32,18 @@ class NotificationSettingId:
     @staticmethod
     def from_str(raw: str) -> NotificationSettingId:
         return NotificationSettingId(value=uuid.UUID(raw))
+
+
+@dataclass(frozen=True)
+class ReminderLogId:
+    """Reminder log identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> ReminderLogId:
+        return ReminderLogId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> ReminderLogId:
+        return ReminderLogId(value=uuid.UUID(raw))

--- a/backend/contexts/notification/infrastructure/sqlalchemy_reminder_log_repository.py
+++ b/backend/contexts/notification/infrastructure/sqlalchemy_reminder_log_repository.py
@@ -1,0 +1,59 @@
+"""SQLAlchemy implementation of ReminderLogRepository."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.notification.domain.reminder_log import ReminderLog
+from contexts.notification.domain.reminder_log_repository import ReminderLogRepository
+from contexts.notification.domain.value_objects import ReminderLogId
+from contexts.notification.infrastructure.tables import ReminderLogTable
+from contexts.preparation.domain.value_objects import ScheduleId
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyReminderLogRepository(ReminderLogRepository):
+    """SQLAlchemy-based implementation of ReminderLogRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def exists(
+        self,
+        schedule_id: ScheduleId,
+        user_id: UserId,
+        scheduled_at: datetime,
+    ) -> bool:
+        stmt = select(ReminderLogTable.id).where(
+            ReminderLogTable.schedule_id == str(schedule_id.value),
+            ReminderLogTable.user_id == str(user_id.value),
+            ReminderLogTable.scheduled_at == scheduled_at,
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+    async def save(self, log: ReminderLog) -> None:
+        row = ReminderLogTable(
+            id=str(log.id.value),
+            schedule_id=str(log.schedule_id.value),
+            user_id=str(log.user_id.value),
+            scheduled_at=log.scheduled_at,
+            sent_at=log.sent_at,
+            reminder_minutes_before=log.reminder_minutes_before,
+        )
+        self._session.add(row)
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: ReminderLogTable) -> ReminderLog:
+        return ReminderLog(
+            id=ReminderLogId.from_str(row.id),
+            schedule_id=ScheduleId.from_str(row.schedule_id),
+            user_id=UserId.from_str(row.user_id),
+            scheduled_at=row.scheduled_at,
+            _sent_at=row.sent_at,
+            _reminder_minutes_before=row.reminder_minutes_before,
+        )

--- a/backend/contexts/notification/infrastructure/tables.py
+++ b/backend/contexts/notification/infrastructure/tables.py
@@ -1,4 +1,7 @@
-from sqlalchemy import CHAR, Boolean, Integer
+from datetime import datetime
+
+from sqlalchemy import CHAR, Boolean, Integer, UniqueConstraint
+from sqlalchemy.dialects.mysql import DATETIME
 from sqlalchemy.orm import Mapped, mapped_column
 
 from foundation.db.base import Base, TimestampMixin
@@ -19,3 +22,24 @@ class NotificationSettingTable(Base, TimestampMixin):
         Integer, nullable=False, default=30
     )
     is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+
+class ReminderLogTable(Base, TimestampMixin):
+    """ORM model for the reminder_logs table."""
+
+    __tablename__ = "reminder_logs"
+    __table_args__ = (
+        UniqueConstraint(
+            "schedule_id",
+            "user_id",
+            "scheduled_at",
+            name="uq_reminder_logs_schedule_user_scheduled_at",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    schedule_id: Mapped[str] = mapped_column(CHAR(36), nullable=False)
+    user_id: Mapped[str] = mapped_column(CHAR(36), nullable=False)
+    scheduled_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
+    sent_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
+    reminder_minutes_before: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/contexts/preparation/domain/schedule_repository.py
+++ b/backend/contexts/preparation/domain/schedule_repository.py
@@ -35,3 +35,13 @@ class ScheduleRepository(BaseRepository[Schedule, ScheduleId]):
         Only schedules with ``scheduled_at >= now`` and matching one of the
         given *statuses* are returned, ordered by ``scheduled_at`` ascending.
         """
+
+    @abstractmethod
+    async def list_confirmed_upcoming(
+        self, now: datetime, lookahead_minutes: int
+    ) -> list[Schedule]:
+        """Return CONFIRMED schedules between now and now + lookahead_minutes.
+
+        Only schedules with ``scheduled_at > now`` and
+        ``scheduled_at <= now + lookahead_minutes`` are returned.
+        """

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -69,6 +69,19 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
             )
             .order_by(ScheduleTable.scheduled_at.asc())
             .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [self._to_entity(row) for row in rows]
+
+    async def list_confirmed_upcoming(
+        self, now: datetime, lookahead_minutes: int
+    ) -> list[Schedule]:
+        upper = now + timedelta(minutes=lookahead_minutes)
+        stmt = select(ScheduleTable).where(
+            ScheduleTable.status == ScheduleStatus.CONFIRMED.value,
+            ScheduleTable.scheduled_at > now,
+            ScheduleTable.scheduled_at <= upper,
         )
         result = await self._session.execute(stmt)
         rows = result.scalars().all()

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -6,6 +6,7 @@ via Base.metadata. When adding a new table, add an explicit import below.
 
 from contexts.notification.infrastructure.tables import (
     NotificationSettingTable,  # noqa: F401
+    ReminderLogTable,  # noqa: F401
 )
 from contexts.preparation.infrastructure.tables import (
     ConfirmationRequestTable,  # noqa: F401
@@ -32,6 +33,7 @@ from shared.infrastructure.tables import UserTable  # noqa: F401
 __all__ = [
     "ActionItemTable",
     "NotificationSettingTable",
+    "ReminderLogTable",
     "CommentTable",
     "ConfirmationRequestTable",
     "MembershipTable",

--- a/backend/foundation/scheduler/lifespan.py
+++ b/backend/foundation/scheduler/lifespan.py
@@ -1,0 +1,91 @@
+"""Factory for ReminderScheduler with wired dependencies.
+
+Used by the FastAPI lifespan to create and manage the scheduler.
+Returns None if the database is not configured (e.g. in test environments).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from contexts.notification.domain.notification_sender import NotificationSender
+from foundation.scheduler.reminder_scheduler import ReminderScheduler
+
+logger = logging.getLogger(__name__)
+
+
+def create_reminder_scheduler() -> ReminderScheduler | None:
+    """Create a ReminderScheduler with production dependencies.
+
+    Returns None if construction fails (e.g. missing DB config).
+    """
+    try:
+        service = _SessionScopedReminderService()
+        return ReminderScheduler(service)
+    except Exception:
+        logger.exception("Failed to create ReminderScheduler")
+        return None
+
+
+class _SessionScopedReminderService:
+    """Proxy that creates a fresh DB session per scheduler invocation.
+
+    The scheduler runs outside of FastAPI's request lifecycle, so each
+    execute() call creates its own session and wires up repositories
+    and the SendReminderService.
+    """
+
+    async def execute(self, now: object) -> None:
+        """Create dependencies and delegate to SendReminderService."""
+        from datetime import datetime as dt
+
+        from contexts.notification.application.send_reminder_service import (
+            SendReminderService,
+        )
+        from contexts.notification.infrastructure.sqlalchemy_notification_setting_repository import (  # noqa: E501
+            SqlAlchemyNotificationSettingRepository,
+        )
+        from contexts.notification.infrastructure.sqlalchemy_reminder_log_repository import (  # noqa: E501
+            SqlAlchemyReminderLogRepository,
+        )
+        from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+            SqlAlchemyScheduleRepository,
+        )
+        from foundation.db.session import async_session_factory
+
+        assert isinstance(now, dt)
+
+        async with async_session_factory() as session:
+            service = SendReminderService(
+                schedule_repository=SqlAlchemyScheduleRepository(session),
+                notification_setting_repository=SqlAlchemyNotificationSettingRepository(
+                    session
+                ),
+                reminder_log_repository=SqlAlchemyReminderLogRepository(session),
+                notification_sender=_get_notification_sender(),
+            )
+            await service.execute(now)
+            await session.commit()
+
+
+def _get_notification_sender() -> NotificationSender:
+    """Get the NotificationSender implementation.
+
+    Returns a log-only sender until Slack integration is configured.
+    """
+    from contexts.notification.domain.notification_message import NotificationMessage
+    from shared.domain.value_objects import UserId
+
+    class LogOnlyNotificationSender(NotificationSender):
+        """Placeholder sender that logs instead of sending."""
+
+        async def send(
+            self, recipient_id: UserId, message: NotificationMessage
+        ) -> None:
+            logger.info(
+                "Reminder notification for user %s: %s",
+                recipient_id,
+                message.title,
+            )
+
+    return LogOnlyNotificationSender()

--- a/backend/foundation/scheduler/reminder_scheduler.py
+++ b/backend/foundation/scheduler/reminder_scheduler.py
@@ -1,0 +1,54 @@
+"""APScheduler integration for periodic reminder checks.
+
+Uses AsyncIOScheduler with an IntervalTrigger to invoke
+the reminder service every minute.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Protocol
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+logger = logging.getLogger(__name__)
+
+
+class ReminderServiceProtocol(Protocol):
+    """Protocol for the service invoked by the scheduler."""
+
+    async def execute(self, now: datetime) -> None: ...
+
+
+class ReminderScheduler:
+    """Wraps APScheduler to periodically run reminder checks."""
+
+    def __init__(self, service: ReminderServiceProtocol) -> None:
+        self._service = service
+        self._scheduler = AsyncIOScheduler()
+
+    def start(self) -> None:
+        """Start the scheduler with a 1-minute interval."""
+        self._scheduler.add_job(
+            self._run,
+            trigger=IntervalTrigger(minutes=1),
+            id="send_reminders",
+            replace_existing=True,
+        )
+        self._scheduler.start()
+        logger.info("ReminderScheduler started")
+
+    def shutdown(self) -> None:
+        """Gracefully shut down the scheduler."""
+        self._scheduler.shutdown(wait=False)
+        logger.info("ReminderScheduler shut down")
+
+    async def _run(self) -> None:
+        """Execute one cycle of reminder processing."""
+        now = datetime.now(UTC)
+        try:
+            await self._service.execute(now)
+        except Exception:
+            logger.exception("Reminder scheduler cycle failed")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,23 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from api.register_routers import register_routers
+from foundation.scheduler.lifespan import create_reminder_scheduler
 
-app = FastAPI(title="perigee", version="0.1.0")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    scheduler = create_reminder_scheduler()
+    if scheduler is not None:
+        scheduler.start()
+    yield
+    if scheduler is not None:
+        scheduler.shutdown()
+
+
+app = FastAPI(title="perigee", version="0.1.0", lifespan=lifespan)
 
 register_routers(app)
 

--- a/backend/migrations/versions/0007_create_reminder_logs.py
+++ b/backend/migrations/versions/0007_create_reminder_logs.py
@@ -1,0 +1,51 @@
+"""create reminder_logs table
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-03-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reminder_logs",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("schedule_id", sa.CHAR(36), nullable=False),
+        sa.Column("user_id", sa.CHAR(36), nullable=False),
+        sa.Column("scheduled_at", sa.DATETIME(), nullable=False),
+        sa.Column("sent_at", sa.DATETIME(), nullable=False),
+        sa.Column("reminder_minutes_before", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "schedule_id",
+            "user_id",
+            "scheduled_at",
+            name="uq_reminder_logs_schedule_user_scheduled_at",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reminder_logs")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "asyncmy~=0.2",
     "alembic~=1.18",
     "pydantic-settings~=2.13",
+    "apscheduler~=3.11",
 ]
 
 [dependency-groups]

--- a/backend/tests/contexts/notification/application/handlers/conftest.py
+++ b/backend/tests/contexts/notification/application/handlers/conftest.py
@@ -96,6 +96,22 @@ class InMemoryScheduleRepository(ScheduleRepository):
     ) -> list[Schedule]:
         return []  # not needed for notification handler tests
 
+    async def list_confirmed_upcoming(
+        self, now: datetime, lookahead_minutes: int
+    ) -> list[Schedule]:
+        from datetime import timedelta
+
+        from contexts.preparation.domain.value_objects import ScheduleStatus
+
+        upper = now + timedelta(minutes=lookahead_minutes)
+        return [
+            s
+            for s in self._schedules.values()
+            if s.status == ScheduleStatus.CONFIRMED
+            and s.scheduled_at > now
+            and s.scheduled_at <= upper
+        ]
+
     def add(self, schedule: Schedule) -> None:
         """Pre-populate a schedule for testing."""
         self._schedules[schedule.id] = schedule

--- a/backend/tests/contexts/notification/application/test_send_reminder_service.py
+++ b/backend/tests/contexts/notification/application/test_send_reminder_service.py
@@ -1,0 +1,354 @@
+"""Tests for SendReminderService."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from contexts.notification.application.send_reminder_service import (
+    SendReminderService,
+)
+from contexts.notification.domain.notification_setting import NotificationSetting
+from contexts.notification.domain.notification_setting_repository import (
+    NotificationSettingRepository,
+)
+from contexts.notification.domain.reminder_log import ReminderLog
+from contexts.notification.domain.reminder_log_repository import ReminderLogRepository
+from contexts.notification.domain.value_objects import NotificationType
+from contexts.preparation.domain.schedule import Schedule
+from contexts.preparation.domain.schedule_title import ScheduleTitle
+from contexts.preparation.domain.value_objects import ScheduleId, ScheduleStatus
+from shared.domain.value_objects import UserId
+from tests.contexts.notification.application.handlers.conftest import (
+    InMemoryNotificationSettingRepository,
+    InMemoryScheduleRepository,
+    SpyNotificationSender,
+)
+
+SCHEDULED_AT = datetime(2026, 4, 1, 10, 0)
+CREATION_TIME = datetime(2026, 3, 20, 10, 0)
+
+
+def _make_confirmed_schedule(
+    organizer: UserId,
+    counterpart: UserId,
+    scheduled_at: datetime = SCHEDULED_AT,
+) -> Schedule:
+    """Create a CONFIRMED schedule for testing."""
+    schedule = Schedule.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        scheduled_at=scheduled_at,
+        requested_by=organizer,
+        title=ScheduleTitle("Test 1on1"),
+        now=CREATION_TIME,
+    )
+    schedule.confirm(actor_id=counterpart, now=CREATION_TIME)
+    schedule.collect_events()
+    return schedule
+
+
+class InMemoryReminderLogRepository(ReminderLogRepository):
+    """In-memory stub for ReminderLogRepository."""
+
+    def __init__(self) -> None:
+        self._logs: list[ReminderLog] = []
+
+    async def exists(
+        self,
+        schedule_id: ScheduleId,
+        user_id: UserId,
+        scheduled_at: datetime,
+    ) -> bool:
+        return any(
+            log.schedule_id == schedule_id
+            and log.user_id == user_id
+            and log.scheduled_at == scheduled_at
+            for log in self._logs
+        )
+
+    async def save(self, log: ReminderLog) -> None:
+        self._logs.append(log)
+
+    @property
+    def saved_logs(self) -> list[ReminderLog]:
+        return list(self._logs)
+
+
+def _build_service(
+    *,
+    schedule_repo: InMemoryScheduleRepository | None = None,
+    setting_repo: NotificationSettingRepository | None = None,
+    reminder_log_repo: InMemoryReminderLogRepository | None = None,
+    sender: SpyNotificationSender | None = None,
+) -> tuple[
+    SendReminderService,
+    InMemoryScheduleRepository,
+    InMemoryReminderLogRepository,
+    SpyNotificationSender,
+]:
+    sr = schedule_repo or InMemoryScheduleRepository()
+    st = setting_repo or InMemoryNotificationSettingRepository()
+    rl = reminder_log_repo or InMemoryReminderLogRepository()
+    sn = sender or SpyNotificationSender()
+    service = SendReminderService(
+        schedule_repository=sr,
+        notification_setting_repository=st,
+        reminder_log_repository=rl,
+        notification_sender=sn,
+    )
+    return service, sr, rl, sn
+
+
+class TestSendReminderService:
+    """Tests for SendReminderService reminder logic."""
+
+    async def test_sends_reminder_to_both_participants(self) -> None:
+        """Both organizer and counterpart receive reminders."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        service, sr, rl, sn = _build_service()
+        sr.add(schedule)
+
+        # Default reminder is 30 minutes before; now = scheduled_at - 25 min
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+
+        assert len(sn.sent) == 2
+        sent_ids = {r for r, _ in sn.sent}
+        assert sent_ids == {organizer, counterpart}
+        assert all(
+            msg.notification_type == NotificationType.REMINDER for _, msg in sn.sent
+        )
+
+    async def test_does_not_send_before_reminder_window(self) -> None:
+        """Reminders are not sent if the window has not opened yet."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        service, sr, _rl, sn = _build_service()
+        sr.add(schedule)
+
+        # Default 30 min reminder; now = scheduled_at - 35 min (too early)
+        now = SCHEDULED_AT - timedelta(minutes=35)
+        await service.execute(now)
+
+        assert sn.sent == []
+
+    async def test_does_not_send_for_past_schedule(self) -> None:
+        """Schedules where scheduled_at <= now are excluded."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        service, sr, _rl, sn = _build_service()
+        sr.add(schedule)
+
+        # now == scheduled_at (boundary: scheduled_at > now must be strict)
+        now = SCHEDULED_AT
+        await service.execute(now)
+
+        assert sn.sent == []
+
+    async def test_does_not_send_when_disabled(self) -> None:
+        """Users with is_enabled=false do not get reminders."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        setting_repo = InMemoryNotificationSettingRepository(
+            disabled_users={organizer, counterpart}
+        )
+        service, sr, _rl, sn = _build_service(setting_repo=setting_repo)
+        sr.add(schedule)
+
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+
+        assert sn.sent == []
+
+    async def test_prevents_duplicate_send(self) -> None:
+        """Second run does not re-send if ReminderLog exists."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        service, sr, rl, sn = _build_service()
+        sr.add(schedule)
+
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+        assert len(sn.sent) == 2
+
+        # Run again - should not send duplicates
+        await service.execute(now)
+        assert len(sn.sent) == 2
+
+    async def test_reminder_log_saved_for_each_recipient(self) -> None:
+        """A ReminderLog is created for each sent reminder."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        service, sr, rl, _sn = _build_service()
+        sr.add(schedule)
+
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+
+        assert len(rl.saved_logs) == 2
+        log_user_ids = {log.user_id for log in rl.saved_logs}
+        assert log_user_ids == {organizer, counterpart}
+        for log in rl.saved_logs:
+            assert log.schedule_id == schedule.id
+            assert log.scheduled_at == SCHEDULED_AT
+            assert log.reminder_minutes_before == 30  # default
+
+    async def test_reschedule_allows_new_reminder(self) -> None:
+        """After reschedule to new datetime, reminders can be sent again."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        rl = InMemoryReminderLogRepository()
+        service, sr, rl, sn = _build_service(reminder_log_repo=rl)
+        sr.add(schedule)
+
+        # Send first reminder
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+        assert len(sn.sent) == 2
+
+        # Pre-populate a ReminderLog for the OLD scheduled_at
+        # (simulating that the first reminders were already sent)
+        # The schedule is rescheduled to a new datetime
+        new_scheduled_at = datetime(2026, 4, 5, 14, 0)
+        schedule.reschedule(
+            actor_id=organizer,
+            new_proposed_at=new_scheduled_at,
+            now=now,
+        )
+        schedule.confirm(actor_id=counterpart, now=now)
+        schedule.collect_events()
+
+        # Now the schedule is at a new datetime
+        now2 = new_scheduled_at - timedelta(minutes=25)
+        await service.execute(now2)
+
+        # Should have 4 total sends: 2 for old + 2 for new
+        assert len(sn.sent) == 4
+
+    async def test_respects_per_user_reminder_minutes(self) -> None:
+        """Each user's individual reminder_minutes_before is respected."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        # Organizer has 60 min reminder, counterpart has default 30 min
+        setting_repo = _PerUserSettingRepository({organizer: 60})
+        service, sr, _rl, sn = _build_service(setting_repo=setting_repo)
+        sr.add(schedule)
+
+        # At 45 min before: organizer window open (60 min), counterpart not yet (30 min)
+        now = SCHEDULED_AT - timedelta(minutes=45)
+        await service.execute(now)
+
+        assert len(sn.sent) == 1
+        assert sn.sent_recipient_ids == [organizer]
+
+    async def test_does_not_send_for_requested_schedule(self) -> None:
+        """REQUESTED schedules are not eligible for reminders."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        # Create but do NOT confirm
+        schedule = Schedule.create(
+            organizer_id=organizer,
+            counterpart_id=counterpart,
+            scheduled_at=SCHEDULED_AT,
+            requested_by=organizer,
+            title=ScheduleTitle("Test 1on1"),
+            now=CREATION_TIME,
+        )
+        schedule.collect_events()
+        assert schedule.status == ScheduleStatus.REQUESTED
+
+        service, sr, _rl, sn = _build_service()
+        sr.add(schedule)
+
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+
+        assert sn.sent == []
+
+    async def test_does_not_send_for_cancelled_schedule(self) -> None:
+        """CANCELLED schedules are not eligible for reminders."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+        schedule.cancel(actor_id=organizer, now=CREATION_TIME)
+        schedule.collect_events()
+        assert schedule.status == ScheduleStatus.CANCELLED
+
+        service, sr, _rl, sn = _build_service()
+        sr.add(schedule)
+
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+
+        assert sn.sent == []
+
+    async def test_send_failure_does_not_block_other_participants(self) -> None:
+        """If sending fails for one user, the other still gets notified."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        sender = SpyNotificationSender(fail_for={organizer})
+        service, sr, rl, _sn = _build_service(sender=sender)
+        sr.add(schedule)
+
+        now = SCHEDULED_AT - timedelta(minutes=25)
+        await service.execute(now)
+
+        # Counterpart should still receive notification
+        assert len(sender.sent) == 1
+        assert sender.sent_recipient_ids == [counterpart]
+        # Only counterpart's log should be saved
+        assert len(rl.saved_logs) == 1
+        assert rl.saved_logs[0].user_id == counterpart
+
+    async def test_boundary_now_equals_scheduled_at_minus_reminder(self) -> None:
+        """Exact boundary: now == scheduled_at - reminder_minutes sends."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        schedule = _make_confirmed_schedule(organizer, counterpart)
+
+        service, sr, _rl, sn = _build_service()
+        sr.add(schedule)
+
+        # Exactly at the reminder threshold
+        now = SCHEDULED_AT - timedelta(minutes=30)
+        await service.execute(now)
+
+        assert len(sn.sent) == 2
+
+
+class _PerUserSettingRepository(NotificationSettingRepository):
+    """Test helper that returns custom reminder minutes per user."""
+
+    def __init__(self, custom_minutes: dict[UserId, int]) -> None:
+        self._custom = custom_minutes
+
+    async def get_by_user_id(self, user_id: UserId) -> NotificationSetting | None:
+        if user_id in self._custom:
+            return NotificationSetting.create(
+                user_id=user_id,
+                reminder_minutes_before=self._custom[user_id],
+                is_enabled=True,
+            )
+        return None  # default
+
+    async def save(self, entity: NotificationSetting) -> None:
+        pass

--- a/backend/tests/contexts/notification/domain/test_reminder_log.py
+++ b/backend/tests/contexts/notification/domain/test_reminder_log.py
@@ -1,0 +1,57 @@
+"""Tests for ReminderLog entity."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from contexts.notification.domain.reminder_log import ReminderLog
+from contexts.notification.domain.value_objects import ReminderLogId
+from contexts.preparation.domain.value_objects import ScheduleId
+from shared.domain.value_objects import UserId
+
+NOW = datetime(2026, 3, 25, 10, 0)
+SCHEDULED_AT = datetime(2026, 4, 1, 10, 0)
+
+
+class TestReminderLog:
+    """Tests for ReminderLog entity creation."""
+
+    def test_create_sets_fields(self) -> None:
+        schedule_id = ScheduleId.generate()
+        user_id = UserId.generate()
+
+        log = ReminderLog.create(
+            schedule_id=schedule_id,
+            user_id=user_id,
+            scheduled_at=SCHEDULED_AT,
+            reminder_minutes_before=30,
+            now=NOW,
+        )
+
+        assert log.schedule_id == schedule_id
+        assert log.user_id == user_id
+        assert log.scheduled_at == SCHEDULED_AT
+        assert log.sent_at == NOW
+        assert log.reminder_minutes_before == 30
+        assert isinstance(log.id, ReminderLogId)
+
+    def test_create_generates_unique_ids(self) -> None:
+        schedule_id = ScheduleId.generate()
+        user_id = UserId.generate()
+
+        log1 = ReminderLog.create(
+            schedule_id=schedule_id,
+            user_id=user_id,
+            scheduled_at=SCHEDULED_AT,
+            reminder_minutes_before=30,
+            now=NOW,
+        )
+        log2 = ReminderLog.create(
+            schedule_id=schedule_id,
+            user_id=user_id,
+            scheduled_at=SCHEDULED_AT,
+            reminder_minutes_before=30,
+            now=NOW,
+        )
+
+        assert log1.id != log2.id

--- a/backend/tests/contexts/notification/infrastructure/conftest.py
+++ b/backend/tests/contexts/notification/infrastructure/conftest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+import foundation.db.models  # noqa: F401
+from foundation.config.settings import settings
+from foundation.db.base import Base
+
+
+def _test_database_url() -> str:
+    """Build a URL pointing to the perigee_test database."""
+    return (
+        f"mysql+asyncmy://{settings.db_user}:{settings.db_password}"
+        f"@{settings.db_host}:{settings.db_port}/perigee_test"
+    )
+
+
+@pytest_asyncio.fixture(scope="session")
+async def test_engine() -> AsyncGenerator[AsyncEngine]:
+    """Create a test engine that connects to perigee_test."""
+    engine = create_async_engine(
+        _test_database_url(),
+        echo=False,
+        pool_pre_ping=True,
+        connect_args={"init_command": "SET time_zone='+00:00'"},
+    )
+    # Create all tables at the start of the test session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    # Drop all tables at the end of the test session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(
+    test_engine: AsyncEngine,
+) -> AsyncGenerator[AsyncSession]:
+    """Provide a transactional session that rolls back after each test."""
+    session_factory = async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as session:
+        yield session
+        # Roll back any uncommitted changes after each test
+        await session.rollback()
+
+
+@pytest.fixture
+def session_factory(
+    test_engine: AsyncEngine,
+) -> async_sessionmaker[AsyncSession]:
+    """Provide a session factory for tests that need multiple sessions."""
+    return async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )

--- a/backend/tests/contexts/notification/infrastructure/test_sqlalchemy_reminder_log_repository.py
+++ b/backend/tests/contexts/notification/infrastructure/test_sqlalchemy_reminder_log_repository.py
@@ -1,0 +1,110 @@
+"""Integration tests for SqlAlchemyReminderLogRepository."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.notification.domain.reminder_log import ReminderLog
+from contexts.notification.domain.value_objects import ReminderLogId
+from contexts.notification.infrastructure.sqlalchemy_reminder_log_repository import (
+    SqlAlchemyReminderLogRepository,
+)
+from contexts.preparation.domain.value_objects import ScheduleId
+from shared.domain.value_objects import UserId
+
+pytestmark = pytest.mark.integration
+
+SCHEDULED_AT = datetime(2026, 4, 1, 10, 0)
+SENT_AT = datetime(2026, 3, 31, 9, 30)
+
+
+def _make_log(
+    *,
+    schedule_id: ScheduleId | None = None,
+    user_id: UserId | None = None,
+    scheduled_at: datetime = SCHEDULED_AT,
+) -> ReminderLog:
+    return ReminderLog(
+        id=ReminderLogId.generate(),
+        schedule_id=schedule_id or ScheduleId.generate(),
+        user_id=user_id or UserId.generate(),
+        scheduled_at=scheduled_at,
+        _sent_at=SENT_AT,
+        _reminder_minutes_before=30,
+    )
+
+
+class TestUniqueConstraint:
+    """Verify the DB unique constraint on (schedule_id, user_id, scheduled_at)."""
+
+    async def test_duplicate_save_raises_integrity_error(
+        self, session: AsyncSession
+    ) -> None:
+        """Same composite key violates the unique constraint."""
+        repo = SqlAlchemyReminderLogRepository(session)
+
+        schedule_id = ScheduleId.generate()
+        user_id = UserId.generate()
+
+        log1 = _make_log(schedule_id=schedule_id, user_id=user_id)
+        await repo.save(log1)
+        await session.flush()
+
+        log2 = _make_log(schedule_id=schedule_id, user_id=user_id)
+        with pytest.raises(IntegrityError):
+            await repo.save(log2)
+            await session.flush()
+
+    async def test_different_scheduled_at_allows_save(
+        self, session: AsyncSession
+    ) -> None:
+        """Different scheduled_at with same schedule_id/user_id is allowed."""
+        repo = SqlAlchemyReminderLogRepository(session)
+
+        schedule_id = ScheduleId.generate()
+        user_id = UserId.generate()
+
+        log1 = _make_log(
+            schedule_id=schedule_id,
+            user_id=user_id,
+            scheduled_at=datetime(2026, 4, 1, 10, 0),
+        )
+        await repo.save(log1)
+
+        log2 = _make_log(
+            schedule_id=schedule_id,
+            user_id=user_id,
+            scheduled_at=datetime(2026, 4, 5, 14, 0),
+        )
+        await repo.save(log2)
+        await session.flush()
+
+        assert await repo.exists(schedule_id, user_id, datetime(2026, 4, 1, 10, 0))
+        assert await repo.exists(schedule_id, user_id, datetime(2026, 4, 5, 14, 0))
+
+
+class TestExistsQuery:
+    """Verify the exists() query works correctly."""
+
+    async def test_exists_returns_false_when_empty(self, session: AsyncSession) -> None:
+        """exists() returns False when no matching log exists."""
+        repo = SqlAlchemyReminderLogRepository(session)
+        result = await repo.exists(
+            ScheduleId.generate(), UserId.generate(), SCHEDULED_AT
+        )
+        assert result is False
+
+    async def test_exists_returns_true_after_save(self, session: AsyncSession) -> None:
+        """exists() returns True after saving a matching log."""
+        repo = SqlAlchemyReminderLogRepository(session)
+
+        log = _make_log()
+        await repo.save(log)
+        await session.flush()
+
+        result = await repo.exists(log.schedule_id, log.user_id, log.scheduled_at)
+        assert result is True

--- a/backend/tests/contexts/preparation/application/conftest.py
+++ b/backend/tests/contexts/preparation/application/conftest.py
@@ -108,6 +108,11 @@ class InMemoryScheduleRepository(ScheduleRepository):
         matching.sort(key=lambda s: s.scheduled_at)
         return matching[:limit]
 
+    async def list_confirmed_upcoming(
+        self, now: datetime, lookahead_minutes: int
+    ) -> list[Schedule]:
+        return []  # not needed for preparation tests
+
     @property
     def schedules(self) -> dict[ScheduleId, Schedule]:
         return dict(self._store)

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -204,6 +204,11 @@ class InMemoryScheduleRepository(ScheduleRepository):
     ) -> list[Schedule]:
         return []  # not needed for record tests
 
+    async def list_confirmed_upcoming(
+        self, now: datetime, lookahead_minutes: int
+    ) -> list[Schedule]:
+        return []  # not needed for record tests
+
     def add(self, schedule: Schedule) -> None:
         """Pre-populate a schedule for testing."""
         self._schedules[schedule.id] = schedule

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -47,6 +47,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "asyncmy"
 version = "0.2.11"
 source = { registry = "https://pypi.org/simple" }
@@ -282,6 +294,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "apscheduler" },
     { name = "asyncmy" },
     { name = "fastapi" },
     { name = "pydantic-settings" },
@@ -301,6 +314,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = "~=1.18" },
+    { name = "apscheduler", specifier = "~=3.11" },
     { name = "asyncmy", specifier = "~=0.2" },
     { name = "fastapi", specifier = "~=0.135" },
     { name = "pydantic-settings", specifier = "~=2.13" },
@@ -562,6 +576,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #108

## Summary
- `SendReminderService` - CONFIRMED 状態の Schedule に対してリマインド通知を送信
- `ReminderLog` エンティティ + リポジトリ（二重送信防止、`schedule_id + user_id + scheduled_at` ユニーク制約）
- APScheduler による1分間隔の定期実行（FastAPI lifespan 統合）
- `ScheduleRepository` に `list_confirmed_upcoming` メソッド追加
- ユニットテスト 12件 + ドメインテスト

## Test plan
- [x] ruff check / format OK
- [x] pyright 0 errors
- [x] pytest unit 770 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)