### PR TITLE
feat(api): DI Provider（Depends チェーン）

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from fastapi import Request
 
 from foundation.application.unit_of_work import UnitOfWork
-from foundation.db.session import async_session_factory
 from foundation.domain.event_dispatcher import EventDispatcher
-from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 
 
 def get_unit_of_work() -> UnitOfWork:
     """Provide a new UnitOfWork backed by SQLAlchemy."""
+    from foundation.db.session import async_session_factory
+    from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+
     return SqlAlchemyUnitOfWork(async_session_factory)
 
 

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -1,0 +1,21 @@
+"""Shared DI providers for FastAPI Depends chains."""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.db.session import async_session_factory
+from foundation.domain.event_dispatcher import EventDispatcher
+from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+
+
+def get_unit_of_work() -> UnitOfWork:
+    """Provide a new UnitOfWork backed by SQLAlchemy."""
+    return SqlAlchemyUnitOfWork(async_session_factory)
+
+
+def get_event_dispatcher(request: Request) -> EventDispatcher:
+    """Return the app-scope singleton EventDispatcher from app.state."""
+    dispatcher: EventDispatcher = request.app.state.event_dispatcher
+    return dispatcher

--- a/backend/api/event_setup.py
+++ b/backend/api/event_setup.py
@@ -1,0 +1,27 @@
+"""EventDispatcher initialization for the application lifecycle."""
+
+from __future__ import annotations
+
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+
+
+def create_event_dispatcher() -> InMemoryEventDispatcher:
+    """Create an InMemoryEventDispatcher and register all event handlers.
+
+    This function is called once at application startup.  The returned
+    dispatcher is stored on ``app.state`` and shared across all requests.
+
+    Returns:
+        A fully-configured InMemoryEventDispatcher instance.
+    """
+    dispatcher = InMemoryEventDispatcher()
+
+    # Register event handlers here as contexts are implemented.
+    # Example:
+    #   from contexts.notification.application.handlers import (
+    #       schedule_created_handler,
+    #   )
+    #   from contexts.preparation.domain.events import ScheduleCreated
+    #   dispatcher.register(ScheduleCreated, schedule_created_handler)
+
+    return dispatcher

--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from typing import Annotated
 
 from fastapi import Depends
@@ -19,15 +20,20 @@ from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
 
 
-def _get_session() -> AsyncSession:
-    """Lazy import wrapper to avoid DB driver import at collection time."""
-    from foundation.db.session import get_session
+async def get_session() -> AsyncGenerator[AsyncSession]:
+    """Lazy wrapper around foundation.db.session.get_session.
 
-    return get_session  # type: ignore[return-value]
+    Avoids importing the DB engine at module collection time,
+    which would fail without the asyncmy driver installed.
+    """
+    from foundation.db.session import async_session_factory
+
+    async with async_session_factory() as session:
+        yield session
 
 
 def get_schedule_repository(
-    session: Annotated[AsyncSession, Depends(_get_session)],
+    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ScheduleRepository:
     """Provide a ScheduleRepository backed by the current DB session."""
     return SqlAlchemyScheduleRepository(session)

--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -1,0 +1,40 @@
+"""DI providers for the Preparation context."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.dependencies import get_event_dispatcher, get_unit_of_work
+from contexts.preparation.application.create_schedule_service import (
+    CreateScheduleService,
+)
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+    SqlAlchemyScheduleRepository,
+)
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.db.session import get_session
+from foundation.domain.event_dispatcher import EventDispatcher
+
+
+def get_schedule_repository(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ScheduleRepository:
+    """Provide a ScheduleRepository backed by the current DB session."""
+    return SqlAlchemyScheduleRepository(session)
+
+
+def get_create_schedule_service(
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    schedule_repo: Annotated[ScheduleRepository, Depends(get_schedule_repository)],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> CreateScheduleService:
+    """Provide a CreateScheduleService with all dependencies injected."""
+    return CreateScheduleService(
+        uow=uow,
+        schedule_repo=schedule_repo,
+        event_dispatcher=event_dispatcher,
+    )

--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -16,12 +16,18 @@ from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
     SqlAlchemyScheduleRepository,
 )
 from foundation.application.unit_of_work import UnitOfWork
-from foundation.db.session import get_session
 from foundation.domain.event_dispatcher import EventDispatcher
 
 
+def _get_session() -> AsyncSession:
+    """Lazy import wrapper to avoid DB driver import at collection time."""
+    from foundation.db.session import get_session
+
+    return get_session  # type: ignore[return-value]
+
+
 def get_schedule_repository(
-    session: Annotated[AsyncSession, Depends(get_session)],
+    session: Annotated[AsyncSession, Depends(_get_session)],
 ) -> ScheduleRepository:
     """Provide a ScheduleRepository backed by the current DB session."""
     return SqlAlchemyScheduleRepository(session)

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from api.event_setup import create_event_dispatcher
 from api.exception_handlers import register_exception_handlers
 from api.register_routers import register_routers
 from foundation.scheduler.lifespan import create_reminder_scheduler
@@ -10,6 +11,8 @@ from foundation.scheduler.lifespan import create_reminder_scheduler
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    app.state.event_dispatcher = create_event_dispatcher()
+
     scheduler = create_reminder_scheduler()
     if scheduler is not None:
         scheduler.start()

--- a/backend/tests/api/test_dependencies.py
+++ b/backend/tests/api/test_dependencies.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from api.dependencies import get_event_dispatcher, get_unit_of_work
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
@@ -11,8 +13,13 @@ from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDi
 from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 
 
+@pytest.mark.integration
 class TestGetUnitOfWork:
-    """Tests for the get_unit_of_work provider."""
+    """Tests for the get_unit_of_work provider.
+
+    Marked as integration because get_unit_of_work() imports
+    async_session_factory which requires the DB driver (asyncmy).
+    """
 
     def test_returns_sqlalchemy_unit_of_work(self) -> None:
         """get_unit_of_work returns a SqlAlchemyUnitOfWork instance."""

--- a/backend/tests/api/test_dependencies.py
+++ b/backend/tests/api/test_dependencies.py
@@ -1,0 +1,41 @@
+"""Tests for shared DI providers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from api.dependencies import get_event_dispatcher, get_unit_of_work
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+
+
+class TestGetUnitOfWork:
+    """Tests for the get_unit_of_work provider."""
+
+    def test_returns_sqlalchemy_unit_of_work(self) -> None:
+        """get_unit_of_work returns a SqlAlchemyUnitOfWork instance."""
+        uow = get_unit_of_work()
+        assert isinstance(uow, SqlAlchemyUnitOfWork)
+
+    def test_returns_unit_of_work_protocol(self) -> None:
+        """The returned object satisfies the UnitOfWork abstract interface."""
+        uow = get_unit_of_work()
+        assert isinstance(uow, UnitOfWork)
+
+
+class TestGetEventDispatcher:
+    """Tests for the get_event_dispatcher provider."""
+
+    def test_returns_dispatcher_from_app_state(self) -> None:
+        """get_event_dispatcher reads from request.app.state.event_dispatcher."""
+        dispatcher = InMemoryEventDispatcher()
+
+        mock_request = MagicMock()
+        mock_request.app.state.event_dispatcher = dispatcher
+
+        result = get_event_dispatcher(mock_request)
+
+        assert result is dispatcher
+        assert isinstance(result, EventDispatcher)

--- a/backend/tests/api/test_event_setup.py
+++ b/backend/tests/api/test_event_setup.py
@@ -1,0 +1,27 @@
+"""Tests for EventDispatcher initialization."""
+
+from __future__ import annotations
+
+from api.event_setup import create_event_dispatcher
+from foundation.domain.event_dispatcher import EventDispatcher
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+
+
+class TestCreateEventDispatcher:
+    """Tests for the create_event_dispatcher factory."""
+
+    def test_returns_in_memory_event_dispatcher(self) -> None:
+        """create_event_dispatcher returns an InMemoryEventDispatcher."""
+        dispatcher = create_event_dispatcher()
+        assert isinstance(dispatcher, InMemoryEventDispatcher)
+
+    def test_satisfies_event_dispatcher_interface(self) -> None:
+        """The returned dispatcher satisfies the EventDispatcher ABC."""
+        dispatcher = create_event_dispatcher()
+        assert isinstance(dispatcher, EventDispatcher)
+
+    def test_returns_new_instance_each_call(self) -> None:
+        """Each call creates a fresh dispatcher (app startup calls once)."""
+        d1 = create_event_dispatcher()
+        d2 = create_event_dispatcher()
+        assert d1 is not d2

--- a/backend/tests/api/test_lifespan.py
+++ b/backend/tests/api/test_lifespan.py
@@ -1,0 +1,24 @@
+"""Tests for application lifespan event dispatcher initialization."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+from main import app
+
+
+class TestLifespanEventDispatcher:
+    """Verify that the lifespan sets up event_dispatcher on app.state."""
+
+    @pytest.mark.integration
+    async def test_event_dispatcher_available_on_app_state(self) -> None:
+        """After lifespan startup, app.state has an InMemoryEventDispatcher."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Trigger lifespan by making any request
+            response = await client.get("/health")
+
+        assert response.status_code == 200
+        assert isinstance(app.state.event_dispatcher, InMemoryEventDispatcher)

--- a/backend/tests/contexts/preparation/presentation/test_dependencies.py
+++ b/backend/tests/contexts/preparation/presentation/test_dependencies.py
@@ -2,6 +2,8 @@
 
 These tests verify the FastAPI Depends chain resolves correctly
 by mounting a small test router and exercising the dependency injection.
+
+Marked as integration because the Depends chain creates real DB sessions.
 """
 
 from __future__ import annotations
@@ -10,6 +12,8 @@ from typing import Annotated
 
 import pytest
 from fastapi import Depends, FastAPI
+
+pytestmark = pytest.mark.integration
 from httpx import ASGITransport, AsyncClient
 
 from api.event_setup import create_event_dispatcher

--- a/backend/tests/contexts/preparation/presentation/test_dependencies.py
+++ b/backend/tests/contexts/preparation/presentation/test_dependencies.py
@@ -1,0 +1,73 @@
+"""Tests for Preparation context DI providers.
+
+These tests verify the FastAPI Depends chain resolves correctly
+by mounting a small test router and exercising the dependency injection.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.event_setup import create_event_dispatcher
+from contexts.preparation.application.create_schedule_service import (
+    CreateScheduleService,
+)
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.presentation.dependencies import (
+    get_create_schedule_service,
+    get_schedule_repository,
+)
+
+
+@pytest.fixture
+def di_test_app() -> FastAPI:
+    """Create a minimal FastAPI app with test routes that use DI providers."""
+    app = FastAPI()
+    app.state.event_dispatcher = create_event_dispatcher()
+
+    @app.get("/test/schedule-repo")
+    async def check_schedule_repo(
+        repo: Annotated[ScheduleRepository, Depends(get_schedule_repository)],
+    ) -> dict[str, str]:
+        return {"type": type(repo).__name__}
+
+    @app.get("/test/create-schedule-service")
+    async def check_create_schedule_service(
+        service: Annotated[CreateScheduleService, Depends(get_create_schedule_service)],
+    ) -> dict[str, str]:
+        return {"type": type(service).__name__}
+
+    return app
+
+
+@pytest.mark.integration
+class TestPreparationDependencyChain:
+    """Integration tests that verify Depends chains resolve correctly.
+
+    These tests require a running database because get_session creates
+    a real AsyncSession via the session factory.
+    """
+
+    async def test_schedule_repository_resolves_to_sqlalchemy_impl(
+        self, di_test_app: FastAPI
+    ) -> None:
+        """The schedule repository provider yields a SqlAlchemyScheduleRepository."""
+        transport = ASGITransport(app=di_test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test/schedule-repo")
+
+        assert response.status_code == 200
+        assert response.json()["type"] == "SqlAlchemyScheduleRepository"
+
+    async def test_create_schedule_service_resolves(self, di_test_app: FastAPI) -> None:
+        """The create schedule service provider yields a CreateScheduleService."""
+        transport = ASGITransport(app=di_test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test/create-schedule-service")
+
+        assert response.status_code == 200
+        assert response.json()["type"] == "CreateScheduleService"


### PR DESCRIPTION
Closes #121

## Summary
- `api/dependencies.py` - 共通 DI Provider（`get_unit_of_work`, `get_event_dispatcher`）
- `api/event_setup.py` - EventDispatcher の app-scope singleton 初期化
- `contexts/preparation/presentation/dependencies.py` - Preparation コンテキストのリポジトリ/ユースケース Provider
- `main.py` の lifespan 更新（EventDispatcher 初期化）
- ユニットテスト + 結合テスト

## Test plan
- [x] ruff check / format OK
- [x] pyright 0 errors
- [x] pytest 797 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)