### PR TITLE
feat(api): エラーハンドリング（ドメイン例外 → HTTP マッピング）

### DIFF
--- a/backend/api/exception_handlers.py
+++ b/backend/api/exception_handlers.py
@@ -1,0 +1,323 @@
+"""Centralized exception-to-HTTP-status mapping and handler registration."""
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
+
+# --- Notification context: domain exceptions ---
+from contexts.notification.domain.exceptions import (
+    InvalidReminderMinutesError,
+)
+from contexts.notification.domain.exceptions import (
+    UnauthorizedOperationError as NotificationUnauthorizedOperationError,
+)
+
+# --- Preparation context: application exceptions ---
+from contexts.preparation.application.accept_consultation_request_service import (
+    ScheduleNotFoundError as AcceptConsultationScheduleNotFoundError,
+)
+from contexts.preparation.application.add_agenda_comment_service import (
+    AgendaNotFoundError as AgendaCommentAgendaNotFoundError,
+)
+from contexts.preparation.application.add_agenda_comment_service import (
+    ScheduleNotFoundError as AgendaCommentScheduleNotFoundError,
+)
+from contexts.preparation.application.add_agenda_comment_service import (
+    UnauthorizedAgendaCommentError,
+)
+from contexts.preparation.application.add_agenda_service import (
+    ScheduleNotFoundError as AddAgendaScheduleNotFoundError,
+)
+from contexts.preparation.application.add_agenda_service import (
+    UnauthorizedAgendaOperationError as AddAgendaUnauthorizedError,
+)
+from contexts.preparation.application.add_agenda_to_group_service import (
+    ScheduleGroupNotFoundError as AddAgendaToGroupScheduleGroupNotFoundError,
+)
+from contexts.preparation.application.cancel_schedule_group_service import (
+    ScheduleGroupNotFoundError as CancelGroupScheduleGroupNotFoundError,
+)
+from contexts.preparation.application.cancel_schedule_service import (
+    ScheduleNotFoundError as CancelScheduleNotFoundError,
+)
+from contexts.preparation.application.create_schedule_group_from_past_service import (
+    SourceScheduleGroupNotFoundError,
+    UnauthorizedCopyError,
+)
+from contexts.preparation.application.create_schedule_group_from_template_service import (  # noqa: E501
+    TemplateNotFoundError as CreateFromTemplateTemplateNotFoundError,
+)
+from contexts.preparation.application.create_schedule_group_from_template_service import (  # noqa: E501
+    UnauthorizedTemplateUseError,
+)
+from contexts.preparation.application.delete_agenda_service import (
+    AgendaNotFoundError as DeleteAgendaNotFoundError,
+)
+from contexts.preparation.application.delete_agenda_service import (
+    ScheduleNotFoundError as DeleteAgendaScheduleNotFoundError,
+)
+from contexts.preparation.application.delete_agenda_service import (
+    UnauthorizedAgendaOperationError as DeleteAgendaUnauthorizedError,
+)
+from contexts.preparation.application.get_template_service import (
+    TemplateNotFoundError as GetTemplateNotFoundError,
+)
+from contexts.preparation.application.get_template_service import (
+    UnauthorizedTemplateAccessError,
+)
+from contexts.preparation.application.reject_consultation_request_service import (
+    ScheduleNotFoundError as RejectConsultationScheduleNotFoundError,
+)
+from contexts.preparation.application.remove_agenda_from_group_service import (
+    ScheduleGroupNotFoundError as RemoveAgendaFromGroupScheduleGroupNotFoundError,
+)
+from contexts.preparation.application.rename_schedule_group_service import (
+    ScheduleGroupNotFoundError as RenameGroupScheduleGroupNotFoundError,
+)
+from contexts.preparation.application.rename_schedule_service import (
+    ScheduleNotFoundError as RenameScheduleNotFoundError,
+)
+from contexts.preparation.application.rename_schedule_service import (
+    UnauthorizedRenameError,
+)
+from contexts.preparation.application.reschedule_service import (
+    ScheduleNotFoundError as RescheduleScheduleNotFoundError,
+)
+
+# --- Preparation context: domain exceptions ---
+from contexts.preparation.domain.exceptions import (
+    AgendaEditNotAllowedError,
+    InconsistentScheduleAgendasError,
+    InconsistentSchedulesError,
+    InvalidScheduleOperationError,
+    InvalidScheduleTitleError,
+    InvalidTemplateNameError,
+    InvalidTopicError,
+    NoPendingConfirmationRequestError,
+    ScheduleAlreadyCancelledError,
+    UnauthorizedScheduleGroupOperationError,
+    UnauthorizedScheduleOperationError,
+    UnauthorizedTemplateOperationError,
+)
+from contexts.preparation.domain.exceptions import (
+    InvalidCommentBodyError as PreparationInvalidCommentBodyError,
+)
+
+# --- Record context: application exceptions ---
+from contexts.record.application.add_action_item import (
+    RecordNotFoundError as AddActionItemRecordNotFoundError,
+)
+from contexts.record.application.add_comment import (
+    RecordNotFoundError as AddCommentRecordNotFoundError,
+)
+from contexts.record.application.complete_action_item import (
+    ActionItemNotFoundError,
+)
+from contexts.record.application.confirm_agenda import (
+    RecordNotFoundError as ConfirmAgendaRecordNotFoundError,
+)
+from contexts.record.application.create_post_hoc_record import (
+    SameUserError,
+)
+from contexts.record.application.create_record_from_schedule import (
+    ScheduleCancelledError,
+)
+from contexts.record.application.create_record_from_schedule import (
+    ScheduleNotFoundError as CreateRecordScheduleNotFoundError,
+)
+from contexts.record.application.get_viewers import (
+    RecordNotFoundError as GetViewersRecordNotFoundError,
+)
+from contexts.record.application.list_oneonone_history import (
+    InvalidPaginationError,
+)
+from contexts.record.application.list_pending_action_items import (
+    InvalidLimitError,
+)
+from contexts.record.application.publish_record import (
+    RecordNotFoundError as PublishRecordNotFoundError,
+)
+from contexts.record.application.save_draft import (
+    RecordNotFoundError as SaveDraftRecordNotFoundError,
+)
+from contexts.record.application.set_viewers import (
+    RecordNotFoundError as SetViewersRecordNotFoundError,
+)
+from contexts.record.application.suggest_default_viewers import (
+    RecordNotFoundError as SuggestViewersRecordNotFoundError,
+)
+from contexts.record.application.update_memo import (
+    RecordNotFoundError as UpdateMemoRecordNotFoundError,
+)
+
+# --- Record context: domain exceptions ---
+from contexts.record.domain.exceptions import (
+    ActionItemAlreadyCompletedError,
+    AgendaAlreadyConfirmedError,
+    CommentAlreadyExistsError,
+    InvalidActionItemTitleError,
+    InvalidMemoError,
+    RecordAlreadyPublishedError,
+    RecordNotPublishedError,
+)
+from contexts.record.domain.exceptions import (
+    InvalidCommentBodyError as RecordInvalidCommentBodyError,
+)
+from contexts.record.domain.exceptions import (
+    UnauthorizedOperationError as RecordUnauthorizedOperationError,
+)
+
+# --- Workspace context: application exceptions ---
+from contexts.workspace.application.add_member_service import (
+    WorkspaceNotFoundError as AddMemberWorkspaceNotFoundError,
+)
+from contexts.workspace.application.change_member_role_service import (
+    WorkspaceNotFoundError as ChangeMemberRoleWorkspaceNotFoundError,
+)
+from contexts.workspace.application.change_workspace_parent_service import (
+    ParentWorkspaceNotFoundError as ChangeParentParentNotFoundError,
+)
+from contexts.workspace.application.change_workspace_parent_service import (
+    WorkspaceNotFoundError as ChangeParentWorkspaceNotFoundError,
+)
+from contexts.workspace.application.create_workspace_service import (
+    ParentWorkspaceNotFoundError as CreateWorkspaceParentNotFoundError,
+)
+from contexts.workspace.application.remove_member_service import (
+    WorkspaceNotFoundError as RemoveMemberWorkspaceNotFoundError,
+)
+from contexts.workspace.application.rename_workspace_service import (
+    WorkspaceNotFoundError as RenameWorkspaceNotFoundError,
+)
+
+# --- Workspace context: domain exceptions ---
+from contexts.workspace.domain.exceptions import (
+    CircularHierarchyError,
+    DuplicateMembershipError,
+    InvalidWorkspaceNameError,
+    MembershipNotFoundError,
+)
+
+EXCEPTION_STATUS_MAP: dict[type[Exception], int] = {
+    # -------------------------------------------------------
+    # 403 Forbidden -- authorization / permission errors
+    # -------------------------------------------------------
+    RecordUnauthorizedOperationError: 403,
+    NotificationUnauthorizedOperationError: 403,
+    UnauthorizedScheduleOperationError: 403,
+    UnauthorizedScheduleGroupOperationError: 403,
+    UnauthorizedTemplateOperationError: 403,
+    UnauthorizedCopyError: 403,
+    UnauthorizedTemplateUseError: 403,
+    UnauthorizedTemplateAccessError: 403,
+    UnauthorizedAgendaCommentError: 403,
+    AddAgendaUnauthorizedError: 403,
+    DeleteAgendaUnauthorizedError: 403,
+    UnauthorizedRenameError: 403,
+    # -------------------------------------------------------
+    # 404 Not Found
+    # -------------------------------------------------------
+    # Preparation -- Schedule
+    CancelScheduleNotFoundError: 404,
+    RescheduleScheduleNotFoundError: 404,
+    RejectConsultationScheduleNotFoundError: 404,
+    AcceptConsultationScheduleNotFoundError: 404,
+    AddAgendaScheduleNotFoundError: 404,
+    AgendaCommentScheduleNotFoundError: 404,
+    DeleteAgendaScheduleNotFoundError: 404,
+    RenameScheduleNotFoundError: 404,
+    # Preparation -- ScheduleGroup
+    AddAgendaToGroupScheduleGroupNotFoundError: 404,
+    RemoveAgendaFromGroupScheduleGroupNotFoundError: 404,
+    RenameGroupScheduleGroupNotFoundError: 404,
+    CancelGroupScheduleGroupNotFoundError: 404,
+    SourceScheduleGroupNotFoundError: 404,
+    # Preparation -- Template
+    GetTemplateNotFoundError: 404,
+    CreateFromTemplateTemplateNotFoundError: 404,
+    # Preparation -- Agenda
+    DeleteAgendaNotFoundError: 404,
+    AgendaCommentAgendaNotFoundError: 404,
+    # Record -- Record
+    AddActionItemRecordNotFoundError: 404,
+    AddCommentRecordNotFoundError: 404,
+    ConfirmAgendaRecordNotFoundError: 404,
+    GetViewersRecordNotFoundError: 404,
+    PublishRecordNotFoundError: 404,
+    SaveDraftRecordNotFoundError: 404,
+    SetViewersRecordNotFoundError: 404,
+    SuggestViewersRecordNotFoundError: 404,
+    UpdateMemoRecordNotFoundError: 404,
+    CreateRecordScheduleNotFoundError: 404,
+    # Record -- ActionItem
+    ActionItemNotFoundError: 404,
+    # Workspace
+    AddMemberWorkspaceNotFoundError: 404,
+    ChangeMemberRoleWorkspaceNotFoundError: 404,
+    ChangeParentWorkspaceNotFoundError: 404,
+    ChangeParentParentNotFoundError: 404,
+    CreateWorkspaceParentNotFoundError: 404,
+    RemoveMemberWorkspaceNotFoundError: 404,
+    RenameWorkspaceNotFoundError: 404,
+    MembershipNotFoundError: 404,
+    # -------------------------------------------------------
+    # 409 Conflict -- state violation
+    # -------------------------------------------------------
+    ScheduleAlreadyCancelledError: 409,
+    RecordAlreadyPublishedError: 409,
+    ActionItemAlreadyCompletedError: 409,
+    AgendaAlreadyConfirmedError: 409,
+    CommentAlreadyExistsError: 409,
+    DuplicateMembershipError: 409,
+    CircularHierarchyError: 409,
+    NoPendingConfirmationRequestError: 409,
+    ScheduleCancelledError: 409,
+    SameUserError: 409,
+    # -------------------------------------------------------
+    # 422 Unprocessable Entity -- validation / business rule
+    # -------------------------------------------------------
+    InvalidReminderMinutesError: 422,
+    InvalidScheduleOperationError: 422,
+    RecordNotPublishedError: 422,
+    InvalidLimitError: 422,
+    InvalidPaginationError: 422,
+    InvalidTopicError: 422,
+    InvalidTemplateNameError: 422,
+    InvalidScheduleTitleError: 422,
+    PreparationInvalidCommentBodyError: 422,
+    RecordInvalidCommentBodyError: 422,
+    InvalidActionItemTitleError: 422,
+    InvalidMemoError: 422,
+    InvalidWorkspaceNameError: 422,
+    AgendaEditNotAllowedError: 422,
+    InconsistentScheduleAgendasError: 422,
+    InconsistentSchedulesError: 422,
+}
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register exception handlers for all mapped domain/application exceptions.
+
+    Each exception class in ``EXCEPTION_STATUS_MAP`` gets a handler that
+    returns a JSON response with the corresponding HTTP status code and
+    a ``{"detail": "..."}`` body.
+
+    Unmapped exceptions will fall through to FastAPI's default 500 handler.
+    """
+
+    for exc_cls, status_code in EXCEPTION_STATUS_MAP.items():
+
+        def _make_handler(
+            code: int,
+        ) -> Callable[[Request, Exception], Awaitable[JSONResponse]]:
+            async def _handler(_request: Request, exc: Exception) -> JSONResponse:
+                return JSONResponse(
+                    status_code=code,
+                    content={"detail": str(exc)},
+                )
+
+            return _handler
+
+        app.add_exception_handler(exc_cls, _make_handler(status_code))

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from api.exception_handlers import register_exception_handlers
 from api.register_routers import register_routers
 from foundation.scheduler.lifespan import create_reminder_scheduler
 
@@ -19,6 +20,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
 app = FastAPI(title="perigee", version="0.1.0", lifespan=lifespan)
 
+register_exception_handlers(app)
 register_routers(app)
 
 

--- a/backend/tests/api/test_exception_handlers.py
+++ b/backend/tests/api/test_exception_handlers.py
@@ -1,0 +1,193 @@
+"""Unit tests for the centralized exception handler registration."""
+
+import uuid
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.exception_handlers import EXCEPTION_STATUS_MAP, register_exception_handlers
+from contexts.notification.domain.exceptions import (
+    InvalidReminderMinutesError,
+)
+from contexts.notification.domain.exceptions import (
+    UnauthorizedOperationError as NotificationUnauthorizedOperationError,
+)
+from contexts.preparation.application.cancel_schedule_service import (
+    ScheduleNotFoundError,
+)
+from contexts.preparation.domain.exceptions import (
+    InvalidScheduleOperationError,
+    ScheduleAlreadyCancelledError,
+    UnauthorizedScheduleOperationError,
+)
+from contexts.preparation.domain.value_objects import ScheduleId
+from contexts.record.application.complete_action_item import (
+    ActionItemNotFoundError,
+)
+from contexts.record.domain.exceptions import (
+    ActionItemAlreadyCompletedError,
+    AgendaAlreadyConfirmedError,
+    RecordAlreadyPublishedError,
+    RecordNotPublishedError,
+)
+from contexts.record.domain.exceptions import (
+    UnauthorizedOperationError as RecordUnauthorizedOperationError,
+)
+from contexts.record.domain.value_objects import ActionItemId
+
+
+def _build_app_with_raising_route(exc: Exception) -> FastAPI:
+    """Create a minimal FastAPI app that raises the given exception."""
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.get("/raise")
+    async def _raise() -> None:
+        raise exc
+
+    return app
+
+
+async def _get_response(exc: Exception) -> tuple[int, dict]:
+    app = _build_app_with_raising_route(exc)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/raise")
+    return response.status_code, response.json()
+
+
+class TestExceptionStatusMap:
+    """Verify EXCEPTION_STATUS_MAP covers all expected categories."""
+
+    def test_map_is_not_empty(self) -> None:
+        assert len(EXCEPTION_STATUS_MAP) > 0
+
+    def test_all_values_are_valid_http_status_codes(self) -> None:
+        for exc_cls, status_code in EXCEPTION_STATUS_MAP.items():
+            assert 400 <= status_code < 600, (
+                f"{exc_cls.__name__} mapped to invalid status {status_code}"
+            )
+
+    def test_all_keys_are_exception_subclasses(self) -> None:
+        for exc_cls in EXCEPTION_STATUS_MAP:
+            assert issubclass(exc_cls, Exception), (
+                f"{exc_cls} is not an Exception subclass"
+            )
+
+
+class TestForbiddenExceptions:
+    """403 Forbidden responses."""
+
+    async def test_record_unauthorized_operation(self) -> None:
+        status, body = await _get_response(
+            RecordUnauthorizedOperationError("No permission")
+        )
+        assert status == 403
+        assert body == {"detail": "No permission"}
+
+    async def test_notification_unauthorized_operation(self) -> None:
+        status, body = await _get_response(
+            NotificationUnauthorizedOperationError("Not allowed")
+        )
+        assert status == 403
+        assert body == {"detail": "Not allowed"}
+
+    async def test_unauthorized_schedule_operation(self) -> None:
+        status, body = await _get_response(
+            UnauthorizedScheduleOperationError("Forbidden")
+        )
+        assert status == 403
+        assert body == {"detail": "Forbidden"}
+
+
+class TestNotFoundExceptions:
+    """404 Not Found responses."""
+
+    async def test_schedule_not_found(self) -> None:
+        schedule_id = ScheduleId(uuid.uuid4())
+        status, body = await _get_response(ScheduleNotFoundError(schedule_id))
+        assert status == 404
+        assert str(schedule_id.value) in body["detail"]
+
+    async def test_action_item_not_found(self) -> None:
+        action_item_id = ActionItemId(uuid.uuid4())
+        status, body = await _get_response(ActionItemNotFoundError(action_item_id))
+        assert status == 404
+        assert str(action_item_id.value) in body["detail"]
+
+
+class TestConflictExceptions:
+    """409 Conflict responses."""
+
+    async def test_schedule_already_cancelled(self) -> None:
+        status, body = await _get_response(ScheduleAlreadyCancelledError())
+        assert status == 409
+        assert body == {"detail": "Schedule is already cancelled."}
+
+    async def test_record_already_published(self) -> None:
+        status, body = await _get_response(RecordAlreadyPublishedError())
+        assert status == 409
+        assert body == {"detail": "Record is already published."}
+
+    async def test_action_item_already_completed(self) -> None:
+        status, body = await _get_response(ActionItemAlreadyCompletedError())
+        assert status == 409
+        assert body == {"detail": "Action item is already completed."}
+
+    async def test_agenda_already_confirmed(self) -> None:
+        status, body = await _get_response(AgendaAlreadyConfirmedError())
+        assert status == 409
+        assert body == {"detail": "Agenda is already confirmed."}
+
+
+class TestUnprocessableEntityExceptions:
+    """422 Unprocessable Entity responses."""
+
+    async def test_invalid_reminder_minutes(self) -> None:
+        status, body = await _get_response(InvalidReminderMinutesError())
+        assert status == 422
+        assert "reminder_minutes_before" in body["detail"]
+
+    async def test_invalid_schedule_operation(self) -> None:
+        status, body = await _get_response(
+            InvalidScheduleOperationError("Bad operation")
+        )
+        assert status == 422
+        assert body == {"detail": "Bad operation"}
+
+    async def test_record_not_published(self) -> None:
+        status, body = await _get_response(RecordNotPublishedError())
+        assert status == 422
+        assert body == {"detail": "Record is not published."}
+
+
+class TestUnmappedException:
+    """Unmapped exceptions are not caught by the handler.
+
+    FastAPI's default ServerErrorMiddleware re-raises unmapped exceptions
+    when ``debug=True`` (the default).  We verify that the exception is
+    **not** intercepted by our handler, confirming that only registered
+    exception classes are mapped.
+    """
+
+    async def test_unmapped_exception_is_not_handled(self) -> None:
+        app = _build_app_with_raising_route(RuntimeError("unexpected"))
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/raise")
+        assert response.status_code == 500
+
+
+class TestResponseFormat:
+    """Verify the response body format is consistent."""
+
+    async def test_detail_field_matches_exception_message(self) -> None:
+        custom_msg = "Custom error message for testing"
+        status, body = await _get_response(RecordAlreadyPublishedError(custom_msg))
+        assert status == 409
+        assert body == {"detail": custom_msg}
+
+    async def test_default_message_used_when_no_custom_message(self) -> None:
+        status, body = await _get_response(AgendaAlreadyConfirmedError())
+        assert status == 409
+        assert body == {"detail": "Agenda is already confirmed."}


### PR DESCRIPTION
Closes #122

## Summary
- `api/exception_handlers.py` にマッピングテーブル + `register_exception_handlers(app)` を実装
- ドメイン例外 + アプリケーション例外の両方を対象
- 同名例外クラスは import alias で区別
- 未登録例外は 500（FastAPI デフォルト）
- ユニットテスト

## Test plan
- [x] ruff check / format OK
- [x] pyright 0 errors
- [x] pytest passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)