### PR TITLE
fix(di): UoW をセッション受け取り方式に変更し DI のセッション不一致を解消

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -2,18 +2,38 @@
 
 from __future__ import annotations
 
-from fastapi import Request
+from collections.abc import AsyncGenerator
+from typing import Annotated
+
+from fastapi import Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
 
 
-def get_unit_of_work() -> UnitOfWork:
-    """Provide a new UnitOfWork backed by SQLAlchemy."""
+async def get_session() -> AsyncGenerator[AsyncSession]:
+    """Provide a DB session scoped to a single request.
+
+    Uses a lazy import to avoid importing the DB engine at module
+    collection time, which would fail without the asyncmy driver.
+
+    All DI providers that need a session should depend on this single
+    callable so that repositories and the UoW share the same session.
+    """
     from foundation.db.session import async_session_factory
+
+    async with async_session_factory() as session:
+        yield session
+
+
+def get_unit_of_work(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> UnitOfWork:
+    """Provide a UnitOfWork backed by the shared request-scoped session."""
     from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 
-    return SqlAlchemyUnitOfWork(async_session_factory)
+    return SqlAlchemyUnitOfWork(session)
 
 
 def get_event_dispatcher(request: Request) -> EventDispatcher:

--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
 from typing import Annotated
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.dependencies import get_event_dispatcher, get_unit_of_work
+from api.dependencies import get_event_dispatcher, get_session, get_unit_of_work
 from contexts.preparation.application.create_schedule_service import (
     CreateScheduleService,
 )
@@ -18,18 +17,6 @@ from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
 )
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
-
-
-async def get_session() -> AsyncGenerator[AsyncSession]:
-    """Lazy wrapper around foundation.db.session.get_session.
-
-    Avoids importing the DB engine at module collection time,
-    which would fail without the asyncmy driver installed.
-    """
-    from foundation.db.session import async_session_factory
-
-    async with async_session_factory() as session:
-        yield session
 
 
 def get_schedule_repository(

--- a/backend/foundation/infrastructure/sqlalchemy_unit_of_work.py
+++ b/backend/foundation/infrastructure/sqlalchemy_unit_of_work.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from types import TracebackType
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from foundation.application.unit_of_work import UnitOfWork
 
@@ -10,43 +10,39 @@ from foundation.application.unit_of_work import UnitOfWork
 class SqlAlchemyUnitOfWork(UnitOfWork):
     """Unit of Work implementation backed by a SQLAlchemy ``AsyncSession``.
 
+    Receives an ``AsyncSession`` directly (typically injected via FastAPI
+    ``Depends``), so that repositories and the UoW share the same session.
+
     Usage::
 
-        uow = SqlAlchemyUnitOfWork(session_factory)
+        uow = SqlAlchemyUnitOfWork(session)
         async with uow:
-            # use uow.session to interact with repositories
+            # repositories use the same session
             await uow.commit()
 
-    On context-manager exit, any uncommitted changes are rolled back
-    automatically if an exception propagates.
+    The UoW relies on SQLAlchemy's *autobegin* behaviour -- ``__aenter__``
+    does **not** call ``begin()`` explicitly.  On context-manager exit, any
+    uncommitted changes are rolled back automatically if an exception
+    propagates.
     """
 
-    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
-        self._session_factory = session_factory
-        self._session: AsyncSession | None = None
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
 
     @property
     def session(self) -> AsyncSession:
-        """Return the active session.
-
-        Raises ``RuntimeError`` if accessed outside the context manager.
-        """
-        if self._session is None:
-            raise RuntimeError(
-                "SqlAlchemyUnitOfWork must be used as an async context manager."
-            )
+        """Return the underlying session."""
         return self._session
 
     async def commit(self) -> None:
         """Commit the current database transaction."""
-        await self.session.commit()
+        await self._session.commit()
 
     async def rollback(self) -> None:
         """Roll back the current database transaction."""
-        await self.session.rollback()
+        await self._session.rollback()
 
     async def __aenter__(self) -> SqlAlchemyUnitOfWork:
-        self._session = self._session_factory()
         return self
 
     async def __aexit__(
@@ -57,11 +53,3 @@ class SqlAlchemyUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
-        elif self._session is not None and self._session.in_transaction():
-            # Explicitly roll back uncommitted changes on normal exit so the
-            # transaction boundary is visible in the code rather than relying
-            # on SQLAlchemy's implicit rollback-on-close behaviour.
-            await self.rollback()
-        if self._session is not None:
-            await self._session.close()
-            self._session = None

--- a/backend/tests/api/test_dependencies.py
+++ b/backend/tests/api/test_dependencies.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock
 
 from api.dependencies import get_event_dispatcher, get_unit_of_work
 from foundation.application.unit_of_work import UnitOfWork
@@ -13,23 +11,27 @@ from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDi
 from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 
 
-@pytest.mark.integration
 class TestGetUnitOfWork:
-    """Tests for the get_unit_of_work provider.
-
-    Marked as integration because get_unit_of_work() imports
-    async_session_factory which requires the DB driver (asyncmy).
-    """
+    """Tests for the get_unit_of_work provider."""
 
     def test_returns_sqlalchemy_unit_of_work(self) -> None:
         """get_unit_of_work returns a SqlAlchemyUnitOfWork instance."""
-        uow = get_unit_of_work()
+        mock_session = AsyncMock()
+        uow = get_unit_of_work(mock_session)
         assert isinstance(uow, SqlAlchemyUnitOfWork)
 
     def test_returns_unit_of_work_protocol(self) -> None:
         """The returned object satisfies the UnitOfWork abstract interface."""
-        uow = get_unit_of_work()
+        mock_session = AsyncMock()
+        uow = get_unit_of_work(mock_session)
         assert isinstance(uow, UnitOfWork)
+
+    def test_uow_uses_provided_session(self) -> None:
+        """The UoW should use the session that was passed in."""
+        mock_session = AsyncMock()
+        uow = get_unit_of_work(mock_session)
+        assert isinstance(uow, SqlAlchemyUnitOfWork)
+        assert uow.session is mock_session
 
 
 class TestGetEventDispatcher:

--- a/backend/tests/foundation/infrastructure/test_sqlalchemy_unit_of_work.py
+++ b/backend/tests/foundation/infrastructure/test_sqlalchemy_unit_of_work.py
@@ -1,13 +1,54 @@
-import pytest
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
 
 from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 
 
 class TestSqlAlchemyUnitOfWork:
-    def test_session_raises_outside_context(self) -> None:
-        """Accessing session outside async with block should raise RuntimeError."""
-        # We cannot easily construct a real session_factory without a DB,
-        # so we test the guard by passing a dummy factory.
-        uow = SqlAlchemyUnitOfWork(None)  # type: ignore[arg-type]
-        with pytest.raises(RuntimeError, match="async context manager"):
-            _ = uow.session
+    def test_session_property_returns_injected_session(self) -> None:
+        """session property should return the AsyncSession passed to __init__."""
+        mock_session = MagicMock()
+        uow = SqlAlchemyUnitOfWork(mock_session)
+        assert uow.session is mock_session
+
+    async def test_aenter_returns_self(self) -> None:
+        """__aenter__ should return the UoW itself without calling begin()."""
+        mock_session = MagicMock()
+        uow = SqlAlchemyUnitOfWork(mock_session)
+        result = await uow.__aenter__()
+        assert result is uow
+
+    async def test_commit_delegates_to_session(self) -> None:
+        """commit() should delegate to session.commit()."""
+        mock_session = AsyncMock()
+        uow = SqlAlchemyUnitOfWork(mock_session)
+        await uow.commit()
+        mock_session.commit.assert_awaited_once()
+
+    async def test_rollback_delegates_to_session(self) -> None:
+        """rollback() should delegate to session.rollback()."""
+        mock_session = AsyncMock()
+        uow = SqlAlchemyUnitOfWork(mock_session)
+        await uow.rollback()
+        mock_session.rollback.assert_awaited_once()
+
+    async def test_aexit_rolls_back_on_exception(self) -> None:
+        """__aexit__ should rollback when an exception is raised."""
+        mock_session = AsyncMock()
+        uow = SqlAlchemyUnitOfWork(mock_session)
+        await uow.__aenter__()
+
+        await uow.__aexit__(ValueError, ValueError("test"), None)
+
+        mock_session.rollback.assert_awaited_once()
+
+    async def test_aexit_does_not_rollback_on_normal_exit(self) -> None:
+        """__aexit__ should not rollback on normal (no exception) exit."""
+        mock_session = AsyncMock()
+        uow = SqlAlchemyUnitOfWork(mock_session)
+        await uow.__aenter__()
+
+        await uow.__aexit__(None, None, None)
+
+        mock_session.rollback.assert_not_awaited()


### PR DESCRIPTION
## Summary
- `SqlAlchemyUnitOfWork` が `async_sessionmaker` ではなく `AsyncSession` を直接受け取る形に変更
- `get_session` の lazy wrapper を `api/dependencies.py` に集約し、全コンテキストで同一セッションを共有
- `__aenter__` で `begin()` を呼ばず SQLAlchemy の autobegin に委任、セッションの close は `get_session` の yield 後処理に委任

## Test plan
- [x] `tests/api/test_dependencies.py` が修正されてパスする
- [x] `tests/foundation/infrastructure/test_sqlalchemy_unit_of_work.py` が修正されてパスする
- [ ] 既存のユニットテストが全てパスする

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)