### PR TITLE
feat(preparation): Agenda リポジトリ + DBマイグレーション

### DIFF
--- a/backend/contexts/preparation/infrastructure/sqlalchemy_agenda_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_agenda_repository.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.preparation.domain.agenda import Agenda
+from contexts.preparation.domain.agenda_repository import AgendaRepository
+from contexts.preparation.domain.comment import Comment
+from contexts.preparation.domain.comment_body import CommentBody
+from contexts.preparation.domain.topic import Topic
+from contexts.preparation.domain.value_objects import (
+    AddedByTag,
+    AgendaId,
+    CommentId,
+    ScheduleId,
+)
+from contexts.preparation.infrastructure.tables import (
+    AgendaCommentTable,
+    AgendaTable,
+)
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyAgendaRepository(AgendaRepository):
+    """SQLAlchemy-based implementation of AgendaRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: AgendaId) -> Agenda | None:
+        stmt = select(AgendaTable).where(AgendaTable.id == str(entity_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def save(self, entity: Agenda) -> None:
+        existing = await self._session.get(AgendaTable, str(entity.id.value))
+        if existing is None:
+            await self._insert(entity)
+        else:
+            await self._update(entity, existing)
+
+    async def get_by_schedule_id(self, schedule_id: ScheduleId) -> list[Agenda]:
+        stmt = select(AgendaTable).where(
+            AgendaTable.schedule_id == str(schedule_id.value)
+        )
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [self._to_entity(row) for row in rows]
+
+    async def get_by_schedule_ids(
+        self, schedule_ids: list[ScheduleId]
+    ) -> dict[ScheduleId, list[Agenda]]:
+        if not schedule_ids:
+            return {}
+        id_strings = [str(sid.value) for sid in schedule_ids]
+        stmt = select(AgendaTable).where(AgendaTable.schedule_id.in_(id_strings))
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+
+        grouped: dict[ScheduleId, list[Agenda]] = {sid: [] for sid in schedule_ids}
+        for row in rows:
+            sid = ScheduleId.from_str(row.schedule_id)
+            grouped[sid].append(self._to_entity(row))
+        return grouped
+
+    async def save_all(self, agendas: list[Agenda]) -> None:
+        for agenda in agendas:
+            await self.save(agenda)
+
+    async def delete_by_ids(self, agenda_ids: list[AgendaId]) -> None:
+        if not agenda_ids:
+            return
+        id_strings = [str(aid.value) for aid in agenda_ids]
+        stmt = delete(AgendaTable).where(AgendaTable.id.in_(id_strings))
+        await self._session.execute(stmt)
+        await self._session.flush()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _insert(self, entity: Agenda) -> None:
+        agenda_row = AgendaTable(
+            id=str(entity.id.value),
+            schedule_id=str(entity.schedule_id.value),
+            topic=entity.topic.value,
+            added_by=str(entity.added_by.value),
+            added_by_tag=entity.added_by_tag.value,
+            created_at=entity.created_at,
+            updated_at=entity.created_at,
+        )
+        for comment in entity.comments:
+            comment_row = AgendaCommentTable(
+                id=str(comment.id.value),
+                agenda_id=str(entity.id.value),
+                author_id=str(comment.author_id.value),
+                body=comment.body.value,
+                created_at=comment.created_at,
+                updated_at=comment.created_at,
+            )
+            agenda_row.comments.append(comment_row)
+        self._session.add(agenda_row)
+        await self._session.flush()
+
+    async def _update(self, entity: Agenda, existing: AgendaTable) -> None:
+        now = datetime.now(UTC)
+
+        existing.schedule_id = str(entity.schedule_id.value)
+        existing.topic = entity.topic.value
+        existing.added_by = str(entity.added_by.value)
+        existing.added_by_tag = entity.added_by_tag.value
+        existing.updated_at = now
+
+        # Reconcile comments
+        existing_comment_map: dict[str, AgendaCommentTable] = {
+            c.id: c for c in existing.comments
+        }
+        entity_comment_ids: set[str] = set()
+
+        for comment in entity.comments:
+            comment_id = str(comment.id.value)
+            entity_comment_ids.add(comment_id)
+            if comment_id in existing_comment_map:
+                db_comment = existing_comment_map[comment_id]
+                db_comment.author_id = str(comment.author_id.value)
+                db_comment.body = comment.body.value
+                db_comment.updated_at = now
+            else:
+                new_comment = AgendaCommentTable(
+                    id=comment_id,
+                    agenda_id=str(entity.id.value),
+                    author_id=str(comment.author_id.value),
+                    body=comment.body.value,
+                    created_at=comment.created_at,
+                    updated_at=comment.created_at,
+                )
+                existing.comments.append(new_comment)
+
+        for comment_id, db_comment in existing_comment_map.items():
+            if comment_id not in entity_comment_ids:
+                existing.comments.remove(db_comment)
+
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: AgendaTable) -> Agenda:
+        comments = [
+            Comment(
+                _id=CommentId.from_str(c.id),
+                _agenda_id=AgendaId.from_str(c.agenda_id),
+                _author_id=UserId.from_str(c.author_id),
+                _body=CommentBody(c.body),
+                _created_at=c.created_at,
+            )
+            for c in row.comments
+        ]
+        return Agenda(
+            _id=AgendaId.from_str(row.id),
+            _schedule_id=ScheduleId.from_str(row.schedule_id),
+            _topic=Topic(row.topic),
+            _added_by=UserId.from_str(row.added_by),
+            _added_by_tag=AddedByTag(row.added_by_tag),
+            _comments=comments,
+            _created_at=row.created_at,
+        )

--- a/backend/contexts/preparation/infrastructure/tables.py
+++ b/backend/contexts/preparation/infrastructure/tables.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from sqlalchemy import (
     CHAR,
     INTEGER,
+    TEXT,
     VARCHAR,
     ForeignKey,
     UniqueConstraint,
@@ -254,4 +255,74 @@ class ConfirmationRequestTable(Base, TimestampMixin):
 
     schedule: Mapped["ScheduleTable"] = relationship(
         back_populates="confirmation_requests",
+    )
+
+
+# ------------------------------------------------------------------
+# Agenda
+# ------------------------------------------------------------------
+
+
+class AgendaTable(Base, TimestampMixin):
+    """ORM model for the agendas table."""
+
+    __tablename__ = "agendas"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    schedule_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "schedules.id",
+            name="fk_agendas_schedule_id",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    topic: Mapped[str] = mapped_column(VARCHAR(200), nullable=False)
+    added_by: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_agendas_added_by",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    added_by_tag: Mapped[str] = mapped_column(VARCHAR(20), nullable=False)
+
+    comments: Mapped[list["AgendaCommentTable"]] = relationship(
+        back_populates="agenda",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )
+
+
+class AgendaCommentTable(Base, TimestampMixin):
+    """ORM model for the agenda_comments table."""
+
+    __tablename__ = "agenda_comments"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    agenda_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "agendas.id",
+            name="fk_agenda_comments_agenda_id",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    author_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            name="fk_agenda_comments_author_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    body: Mapped[str] = mapped_column(TEXT, nullable=False)
+
+    agenda: Mapped["AgendaTable"] = relationship(
+        back_populates="comments",
     )

--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -11,7 +11,11 @@ from api.dependencies import get_event_dispatcher, get_session, get_unit_of_work
 from contexts.preparation.application.create_schedule_service import (
     CreateScheduleService,
 )
+from contexts.preparation.domain.agenda_repository import AgendaRepository
 from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.infrastructure.sqlalchemy_agenda_repository import (
+    SqlAlchemyAgendaRepository,
+)
 from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
     SqlAlchemyScheduleRepository,
 )
@@ -24,6 +28,13 @@ def get_schedule_repository(
 ) -> ScheduleRepository:
     """Provide a ScheduleRepository backed by the current DB session."""
     return SqlAlchemyScheduleRepository(session)
+
+
+def get_agenda_repository(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> AgendaRepository:
+    """Provide an AgendaRepository backed by the current DB session."""
+    return SqlAlchemyAgendaRepository(session)
 
 
 def get_create_schedule_service(

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -9,6 +9,8 @@ from contexts.notification.infrastructure.tables import (
     ReminderLogTable,  # noqa: F401
 )
 from contexts.preparation.infrastructure.tables import (
+    AgendaCommentTable,  # noqa: F401
+    AgendaTable,  # noqa: F401
     ConfirmationRequestTable,  # noqa: F401
     ScheduleGroupAgendaTemplateTable,  # noqa: F401
     ScheduleGroupTable,  # noqa: F401
@@ -32,6 +34,8 @@ from shared.infrastructure.tables import UserTable  # noqa: F401
 
 __all__ = [
     "ActionItemTable",
+    "AgendaCommentTable",
+    "AgendaTable",
     "NotificationSettingTable",
     "ReminderLogTable",
     "CommentTable",

--- a/backend/migrations/versions/0008_create_agenda_tables.py
+++ b/backend/migrations/versions/0008_create_agenda_tables.py
@@ -1,0 +1,93 @@
+"""create agendas and agenda_comments tables
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-03-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import DATETIME as MYSQL_DATETIME
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- agendas ---
+    op.create_table(
+        "agendas",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("schedule_id", sa.CHAR(36), nullable=False),
+        sa.Column("topic", sa.VARCHAR(200), nullable=False),
+        sa.Column("added_by", sa.CHAR(36), nullable=False),
+        sa.Column("added_by_tag", sa.VARCHAR(20), nullable=False),
+        sa.Column(
+            "created_at",
+            MYSQL_DATETIME(fsp=6),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            MYSQL_DATETIME(fsp=6),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["schedule_id"],
+            ["schedules.id"],
+            name="fk_agendas_schedule_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["added_by"],
+            ["users.id"],
+            name="fk_agendas_added_by",
+            ondelete="RESTRICT",
+        ),
+    )
+
+    # --- agenda_comments ---
+    op.create_table(
+        "agenda_comments",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("agenda_id", sa.CHAR(36), nullable=False),
+        sa.Column("author_id", sa.CHAR(36), nullable=False),
+        sa.Column("body", sa.TEXT(), nullable=False),
+        sa.Column(
+            "created_at",
+            MYSQL_DATETIME(fsp=6),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            MYSQL_DATETIME(fsp=6),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["agenda_id"],
+            ["agendas.id"],
+            name="fk_agenda_comments_agenda_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["author_id"],
+            ["users.id"],
+            name="fk_agenda_comments_author_id",
+            ondelete="RESTRICT",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("agenda_comments")
+    op.drop_table("agendas")


### PR DESCRIPTION
## Summary
- agendas / agenda_comments テーブルの ORM 定義を tables.py に追加
- SqlAlchemyAgendaRepository を新規作成し、AgendaRepository インターフェースの全メソッドを実装（get_by_id, save, get_by_schedule_id, get_by_schedule_ids, save_all, delete_by_ids）
- Alembic マイグレーション 0008 を追加（agendas -> agenda_comments の FK 依存順）
- foundation/db/models.py に AgendaTable, AgendaCommentTable の import を追加
- dependencies.py の _get_agenda_repository を lazy import から通常 import に変更

## Test plan
- [x] ruff check / ruff format --check がパス
- [x] pyright が 0 errors
- [x] pytest -m "not integration" が全テストパス（834 passed）
- [ ] integration テスト（CI で DB コンテナ使用時に alembic upgrade head + リポジトリ CRUD を確認）

Closes #138

Generated with [Claude Code](https://claude.com/claude-code)
