### PR TITLE
feat(record): 記録閲覧・コメント画面APIエンドポイント追加

### DIFF
--- a/backend/api/exception_handlers.py
+++ b/backend/api/exception_handlers.py
@@ -127,6 +127,9 @@ from contexts.record.application.create_record_from_schedule import (
 from contexts.record.application.create_record_from_schedule import (
     ScheduleNotFoundError as CreateRecordScheduleNotFoundError,
 )
+from contexts.record.application.get_record_detail import (
+    RecordNotFoundError as GetRecordDetailRecordNotFoundError,
+)
 from contexts.record.application.get_viewers import (
     RecordNotFoundError as GetViewersRecordNotFoundError,
 )
@@ -135,6 +138,9 @@ from contexts.record.application.list_oneonone_history import (
 )
 from contexts.record.application.list_pending_action_items import (
     InvalidLimitError,
+)
+from contexts.record.application.list_record_comments import (
+    RecordNotFoundError as ListRecordCommentsRecordNotFoundError,
 )
 from contexts.record.application.publish_record import (
     RecordNotFoundError as PublishRecordNotFoundError,
@@ -244,7 +250,9 @@ EXCEPTION_STATUS_MAP: dict[type[Exception], int] = {
     AddActionItemRecordNotFoundError: 404,
     AddCommentRecordNotFoundError: 404,
     ConfirmAgendaRecordNotFoundError: 404,
+    GetRecordDetailRecordNotFoundError: 404,
     GetViewersRecordNotFoundError: 404,
+    ListRecordCommentsRecordNotFoundError: 404,
     PublishRecordNotFoundError: 404,
     SaveDraftRecordNotFoundError: 404,
     SetViewersRecordNotFoundError: 404,

--- a/backend/contexts/record/application/get_record_detail.py
+++ b/backend/contexts/record/application/get_record_detail.py
@@ -1,0 +1,123 @@
+"""Use case: Get Record detail (read-only).
+
+Returns the full record with memo, action items, and confirmed agenda IDs.
+Visibility rules apply: draft records are only visible to the organizer;
+published records are visible to organizer, counterpart, and viewers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.exceptions import UnauthorizedOperationError
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import ActionItemId, RecordId, RecordStatus
+from shared.domain.value_objects import UserId
+
+
+class RecordNotFoundError(Exception):
+    """Raised when the specified record does not exist."""
+
+    def __init__(self, record_id: RecordId) -> None:
+        self.record_id = record_id
+        super().__init__(f"Record not found: {record_id.value}")
+
+
+@dataclass(frozen=True)
+class ActionItemDTO:
+    """Action item summary for record detail output."""
+
+    action_item_id: ActionItemId
+    title: str
+    is_completed: bool
+    counterpart_id: UserId
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class GetRecordDetailInput:
+    """Input DTO for GetRecordDetailUseCase."""
+
+    record_id: RecordId
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class GetRecordDetailOutput:
+    """Output DTO for GetRecordDetailUseCase."""
+
+    record_id: RecordId
+    organizer_id: UserId
+    counterpart_id: UserId
+    schedule_id: ScheduleId | None
+    memo: str
+    status: RecordStatus
+    confirmed_agenda_ids: list[AgendaId]
+    action_items: list[ActionItemDTO]
+    conducted_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+class GetRecordDetailUseCase:
+    """Return the full detail of a record.
+
+    Authorization:
+    - Draft records: only the organizer can view.
+    - Published records: organizer, counterpart, and viewers can view.
+
+    This is a read-only query; no UoW or EventDispatcher needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        action_item_repository: ActionItemRepository,
+    ) -> None:
+        self._record_repository = record_repository
+        self._action_item_repository = action_item_repository
+
+    async def execute(self, input_dto: GetRecordDetailInput) -> GetRecordDetailOutput:
+        record = await self._record_repository.get_by_id(input_dto.record_id)
+        if record is None:
+            raise RecordNotFoundError(input_dto.record_id)
+
+        if not record.is_visible_to(input_dto.actor_id):
+            raise UnauthorizedOperationError(
+                "You do not have permission to view this record."
+            )
+
+        # Fetch action items for this record
+        action_items: list[
+            ActionItem
+        ] = await self._action_item_repository.list_by_record_id(record.id)
+
+        action_item_dtos = [
+            ActionItemDTO(
+                action_item_id=ai.id,
+                title=ai.title.value,
+                is_completed=ai.is_completed,
+                counterpart_id=ai.counterpart_id,
+                created_at=ai.created_at,
+            )
+            for ai in action_items
+        ]
+
+        return GetRecordDetailOutput(
+            record_id=record.id,
+            organizer_id=record.organizer_id,
+            counterpart_id=record.counterpart_id,
+            schedule_id=record.schedule_id,
+            memo=record.memo.value,
+            status=record.status,
+            confirmed_agenda_ids=list(record.confirmed_agenda_ids),
+            action_items=action_item_dtos,
+            conducted_at=record.conducted_at,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+        )

--- a/backend/contexts/record/application/list_record_comments.py
+++ b/backend/contexts/record/application/list_record_comments.py
@@ -1,0 +1,103 @@
+"""Use case: List comments for a published Record (read-only).
+
+Only users who can see the record (organizer, counterpart, viewers) can
+list its comments. Comments on draft records are not accessible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.record.domain.comment_repository import CommentRepository
+from contexts.record.domain.exceptions import (
+    RecordNotPublishedError,
+    UnauthorizedOperationError,
+)
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import CommentId, RecordId, RecordStatus
+from shared.domain.value_objects import UserId
+
+
+class RecordNotFoundError(Exception):
+    """Raised when the specified record does not exist."""
+
+    def __init__(self, record_id: RecordId) -> None:
+        self.record_id = record_id
+        super().__init__(f"Record not found: {record_id.value}")
+
+
+@dataclass(frozen=True)
+class CommentDTO:
+    """Single comment item in the output."""
+
+    comment_id: CommentId
+    author_id: UserId
+    body: str
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class ListRecordCommentsInput:
+    """Input DTO for ListRecordCommentsUseCase."""
+
+    record_id: RecordId
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class ListRecordCommentsOutput:
+    """Output DTO for ListRecordCommentsUseCase."""
+
+    comments: list[CommentDTO]
+
+
+class ListRecordCommentsUseCase:
+    """List all comments for a published record.
+
+    Authorization:
+    - Record must be published.
+    - Actor must be visible to the record (organizer, counterpart, or viewer).
+
+    This is a read-only query; no UoW or EventDispatcher needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        comment_repository: CommentRepository,
+    ) -> None:
+        self._record_repository = record_repository
+        self._comment_repository = comment_repository
+
+    async def execute(
+        self, input_dto: ListRecordCommentsInput
+    ) -> ListRecordCommentsOutput:
+        record = await self._record_repository.get_by_id(input_dto.record_id)
+        if record is None:
+            raise RecordNotFoundError(input_dto.record_id)
+
+        if record.status != RecordStatus.PUBLISHED:
+            raise RecordNotPublishedError(
+                "Comments are only available for published records."
+            )
+
+        if not record.is_visible_to(input_dto.actor_id):
+            raise UnauthorizedOperationError(
+                "You do not have permission to view comments on this record."
+            )
+
+        comments = await self._comment_repository.list_by_record_id(input_dto.record_id)
+
+        return ListRecordCommentsOutput(
+            comments=[
+                CommentDTO(
+                    comment_id=c.id,
+                    author_id=c.author_id,
+                    body=c.body.value,
+                    created_at=c.created_at,
+                )
+                for c in comments
+            ]
+        )

--- a/backend/contexts/record/domain/comment_repository.py
+++ b/backend/contexts/record/domain/comment_repository.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from abc import abstractmethod
+
 from contexts.record.domain.comment import Comment
-from contexts.record.domain.value_objects import CommentId
+from contexts.record.domain.value_objects import CommentId, RecordId
 from foundation.domain.base_repository import BaseRepository
 
 
@@ -12,4 +14,9 @@ class CommentRepository(BaseRepository[Comment, CommentId]):
     if the entity already exists.
     """
 
-    pass
+    @abstractmethod
+    async def list_by_record_id(self, record_id: RecordId) -> list[Comment]:
+        """Return all comments for a given Record.
+
+        Results are ordered by created_at ascending (oldest first).
+        """

--- a/backend/contexts/record/infrastructure/sqlalchemy_comment_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_comment_repository.py
@@ -46,6 +46,15 @@ class SqlAlchemyCommentRepository(CommentRepository):
         self._session.add(comment_row)
         await self._session.flush()
 
+    async def list_by_record_id(self, record_id: RecordId) -> list[Comment]:
+        stmt = (
+            select(CommentTable)
+            .where(CommentTable.record_id == str(record_id.value))
+            .order_by(CommentTable.created_at.asc())
+        )
+        result = await self._session.execute(stmt)
+        return [self._to_entity(row) for row in result.scalars().all()]
+
     @staticmethod
     def _to_entity(row: CommentTable) -> Comment:
         return Comment(

--- a/backend/contexts/record/presentation/dependencies.py
+++ b/backend/contexts/record/presentation/dependencies.py
@@ -8,10 +8,28 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.dependencies import get_event_dispatcher, get_session, get_unit_of_work
+from contexts.record.application.add_comment import AddCommentUseCase
+from contexts.record.application.complete_action_item import CompleteActionItemUseCase
 from contexts.record.application.create_post_hoc_record import (
     CreatePostHocRecordUseCase,
 )
+from contexts.record.application.get_record_detail import GetRecordDetailUseCase
+from contexts.record.application.get_viewers import GetViewersUseCase
+from contexts.record.application.list_oneonone_history import (
+    ListOneOnOneHistoryService,
+)
+from contexts.record.application.list_record_comments import (
+    ListRecordCommentsUseCase,
+)
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.comment_repository import CommentRepository
 from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.infrastructure.sqlalchemy_action_item_repository import (
+    SqlAlchemyActionItemRepository,
+)
+from contexts.record.infrastructure.sqlalchemy_comment_repository import (
+    SqlAlchemyCommentRepository,
+)
 from contexts.record.infrastructure.sqlalchemy_record_repository import (
     SqlAlchemyRecordRepository,
 )
@@ -26,6 +44,20 @@ def get_record_repository(
     return SqlAlchemyRecordRepository(session)
 
 
+def get_comment_repository(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> CommentRepository:
+    """Provide a CommentRepository backed by the current DB session."""
+    return SqlAlchemyCommentRepository(session)
+
+
+def get_action_item_repository(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ActionItemRepository:
+    """Provide an ActionItemRepository backed by the current DB session."""
+    return SqlAlchemyActionItemRepository(session)
+
+
 def get_create_post_hoc_record_use_case(
     uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
     record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
@@ -36,4 +68,76 @@ def get_create_post_hoc_record_use_case(
         record_repository=record_repo,
         unit_of_work=uow,
         event_dispatcher=event_dispatcher,
+    )
+
+
+def get_get_record_detail_use_case(
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    action_item_repo: Annotated[
+        ActionItemRepository, Depends(get_action_item_repository)
+    ],
+) -> GetRecordDetailUseCase:
+    """Provide a GetRecordDetailUseCase with all dependencies injected."""
+    return GetRecordDetailUseCase(
+        record_repository=record_repo,
+        action_item_repository=action_item_repo,
+    )
+
+
+def get_list_record_comments_use_case(
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    comment_repo: Annotated[CommentRepository, Depends(get_comment_repository)],
+) -> ListRecordCommentsUseCase:
+    """Provide a ListRecordCommentsUseCase with all dependencies injected."""
+    return ListRecordCommentsUseCase(
+        record_repository=record_repo,
+        comment_repository=comment_repo,
+    )
+
+
+def get_get_viewers_use_case(
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+) -> GetViewersUseCase:
+    """Provide a GetViewersUseCase with all dependencies injected."""
+    return GetViewersUseCase(
+        record_repository=record_repo,
+    )
+
+
+def get_add_comment_use_case(
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    comment_repo: Annotated[CommentRepository, Depends(get_comment_repository)],
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> AddCommentUseCase:
+    """Provide an AddCommentUseCase with all dependencies injected."""
+    return AddCommentUseCase(
+        record_repository=record_repo,
+        comment_repository=comment_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_complete_action_item_use_case(
+    action_item_repo: Annotated[
+        ActionItemRepository, Depends(get_action_item_repository)
+    ],
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> CompleteActionItemUseCase:
+    """Provide a CompleteActionItemUseCase with all dependencies injected."""
+    return CompleteActionItemUseCase(
+        action_item_repository=action_item_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_list_oneonone_history_service(
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+) -> ListOneOnOneHistoryService:
+    """Provide a ListOneOnOneHistoryService with all dependencies injected."""
+    return ListOneOnOneHistoryService(
+        record_repository=record_repo,
     )

--- a/backend/contexts/record/presentation/router.py
+++ b/backend/contexts/record/presentation/router.py
@@ -1,21 +1,64 @@
-"""FastAPI router for the Record context (post-hoc record endpoint)."""
+"""FastAPI router for the Record context."""
 
 from __future__ import annotations
 
 from typing import Annotated
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 
+from contexts.record.application.add_comment import (
+    AddCommentInput,
+    AddCommentUseCase,
+)
+from contexts.record.application.complete_action_item import (
+    CompleteActionItemInput,
+    CompleteActionItemUseCase,
+)
 from contexts.record.application.create_post_hoc_record import (
     CreatePostHocRecordInput,
     CreatePostHocRecordUseCase,
 )
+from contexts.record.application.get_record_detail import (
+    GetRecordDetailInput,
+    GetRecordDetailUseCase,
+)
+from contexts.record.application.get_viewers import (
+    GetViewersInput,
+    GetViewersUseCase,
+)
+from contexts.record.application.list_oneonone_history import (
+    ListOneOnOneHistoryInput,
+    ListOneOnOneHistoryService,
+)
+from contexts.record.application.list_record_comments import (
+    ListRecordCommentsInput,
+    ListRecordCommentsUseCase,
+)
+from contexts.record.domain.comment_body import CommentBody
+from contexts.record.domain.value_objects import ActionItemId, RecordId
 from contexts.record.presentation.dependencies import (
+    get_add_comment_use_case,
+    get_complete_action_item_use_case,
     get_create_post_hoc_record_use_case,
+    get_get_record_detail_use_case,
+    get_get_viewers_use_case,
+    get_list_oneonone_history_service,
+    get_list_record_comments_use_case,
 )
 from contexts.record.presentation.schemas import (
+    ActionItemSchema,
+    AddCommentRequest,
+    AddCommentResponse,
+    CommentSchema,
+    CompleteActionItemResponse,
     CreatePostHocRecordRequest,
     CreatePostHocRecordResponse,
+    GetRecordDetailResponse,
+    GetViewersResponse,
+    ListOneOnOneHistoryResponse,
+    ListRecordCommentsResponse,
+    OneOnOneHistoryItemSchema,
 )
 from foundation.auth.dependencies import get_current_user_id
 from shared.domain.value_objects import UserId
@@ -44,3 +87,174 @@ async def create_post_hoc_record(
     )
     output = await use_case.execute(input_dto)
     return CreatePostHocRecordResponse(record_id=output.record_id.value)
+
+
+@router.get(
+    "/records/history",
+    response_model=ListOneOnOneHistoryResponse,
+)
+async def list_oneonone_history(
+    organizer_id: Annotated[UUID, Query()],
+    counterpart_id: Annotated[UUID, Query()],
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    service: Annotated[
+        ListOneOnOneHistoryService, Depends(get_list_oneonone_history_service)
+    ],
+    offset: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=200)] = 20,
+) -> ListOneOnOneHistoryResponse:
+    """List 1-on-1 history for an organizer-counterpart pair."""
+    input_dto = ListOneOnOneHistoryInput(
+        actor_id=current_user_id,
+        organizer_id=UserId(value=organizer_id),
+        counterpart_id=UserId(value=counterpart_id),
+        offset=offset,
+        limit=limit,
+    )
+    output = await service.execute(input_dto)
+    return ListOneOnOneHistoryResponse(
+        items=[
+            OneOnOneHistoryItemSchema(
+                record_id=item.record_id.value,
+                organizer_id=item.organizer_id.value,
+                counterpart_id=item.counterpart_id.value,
+                conducted_at=item.conducted_at,
+                memo_excerpt=item.memo_excerpt,
+                schedule_id=item.schedule_id.value if item.schedule_id else None,
+            )
+            for item in output.items
+        ],
+        total_count=output.total_count,
+    )
+
+
+@router.get(
+    "/records/{record_id}",
+    response_model=GetRecordDetailResponse,
+)
+async def get_record_detail(
+    record_id: UUID,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[
+        GetRecordDetailUseCase, Depends(get_get_record_detail_use_case)
+    ],
+) -> GetRecordDetailResponse:
+    """Get record detail."""
+    input_dto = GetRecordDetailInput(
+        record_id=RecordId(value=record_id),
+        actor_id=current_user_id,
+    )
+    output = await use_case.execute(input_dto)
+    return GetRecordDetailResponse(
+        record_id=output.record_id.value,
+        organizer_id=output.organizer_id.value,
+        counterpart_id=output.counterpart_id.value,
+        schedule_id=output.schedule_id.value if output.schedule_id else None,
+        memo=output.memo,
+        status=output.status.value,
+        confirmed_agenda_ids=[aid.value for aid in output.confirmed_agenda_ids],
+        action_items=[
+            ActionItemSchema(
+                action_item_id=ai.action_item_id.value,
+                title=ai.title,
+                is_completed=ai.is_completed,
+                counterpart_id=ai.counterpart_id.value,
+                created_at=ai.created_at,
+            )
+            for ai in output.action_items
+        ],
+        conducted_at=output.conducted_at,
+        created_at=output.created_at,
+        updated_at=output.updated_at,
+    )
+
+
+@router.get(
+    "/records/{record_id}/comments",
+    response_model=ListRecordCommentsResponse,
+)
+async def list_record_comments(
+    record_id: UUID,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[
+        ListRecordCommentsUseCase, Depends(get_list_record_comments_use_case)
+    ],
+) -> ListRecordCommentsResponse:
+    """List comments for a published record."""
+    input_dto = ListRecordCommentsInput(
+        record_id=RecordId(value=record_id),
+        actor_id=current_user_id,
+    )
+    output = await use_case.execute(input_dto)
+    return ListRecordCommentsResponse(
+        comments=[
+            CommentSchema(
+                comment_id=c.comment_id.value,
+                author_id=c.author_id.value,
+                body=c.body,
+                created_at=c.created_at,
+            )
+            for c in output.comments
+        ]
+    )
+
+
+@router.get(
+    "/records/{record_id}/viewers",
+    response_model=GetViewersResponse,
+)
+async def get_viewers(
+    record_id: UUID,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[GetViewersUseCase, Depends(get_get_viewers_use_case)],
+) -> GetViewersResponse:
+    """Get viewers for a record."""
+    input_dto = GetViewersInput(
+        record_id=RecordId(value=record_id),
+        actor_id=current_user_id,
+    )
+    output = await use_case.execute(input_dto)
+    return GetViewersResponse(
+        viewer_ids=[v.value for v in output.viewer_ids],
+    )
+
+
+@router.post(
+    "/records/{record_id}/comments",
+    response_model=AddCommentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_comment(
+    record_id: UUID,
+    body: AddCommentRequest,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[AddCommentUseCase, Depends(get_add_comment_use_case)],
+) -> AddCommentResponse:
+    """Add a comment to a published record."""
+    input_dto = AddCommentInput(
+        record_id=RecordId(value=record_id),
+        actor_id=current_user_id,
+        body=CommentBody(body.body),
+    )
+    output = await use_case.execute(input_dto)
+    return AddCommentResponse(comment_id=output.comment_id.value)
+
+
+@router.post(
+    "/action-items/{action_item_id}/complete",
+    response_model=CompleteActionItemResponse,
+)
+async def complete_action_item(
+    action_item_id: UUID,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[
+        CompleteActionItemUseCase, Depends(get_complete_action_item_use_case)
+    ],
+) -> CompleteActionItemResponse:
+    """Complete an action item."""
+    input_dto = CompleteActionItemInput(
+        action_item_id=ActionItemId(value=action_item_id),
+        actor_id=current_user_id,
+    )
+    output = await use_case.execute(input_dto)
+    return CompleteActionItemResponse(action_item_id=output.action_item_id.value)

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel
+from pydantic import AwareDatetime, BaseModel, Field
 
 # ---------------------------------------------------------------------------
 # Post-hoc record -- POST /records/post-hoc
@@ -21,3 +21,116 @@ class CreatePostHocRecordResponse(BaseModel):
     """Response body for POST /records/post-hoc."""
 
     record_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Record detail -- GET /records/{record_id}
+# ---------------------------------------------------------------------------
+
+
+class ActionItemSchema(BaseModel):
+    """Action item within a record detail response."""
+
+    action_item_id: UUID
+    title: str
+    is_completed: bool
+    counterpart_id: UUID
+    created_at: datetime
+
+
+class GetRecordDetailResponse(BaseModel):
+    """Response body for GET /records/{record_id}."""
+
+    record_id: UUID
+    organizer_id: UUID
+    counterpart_id: UUID
+    schedule_id: UUID | None
+    memo: str
+    status: str
+    confirmed_agenda_ids: list[UUID]
+    action_items: list[ActionItemSchema]
+    conducted_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Comments -- GET /records/{record_id}/comments
+# ---------------------------------------------------------------------------
+
+
+class CommentSchema(BaseModel):
+    """Single comment in a comment list response."""
+
+    comment_id: UUID
+    author_id: UUID
+    body: str
+    created_at: datetime
+
+
+class ListRecordCommentsResponse(BaseModel):
+    """Response body for GET /records/{record_id}/comments."""
+
+    comments: list[CommentSchema]
+
+
+# ---------------------------------------------------------------------------
+# Viewers -- GET /records/{record_id}/viewers
+# ---------------------------------------------------------------------------
+
+
+class GetViewersResponse(BaseModel):
+    """Response body for GET /records/{record_id}/viewers."""
+
+    viewer_ids: list[UUID]
+
+
+# ---------------------------------------------------------------------------
+# Add comment -- POST /records/{record_id}/comments
+# ---------------------------------------------------------------------------
+
+
+class AddCommentRequest(BaseModel):
+    """Request body for POST /records/{record_id}/comments."""
+
+    body: str
+
+
+class AddCommentResponse(BaseModel):
+    """Response body for POST /records/{record_id}/comments."""
+
+    comment_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Complete action item -- POST /action-items/{action_item_id}/complete
+# ---------------------------------------------------------------------------
+
+
+class CompleteActionItemResponse(BaseModel):
+    """Response body for POST /action-items/{action_item_id}/complete."""
+
+    action_item_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# 1on1 history -- GET /records/history
+# ---------------------------------------------------------------------------
+
+
+class OneOnOneHistoryItemSchema(BaseModel):
+    """Single item in the 1-on-1 history list."""
+
+    record_id: UUID
+    organizer_id: UUID
+    counterpart_id: UUID
+    conducted_at: datetime
+    memo_excerpt: str
+    schedule_id: UUID | None
+
+
+class ListOneOnOneHistoryResponse(BaseModel):
+    """Response body for GET /records/history."""
+
+    items: list[OneOnOneHistoryItemSchema]
+    total_count: int = Field(ge=0)

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -169,6 +169,11 @@ class InMemoryCommentRepository(CommentRepository):
     async def save(self, entity: Comment) -> None:
         self._comments[entity.id] = entity
 
+    async def list_by_record_id(self, record_id: RecordId) -> list[Comment]:
+        comments = [c for c in self._comments.values() if c.record_id == record_id]
+        comments.sort(key=lambda c: c.created_at)
+        return comments
+
     @property
     def saved_comments(self) -> list[Comment]:
         return list(self._comments.values())

--- a/backend/tests/contexts/record/presentation/test_viewer_router.py
+++ b/backend/tests/contexts/record/presentation/test_viewer_router.py
@@ -1,0 +1,553 @@
+"""Integration tests for Record viewer/reader API endpoints.
+
+These tests exercise the full HTTP layer (router -> DI -> use case -> repository -> DB)
+for the read-only record endpoints introduced in the record-viewer feature.
+
+Endpoints covered:
+- GET /records/{record_id}
+- GET /records/{record_id}/comments
+- GET /records/{record_id}/viewers
+- GET /records/history
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from api.event_setup import create_event_dispatcher
+from api.exception_handlers import register_exception_handlers
+from api.register_routers import register_routers
+from contexts.record.application.publish_record import (
+    PublishRecordInput,
+    PublishRecordUseCase,
+)
+from contexts.record.domain.value_objects import RecordId
+from contexts.record.infrastructure.sqlalchemy_record_repository import (
+    SqlAlchemyRecordRepository,
+)
+from foundation.infrastructure.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from shared.domain.value_objects import UserId
+
+pytestmark = pytest.mark.integration
+
+_BASE_URL = "http://test"
+
+
+def _create_test_app():
+    """Create a FastAPI app wired with routers and exception handlers."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.state.event_dispatcher = create_event_dispatcher()
+    register_exception_handlers(app)
+    register_routers(app)
+    return app
+
+
+@pytest.fixture
+def app():
+    return _create_test_app()
+
+
+@pytest.fixture
+def organizer_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def counterpart_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def unrelated_user_id() -> str:
+    return str(uuid.uuid4())
+
+
+async def _create_record(
+    client: AsyncClient,
+    organizer_id: str,
+    counterpart_id: str,
+) -> str:
+    """Helper: create a post-hoc record and return its record_id."""
+    response = await client.post(
+        "/records/post-hoc",
+        headers={"X-User-Id": organizer_id},
+        json={
+            "counterpart_id": counterpart_id,
+            "conducted_at": "2026-03-20T14:00:00+09:00",
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["record_id"]
+
+
+async def _publish_record_via_use_case(
+    record_id: str,
+    organizer_id: str,
+) -> None:
+    """Helper: publish a record using the application use case directly.
+
+    Since no publish HTTP endpoint is registered yet, this bypasses the
+    HTTP layer and calls the use-case with a fresh DB session.
+    """
+    from foundation.db.session import async_session_factory
+
+    async with async_session_factory() as session:
+        repo = SqlAlchemyRecordRepository(session)
+        uow = SqlAlchemyUnitOfWork(session)
+        dispatcher = create_event_dispatcher()
+        use_case = PublishRecordUseCase(
+            record_repository=repo,
+            unit_of_work=uow,
+            event_dispatcher=dispatcher,
+        )
+        await use_case.execute(
+            PublishRecordInput(
+                record_id=RecordId(value=uuid.UUID(record_id)),
+                actor_id=UserId(value=uuid.UUID(organizer_id)),
+                viewer_ids=[],
+            )
+        )
+
+
+# -----------------------------------------------------------------------
+# GET /records/{record_id}
+# -----------------------------------------------------------------------
+
+
+class TestGetRecordDetail:
+    """Tests for GET /records/{record_id}."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without X-User-Id header returns 401."""
+        record_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(f"/records/{record_id}")
+
+        assert response.status_code == 401
+
+    async def test_returns_404_for_nonexistent_record(
+        self, app, organizer_id: str
+    ) -> None:
+        """Requesting a non-existent record returns 404."""
+        fake_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{fake_id}",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 404
+
+    async def test_organizer_can_view_draft_record(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """The organizer can view their own draft record."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+            response = await client.get(
+                f"/records/{record_id}",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["record_id"] == record_id
+        assert data["organizer_id"] == organizer_id
+        assert data["counterpart_id"] == counterpart_id
+        assert data["status"] == "draft"
+        assert data["memo"] == ""
+        assert data["action_items"] == []
+        assert data["confirmed_agenda_ids"] == []
+
+    async def test_counterpart_cannot_view_draft_record(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """The counterpart cannot view a draft record (only organizer can)."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+            response = await client.get(
+                f"/records/{record_id}",
+                headers={"X-User-Id": counterpart_id},
+            )
+
+        assert response.status_code == 403
+
+    async def test_counterpart_can_view_published_record(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """The counterpart can view a published record."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{record_id}",
+                headers={"X-User-Id": counterpart_id},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["record_id"] == record_id
+        assert data["status"] == "published"
+
+    async def test_unrelated_user_cannot_view_published_record(
+        self, app, organizer_id: str, counterpart_id: str, unrelated_user_id: str
+    ) -> None:
+        """A user who is neither organizer, counterpart, nor viewer cannot view."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{record_id}",
+                headers={"X-User-Id": unrelated_user_id},
+            )
+
+        assert response.status_code == 403
+
+
+# -----------------------------------------------------------------------
+# GET /records/{record_id}/comments
+# -----------------------------------------------------------------------
+
+
+class TestListRecordComments:
+    """Tests for GET /records/{record_id}/comments."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without X-User-Id header returns 401."""
+        record_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(f"/records/{record_id}/comments")
+
+        assert response.status_code == 401
+
+    async def test_returns_404_for_nonexistent_record(
+        self, app, organizer_id: str
+    ) -> None:
+        """Requesting comments for a non-existent record returns 404."""
+        fake_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{fake_id}/comments",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 404
+
+    async def test_returns_422_for_draft_record(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """Listing comments on a draft record returns 422 (not published)."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+            response = await client.get(
+                f"/records/{record_id}/comments",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 422
+
+    async def test_returns_empty_comments_for_published_record(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """A freshly published record has no comments."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{record_id}/comments",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["comments"] == []
+
+    async def test_counterpart_can_list_comments(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """The counterpart can list comments on a published record."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{record_id}/comments",
+                headers={"X-User-Id": counterpart_id},
+            )
+
+        assert response.status_code == 200
+
+    async def test_unrelated_user_cannot_list_comments(
+        self, app, organizer_id: str, counterpart_id: str, unrelated_user_id: str
+    ) -> None:
+        """An unrelated user cannot list comments on a published record."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{record_id}/comments",
+                headers={"X-User-Id": unrelated_user_id},
+            )
+
+        assert response.status_code == 403
+
+
+# -----------------------------------------------------------------------
+# GET /records/{record_id}/viewers
+# -----------------------------------------------------------------------
+
+
+class TestGetViewers:
+    """Tests for GET /records/{record_id}/viewers."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without X-User-Id header returns 401."""
+        record_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(f"/records/{record_id}/viewers")
+
+        assert response.status_code == 401
+
+    async def test_returns_404_for_nonexistent_record(
+        self, app, organizer_id: str
+    ) -> None:
+        """Requesting viewers for a non-existent record returns 404."""
+        fake_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{fake_id}/viewers",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 404
+
+    async def test_organizer_can_view_viewers(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """The organizer can view the viewers list."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+            response = await client.get(
+                f"/records/{record_id}/viewers",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["viewer_ids"] == []
+
+    async def test_counterpart_can_view_viewers_on_published(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """The counterpart can view viewers on a published record."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/records/{record_id}/viewers",
+                headers={"X-User-Id": counterpart_id},
+            )
+
+        assert response.status_code == 200
+
+    async def test_counterpart_cannot_view_viewers_on_draft(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """The counterpart cannot view viewers on a draft record."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+            response = await client.get(
+                f"/records/{record_id}/viewers",
+                headers={"X-User-Id": counterpart_id},
+            )
+
+        assert response.status_code == 403
+
+    async def test_unrelated_user_cannot_view_viewers(
+        self, app, organizer_id: str, counterpart_id: str, unrelated_user_id: str
+    ) -> None:
+        """An unrelated user cannot view the viewers list."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+            response = await client.get(
+                f"/records/{record_id}/viewers",
+                headers={"X-User-Id": unrelated_user_id},
+            )
+
+        assert response.status_code == 403
+
+
+# -----------------------------------------------------------------------
+# GET /records/history
+# -----------------------------------------------------------------------
+
+
+class TestListOneOnOneHistory:
+    """Tests for GET /records/history."""
+
+    async def test_returns_401_without_auth_header(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """Request without X-User-Id header returns 401."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/records/history",
+                params={
+                    "organizer_id": organizer_id,
+                    "counterpart_id": counterpart_id,
+                },
+            )
+
+        assert response.status_code == 401
+
+    async def test_returns_empty_list_when_no_records(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """Returns empty list when no published records exist for the pair."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/records/history",
+                headers={"X-User-Id": organizer_id},
+                params={
+                    "organizer_id": organizer_id,
+                    "counterpart_id": counterpart_id,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"] == []
+        assert data["total_count"] == 0
+
+    async def test_draft_records_not_included_in_history(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """Draft records are not included in history (only published)."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            await _create_record(client, organizer_id, counterpart_id)
+            response = await client.get(
+                "/records/history",
+                headers={"X-User-Id": organizer_id},
+                params={
+                    "organizer_id": organizer_id,
+                    "counterpart_id": counterpart_id,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"] == []
+        assert data["total_count"] == 0
+
+    async def test_published_records_included_in_history(
+        self, app, organizer_id: str, counterpart_id: str
+    ) -> None:
+        """Published records appear in history."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/records/history",
+                headers={"X-User-Id": organizer_id},
+                params={
+                    "organizer_id": organizer_id,
+                    "counterpart_id": counterpart_id,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["record_id"] == record_id
+
+    async def test_unrelated_user_sees_empty_history(
+        self, app, organizer_id: str, counterpart_id: str, unrelated_user_id: str
+    ) -> None:
+        """An unrelated user does not see records in the history."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            record_id = await _create_record(client, organizer_id, counterpart_id)
+
+        await _publish_record_via_use_case(record_id, organizer_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/records/history",
+                headers={"X-User-Id": unrelated_user_id},
+                params={
+                    "organizer_id": organizer_id,
+                    "counterpart_id": counterpart_id,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"] == []
+        assert data["total_count"] == 0
+
+    async def test_requires_organizer_id_and_counterpart_id(
+        self, app, organizer_id: str
+    ) -> None:
+        """Missing required query parameters returns 422."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/records/history",
+                headers={"X-User-Id": organizer_id},
+            )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary

Issue #132 の要件に基づき、記録閲覧・コメント画面に必要な6つのAPIエンドポイントを追加。

- **GET /records/{id}** - 記録詳細取得（GetRecordDetailUseCase）
- **GET /records/{id}/comments** - コメント一覧取得（ListRecordCommentsUseCase）
- **GET /records/{id}/viewers** - 公開先確認（GetViewersUseCase）
- **POST /records/{id}/comments** - コメント追加（AddCommentUseCase）
- **POST /action-items/{id}/complete** - アクションアイテム完了（CompleteActionItemUseCase）
- **GET /records/history** - 1on1履歴一覧（ListOneOnOneHistoryService、ページネーション対応）

### 変更内容

- CommentRepository インターフェースに list_by_record_id 抽象メソッドを追加
- SqlAlchemyCommentRepository に list_by_record_id の実装を追加
- GetRecordDetailUseCase / ListRecordCommentsUseCase アプリケーションサービスを新規作成
- 全6ユースケースのDIプロバイダーを dependencies.py に追加
- リクエスト/レスポンスの Pydantic スキーマを schemas.py に追加
- テスト用 InMemoryCommentRepository に list_by_record_id を追加

## Test plan

- [x] ruff check / ruff format --check でリント・フォーマット確認済み
- [x] pyright で型チェック通過済み
- [x] pytest -m "not integration" で全856テスト通過済み
- [ ] インテグレーションテストで各エンドポイントの動作確認

Closes #132
