### PR TITLE
feat(api): add recording screen endpoints

### DIFF
--- a/backend/contexts/record/application/delete_action_item.py
+++ b/backend/contexts/record/application/delete_action_item.py
@@ -1,0 +1,127 @@
+"""Use case: Delete an ActionItem from a Record.
+
+The organizer deletes an action item during a 1-on-1 session.
+After a successful commit the ActionItemDeleted domain event is dispatched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.events import ActionItemDeleted
+from contexts.record.domain.exceptions import (
+    RecordAlreadyPublishedError,
+    UnauthorizedOperationError,
+)
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import ActionItemId, RecordId, RecordStatus
+from foundation.application.unit_of_work import UnitOfWork
+from foundation.domain.event_dispatcher import EventDispatcher
+from shared.domain.events import DomainEvent
+from shared.domain.value_objects import UserId
+
+
+class RecordNotFoundError(Exception):
+    """Raised when the specified record does not exist."""
+
+    def __init__(self, record_id: RecordId) -> None:
+        self.record_id = record_id
+        super().__init__(f"Record not found: {record_id.value}")
+
+
+class ActionItemNotFoundError(Exception):
+    """Raised when the specified action item does not exist."""
+
+    def __init__(self, action_item_id: ActionItemId) -> None:
+        self.action_item_id = action_item_id
+        super().__init__(f"Action item not found: {action_item_id.value}")
+
+
+@dataclass(frozen=True)
+class DeleteActionItemInput:
+    """Input DTO for DeleteActionItemUseCase."""
+
+    record_id: RecordId
+    action_item_id: ActionItemId
+    actor_id: UserId
+
+
+@dataclass(frozen=True)
+class DeleteActionItemOutput:
+    """Output DTO for DeleteActionItemUseCase."""
+
+    action_item_id: ActionItemId
+
+
+class DeleteActionItemUseCase:
+    """Delete an action item from a record.
+
+    Workflow:
+    1. Load the record and verify it exists.
+    2. Verify the actor is the organizer.
+    3. Verify the record is still in DRAFT status.
+    4. Load the action item and verify it belongs to the record.
+    5. Delete the action item within a transaction.
+    6. Dispatch domain events after commit.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_repository: RecordRepository,
+        action_item_repository: ActionItemRepository,
+        unit_of_work: UnitOfWork,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        self._record_repository = record_repository
+        self._action_item_repository = action_item_repository
+        self._unit_of_work = unit_of_work
+        self._event_dispatcher = event_dispatcher
+
+    async def execute(
+        self, input_dto: DeleteActionItemInput
+    ) -> DeleteActionItemOutput:
+        now = datetime.now(UTC)
+
+        async with self._unit_of_work:
+            record = await self._record_repository.get_by_id(input_dto.record_id)
+            if record is None:
+                raise RecordNotFoundError(input_dto.record_id)
+
+            # Only organizer may delete action items
+            if input_dto.actor_id != record.organizer_id:
+                raise UnauthorizedOperationError(
+                    "Only the organizer can delete action items."
+                )
+
+            # Record must still be in draft
+            if record.status != RecordStatus.DRAFT:
+                raise RecordAlreadyPublishedError("Record is already published.")
+
+            action_item = await self._action_item_repository.get_by_id(
+                input_dto.action_item_id
+            )
+            if action_item is None:
+                raise ActionItemNotFoundError(input_dto.action_item_id)
+
+            # Verify action item belongs to this record
+            if action_item.record_id != input_dto.record_id:
+                raise ActionItemNotFoundError(input_dto.action_item_id)
+
+            await self._action_item_repository.delete(input_dto.action_item_id)
+            await self._unit_of_work.commit()
+
+        # Dispatch events after successful commit
+        events: list[DomainEvent] = [
+            ActionItemDeleted(
+                occurred_at=now,
+                action_item_id=input_dto.action_item_id,
+                record_id=input_dto.record_id,
+                deleted_by=input_dto.actor_id,
+            )
+        ]
+        await self._event_dispatcher.dispatch(events)
+
+        return DeleteActionItemOutput(action_item_id=input_dto.action_item_id)

--- a/backend/contexts/record/domain/action_item_repository.py
+++ b/backend/contexts/record/domain/action_item_repository.py
@@ -28,3 +28,7 @@ class ActionItemRepository(BaseRepository[ActionItem, ActionItemId]):
 
         Results are ordered by created_at ascending (oldest first).
         """
+
+    @abstractmethod
+    async def delete(self, action_item_id: ActionItemId) -> None:
+        """Delete an action item by its identifier."""

--- a/backend/contexts/record/domain/events.py
+++ b/backend/contexts/record/domain/events.py
@@ -86,6 +86,15 @@ class ActionItemAdded(DomainEvent):
 
 
 @dataclass(frozen=True)
+class ActionItemDeleted(DomainEvent):
+    """Raised when an action item is deleted by the organizer."""
+
+    action_item_id: ActionItemId
+    record_id: RecordId
+    deleted_by: UserId
+
+
+@dataclass(frozen=True)
 class ActionItemCompleted(DomainEvent):
     """Raised when an action item is completed by the counterpart."""
 

--- a/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
@@ -57,6 +57,12 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
         result = await self._session.execute(stmt)
         return [self._to_entity(row) for row in result.scalars().all()]
 
+    async def delete(self, action_item_id: ActionItemId) -> None:
+        row = await self._session.get(ActionItemTable, str(action_item_id.value))
+        if row is not None:
+            await self._session.delete(row)
+            await self._session.flush()
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------

--- a/backend/contexts/record/presentation/dependencies.py
+++ b/backend/contexts/record/presentation/dependencies.py
@@ -8,15 +8,35 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.dependencies import get_event_dispatcher, get_session, get_unit_of_work
+from contexts.preparation.domain.schedule_repository import ScheduleRepository
+from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+    SqlAlchemyScheduleRepository,
+)
+from contexts.record.application.add_action_item import AddActionItemUseCase
+from contexts.record.application.confirm_agenda import ConfirmAgendaUseCase
 from contexts.record.application.create_post_hoc_record import (
     CreatePostHocRecordUseCase,
 )
+from contexts.record.application.create_record_from_schedule import (
+    CreateRecordFromScheduleUseCase,
+)
+from contexts.record.application.delete_action_item import DeleteActionItemUseCase
+from contexts.record.application.save_draft import SaveDraftUseCase
+from contexts.record.application.update_memo import UpdateMemoUseCase
+from contexts.record.domain.action_item_repository import ActionItemRepository
 from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.infrastructure.sqlalchemy_action_item_repository import (
+    SqlAlchemyActionItemRepository,
+)
 from contexts.record.infrastructure.sqlalchemy_record_repository import (
     SqlAlchemyRecordRepository,
 )
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
+
+# ---------------------------------------------------------------------------
+# Repository providers
+# ---------------------------------------------------------------------------
 
 
 def get_record_repository(
@@ -26,6 +46,25 @@ def get_record_repository(
     return SqlAlchemyRecordRepository(session)
 
 
+def get_action_item_repository(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ActionItemRepository:
+    """Provide an ActionItemRepository backed by the current DB session."""
+    return SqlAlchemyActionItemRepository(session)
+
+
+def get_schedule_repository(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ScheduleRepository:
+    """Provide a ScheduleRepository backed by the current DB session."""
+    return SqlAlchemyScheduleRepository(session)
+
+
+# ---------------------------------------------------------------------------
+# Use case providers
+# ---------------------------------------------------------------------------
+
+
 def get_create_post_hoc_record_use_case(
     uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
     record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
@@ -33,6 +72,94 @@ def get_create_post_hoc_record_use_case(
 ) -> CreatePostHocRecordUseCase:
     """Provide a CreatePostHocRecordUseCase with all dependencies injected."""
     return CreatePostHocRecordUseCase(
+        record_repository=record_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_create_record_from_schedule_use_case(
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    schedule_repo: Annotated[ScheduleRepository, Depends(get_schedule_repository)],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> CreateRecordFromScheduleUseCase:
+    """Provide a CreateRecordFromScheduleUseCase with all dependencies injected."""
+    return CreateRecordFromScheduleUseCase(
+        record_repository=record_repo,
+        schedule_repository=schedule_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_update_memo_use_case(
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> UpdateMemoUseCase:
+    """Provide an UpdateMemoUseCase with all dependencies injected."""
+    return UpdateMemoUseCase(
+        record_repository=record_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_confirm_agenda_use_case(
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> ConfirmAgendaUseCase:
+    """Provide a ConfirmAgendaUseCase with all dependencies injected."""
+    return ConfirmAgendaUseCase(
+        record_repository=record_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_add_action_item_use_case(
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    action_item_repo: Annotated[
+        ActionItemRepository, Depends(get_action_item_repository)
+    ],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> AddActionItemUseCase:
+    """Provide an AddActionItemUseCase with all dependencies injected."""
+    return AddActionItemUseCase(
+        record_repository=record_repo,
+        action_item_repository=action_item_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_delete_action_item_use_case(
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    action_item_repo: Annotated[
+        ActionItemRepository, Depends(get_action_item_repository)
+    ],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> DeleteActionItemUseCase:
+    """Provide a DeleteActionItemUseCase with all dependencies injected."""
+    return DeleteActionItemUseCase(
+        record_repository=record_repo,
+        action_item_repository=action_item_repo,
+        unit_of_work=uow,
+        event_dispatcher=event_dispatcher,
+    )
+
+
+def get_save_draft_use_case(
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+    event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
+) -> SaveDraftUseCase:
+    """Provide a SaveDraftUseCase with all dependencies injected."""
+    return SaveDraftUseCase(
         record_repository=record_repo,
         unit_of_work=uow,
         event_dispatcher=event_dispatcher,

--- a/backend/contexts/record/presentation/router.py
+++ b/backend/contexts/record/presentation/router.py
@@ -1,26 +1,74 @@
-"""FastAPI router for the Record context (post-hoc record endpoint)."""
+"""FastAPI router for the Record context."""
 
 from __future__ import annotations
 
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
+from contexts.record.application.add_action_item import (
+    AddActionItemInput,
+    AddActionItemUseCase,
+)
+from contexts.record.application.confirm_agenda import (
+    ConfirmAgendaInput,
+    ConfirmAgendaUseCase,
+)
 from contexts.record.application.create_post_hoc_record import (
     CreatePostHocRecordInput,
     CreatePostHocRecordUseCase,
 )
+from contexts.record.application.create_record_from_schedule import (
+    CreateRecordFromScheduleInput,
+    CreateRecordFromScheduleUseCase,
+)
+from contexts.record.application.delete_action_item import (
+    DeleteActionItemInput,
+    DeleteActionItemUseCase,
+)
+from contexts.record.application.save_draft import (
+    SaveDraftInput,
+    SaveDraftUseCase,
+)
+from contexts.record.application.update_memo import (
+    UpdateMemoInput,
+    UpdateMemoUseCase,
+)
+from contexts.record.domain.memo import Memo
+from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle, RecordId
 from contexts.record.presentation.dependencies import (
+    get_add_action_item_use_case,
+    get_confirm_agenda_use_case,
     get_create_post_hoc_record_use_case,
+    get_create_record_from_schedule_use_case,
+    get_delete_action_item_use_case,
+    get_save_draft_use_case,
+    get_update_memo_use_case,
 )
 from contexts.record.presentation.schemas import (
+    AddActionItemRequest,
+    AddActionItemResponse,
+    ConfirmAgendaResponse,
     CreatePostHocRecordRequest,
     CreatePostHocRecordResponse,
+    CreateRecordFromScheduleRequest,
+    CreateRecordFromScheduleResponse,
+    DeleteActionItemResponse,
+    SaveDraftResponse,
+    UpdateMemoRequest,
+    UpdateMemoResponse,
 )
 from foundation.auth.dependencies import get_current_user_id
 from shared.domain.value_objects import UserId
 
 router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# POST /records/post-hoc
+# ---------------------------------------------------------------------------
 
 
 @router.post(
@@ -44,3 +92,160 @@ async def create_post_hoc_record(
     )
     output = await use_case.execute(input_dto)
     return CreatePostHocRecordResponse(record_id=output.record_id.value)
+
+
+# ---------------------------------------------------------------------------
+# POST /records/from-schedule
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/records/from-schedule",
+    response_model=CreateRecordFromScheduleResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_record_from_schedule(
+    body: CreateRecordFromScheduleRequest,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[
+        CreateRecordFromScheduleUseCase,
+        Depends(get_create_record_from_schedule_use_case),
+    ],
+) -> CreateRecordFromScheduleResponse:
+    """Create a record from a confirmed schedule."""
+    input_dto = CreateRecordFromScheduleInput(
+        schedule_id=ScheduleId(value=body.schedule_id),
+        actor_id=current_user_id,
+        conducted_at=body.conducted_at,
+    )
+    output = await use_case.execute(input_dto)
+    return CreateRecordFromScheduleResponse(record_id=output.record_id.value)
+
+
+# ---------------------------------------------------------------------------
+# PUT /records/{id}/memo
+# ---------------------------------------------------------------------------
+
+
+@router.put(
+    "/records/{record_id}/memo",
+    response_model=UpdateMemoResponse,
+)
+async def update_memo(
+    record_id: UUID,
+    body: UpdateMemoRequest,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[UpdateMemoUseCase, Depends(get_update_memo_use_case)],
+) -> UpdateMemoResponse:
+    """Update the memo of a record."""
+    input_dto = UpdateMemoInput(
+        record_id=RecordId(value=record_id),
+        actor_id=current_user_id,
+        memo=Memo(body.memo),
+    )
+    output = await use_case.execute(input_dto)
+    return UpdateMemoResponse(record_id=output.record_id.value)
+
+
+# ---------------------------------------------------------------------------
+# POST /records/{id}/agendas/{agenda_id}/confirm
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/records/{record_id}/agendas/{agenda_id}/confirm",
+    response_model=ConfirmAgendaResponse,
+)
+async def confirm_agenda(
+    record_id: UUID,
+    agenda_id: UUID,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[ConfirmAgendaUseCase, Depends(get_confirm_agenda_use_case)],
+) -> ConfirmAgendaResponse:
+    """Confirm (check) an agenda item during a 1-on-1."""
+    input_dto = ConfirmAgendaInput(
+        record_id=RecordId(value=record_id),
+        agenda_id=AgendaId(value=agenda_id),
+        actor_id=current_user_id,
+    )
+    output = await use_case.execute(input_dto)
+    return ConfirmAgendaResponse(
+        record_id=output.record_id.value,
+        agenda_id=output.agenda_id.value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /records/{id}/action-items
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/records/{record_id}/action-items",
+    response_model=AddActionItemResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_action_item(
+    record_id: UUID,
+    body: AddActionItemRequest,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[AddActionItemUseCase, Depends(get_add_action_item_use_case)],
+) -> AddActionItemResponse:
+    """Add an action item to a record."""
+    input_dto = AddActionItemInput(
+        record_id=RecordId(value=record_id),
+        actor_id=current_user_id,
+        title=ActionItemTitle(body.title),
+    )
+    output = await use_case.execute(input_dto)
+    return AddActionItemResponse(action_item_id=output.action_item_id.value)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /records/{id}/action-items/{action_item_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete(
+    "/records/{record_id}/action-items/{action_item_id}",
+    response_model=DeleteActionItemResponse,
+)
+async def delete_action_item(
+    record_id: UUID,
+    action_item_id: UUID,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[
+        DeleteActionItemUseCase, Depends(get_delete_action_item_use_case)
+    ],
+) -> DeleteActionItemResponse:
+    """Delete an action item from a record."""
+    input_dto = DeleteActionItemInput(
+        record_id=RecordId(value=record_id),
+        action_item_id=ActionItemId(value=action_item_id),
+        actor_id=current_user_id,
+    )
+    output = await use_case.execute(input_dto)
+    return DeleteActionItemResponse(action_item_id=output.action_item_id.value)
+
+
+# ---------------------------------------------------------------------------
+# POST /records/{id}/save-draft
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/records/{record_id}/save-draft",
+    response_model=SaveDraftResponse,
+)
+async def save_draft(
+    record_id: UUID,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    use_case: Annotated[SaveDraftUseCase, Depends(get_save_draft_use_case)],
+) -> SaveDraftResponse:
+    """Save a record as draft."""
+    input_dto = SaveDraftInput(
+        record_id=RecordId(value=record_id),
+        actor_id=current_user_id,
+    )
+    output = await use_case.execute(input_dto)
+    return SaveDraftResponse(record_id=output.record_id.value)

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -1,6 +1,5 @@
 """Pydantic request/response schemas for the Record context API."""
 
-from datetime import datetime
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel
@@ -19,5 +18,91 @@ class CreatePostHocRecordRequest(BaseModel):
 
 class CreatePostHocRecordResponse(BaseModel):
     """Response body for POST /records/post-hoc."""
+
+    record_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Create record from schedule -- POST /records/from-schedule
+# ---------------------------------------------------------------------------
+
+
+class CreateRecordFromScheduleRequest(BaseModel):
+    """Request body for POST /records/from-schedule."""
+
+    schedule_id: UUID
+    conducted_at: AwareDatetime
+
+
+class CreateRecordFromScheduleResponse(BaseModel):
+    """Response body for POST /records/from-schedule."""
+
+    record_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Update memo -- PUT /records/{id}/memo
+# ---------------------------------------------------------------------------
+
+
+class UpdateMemoRequest(BaseModel):
+    """Request body for PUT /records/{id}/memo."""
+
+    memo: str
+
+
+class UpdateMemoResponse(BaseModel):
+    """Response body for PUT /records/{id}/memo."""
+
+    record_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Confirm agenda -- POST /records/{id}/agendas/{agenda_id}/confirm
+# ---------------------------------------------------------------------------
+
+
+class ConfirmAgendaResponse(BaseModel):
+    """Response body for POST /records/{id}/agendas/{agenda_id}/confirm."""
+
+    record_id: UUID
+    agenda_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Add action item -- POST /records/{id}/action-items
+# ---------------------------------------------------------------------------
+
+
+class AddActionItemRequest(BaseModel):
+    """Request body for POST /records/{id}/action-items."""
+
+    title: str
+
+
+class AddActionItemResponse(BaseModel):
+    """Response body for POST /records/{id}/action-items."""
+
+    action_item_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Delete action item -- DELETE /records/{id}/action-items/{action_item_id}
+# ---------------------------------------------------------------------------
+
+
+class DeleteActionItemResponse(BaseModel):
+    """Response body for DELETE /records/{id}/action-items/{action_item_id}."""
+
+    action_item_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Save draft -- POST /records/{id}/save-draft
+# ---------------------------------------------------------------------------
+
+
+class SaveDraftResponse(BaseModel):
+    """Response body for POST /records/{id}/save-draft."""
 
     record_id: UUID

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -152,6 +152,9 @@ class InMemoryActionItemRepository(ActionItemRepository):
         items.sort(key=lambda item: item.created_at)
         return items
 
+    async def delete(self, action_item_id: ActionItemId) -> None:
+        self._items.pop(action_item_id, None)
+
     @property
     def saved_items(self) -> list[ActionItem]:
         return list(self._items.values())

--- a/backend/tests/contexts/record/presentation/test_router.py
+++ b/backend/tests/contexts/record/presentation/test_router.py
@@ -14,15 +14,64 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from api.exception_handlers import register_exception_handlers
+from contexts.preparation.domain.value_objects import AgendaId, ScheduleId
+from contexts.record.application.add_action_item import (
+    AddActionItemOutput,
+    AddActionItemUseCase,
+)
+from contexts.record.application.add_action_item import (
+    RecordNotFoundError as AddActionItemRecordNotFoundError,
+)
+from contexts.record.application.confirm_agenda import (
+    ConfirmAgendaOutput,
+    ConfirmAgendaUseCase,
+)
+from contexts.record.application.confirm_agenda import (
+    RecordNotFoundError as ConfirmAgendaRecordNotFoundError,
+)
 from contexts.record.application.create_post_hoc_record import (
     CreatePostHocRecordOutput,
     CreatePostHocRecordUseCase,
     SameUserError,
 )
-from contexts.record.domain.exceptions import UnauthorizedOperationError
-from contexts.record.domain.value_objects import RecordId
+from contexts.record.application.create_record_from_schedule import (
+    CreateRecordFromScheduleOutput,
+    CreateRecordFromScheduleUseCase,
+    ScheduleCancelledError,
+    ScheduleNotFoundError,
+)
+from contexts.record.application.delete_action_item import (
+    DeleteActionItemOutput,
+    DeleteActionItemUseCase,
+)
+from contexts.record.application.save_draft import (
+    RecordNotFoundError as SaveDraftRecordNotFoundError,
+)
+from contexts.record.application.save_draft import (
+    SaveDraftOutput,
+    SaveDraftUseCase,
+)
+from contexts.record.application.update_memo import (
+    RecordNotFoundError as UpdateMemoRecordNotFoundError,
+)
+from contexts.record.application.update_memo import (
+    UpdateMemoOutput,
+    UpdateMemoUseCase,
+)
+from contexts.record.domain.exceptions import (
+    AgendaAlreadyConfirmedError,
+    RecordAlreadyPublishedError,
+    UnauthorizedOperationError,
+)
+from contexts.record.domain.value_objects import ActionItemId, RecordId
 from contexts.record.presentation.dependencies import (
+    get_add_action_item_use_case,
+    get_confirm_agenda_use_case,
     get_create_post_hoc_record_use_case,
+    get_create_record_from_schedule_use_case,
+    get_delete_action_item_use_case,
+    get_save_draft_use_case,
+    get_update_memo_use_case,
 )
 from contexts.record.presentation.router import router
 from foundation.auth.dependencies import get_current_user_id
@@ -30,6 +79,10 @@ from shared.domain.value_objects import UserId
 
 ACTOR_ID = UserId(value=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
 COUNTERPART_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+RECORD_ID = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+SCHEDULE_ID = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+AGENDA_ID = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+ACTION_ITEM_ID = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
 
 
 def _build_app() -> FastAPI:
@@ -62,14 +115,12 @@ class TestCreatePostHocRecord:
 
         app = _build_app()
         _override_auth(app)
-        app.dependency_overrides[get_create_post_hoc_record_use_case] = (
-            lambda: mock_use_case
+        app.dependency_overrides[get_create_post_hoc_record_use_case] = lambda: (
+            mock_use_case
         )
 
         transport = ASGITransport(app=app)
-        async with AsyncClient(
-            transport=transport, base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post(
                 "/records/post-hoc",
                 json={
@@ -88,14 +139,12 @@ class TestCreatePostHocRecord:
 
         app = _build_app()
         _override_auth(app)
-        app.dependency_overrides[get_create_post_hoc_record_use_case] = (
-            lambda: mock_use_case
+        app.dependency_overrides[get_create_post_hoc_record_use_case] = lambda: (
+            mock_use_case
         )
 
         transport = ASGITransport(app=app)
-        async with AsyncClient(
-            transport=transport, base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post(
                 "/records/post-hoc",
                 json={
@@ -114,14 +163,12 @@ class TestCreatePostHocRecord:
 
         app = _build_app()
         _override_auth(app)
-        app.dependency_overrides[get_create_post_hoc_record_use_case] = (
-            lambda: mock_use_case
+        app.dependency_overrides[get_create_post_hoc_record_use_case] = lambda: (
+            mock_use_case
         )
 
         transport = ASGITransport(app=app)
-        async with AsyncClient(
-            transport=transport, base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post(
                 "/records/post-hoc",
                 json={
@@ -135,15 +182,561 @@ class TestCreatePostHocRecord:
     async def test_no_auth_returns_401(self) -> None:
         app = _build_app()
         transport = ASGITransport(app=app)
-        async with AsyncClient(
-            transport=transport, base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post(
                 "/records/post-hoc",
                 json={
                     "counterpart_id": str(COUNTERPART_ID),
                     "conducted_at": "2026-03-25T10:00:00Z",
                 },
+            )
+
+        assert response.status_code == 401
+
+
+# -----------------------------------------------------------------------
+# POST /records/from-schedule
+# -----------------------------------------------------------------------
+
+
+class TestCreateRecordFromSchedule:
+    """Tests for POST /records/from-schedule."""
+
+    async def test_success_returns_201(self) -> None:
+        record_id = RecordId.generate()
+        mock_use_case = AsyncMock(spec=CreateRecordFromScheduleUseCase)
+        mock_use_case.execute.return_value = CreateRecordFromScheduleOutput(
+            record_id=record_id,
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_create_record_from_schedule_use_case] = lambda: (
+            mock_use_case
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/records/from-schedule",
+                json={
+                    "schedule_id": str(SCHEDULE_ID),
+                    "conducted_at": "2026-03-25T10:00:00Z",
+                },
+            )
+
+        assert response.status_code == 201
+        assert response.json()["record_id"] == str(record_id.value)
+        mock_use_case.execute.assert_awaited_once()
+
+    async def test_schedule_not_found_returns_404(self) -> None:
+        mock_use_case = AsyncMock(spec=CreateRecordFromScheduleUseCase)
+        mock_use_case.execute.side_effect = ScheduleNotFoundError(
+            ScheduleId(value=SCHEDULE_ID)
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_create_record_from_schedule_use_case] = lambda: (
+            mock_use_case
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/records/from-schedule",
+                json={
+                    "schedule_id": str(SCHEDULE_ID),
+                    "conducted_at": "2026-03-25T10:00:00Z",
+                },
+            )
+
+        assert response.status_code == 404
+
+    async def test_schedule_cancelled_returns_409(self) -> None:
+        mock_use_case = AsyncMock(spec=CreateRecordFromScheduleUseCase)
+        mock_use_case.execute.side_effect = ScheduleCancelledError(
+            ScheduleId(value=SCHEDULE_ID)
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_create_record_from_schedule_use_case] = lambda: (
+            mock_use_case
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/records/from-schedule",
+                json={
+                    "schedule_id": str(SCHEDULE_ID),
+                    "conducted_at": "2026-03-25T10:00:00Z",
+                },
+            )
+
+        assert response.status_code == 409
+
+    async def test_unauthorized_returns_403(self) -> None:
+        mock_use_case = AsyncMock(spec=CreateRecordFromScheduleUseCase)
+        mock_use_case.execute.side_effect = UnauthorizedOperationError(
+            "Only the organizer can create a record."
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_create_record_from_schedule_use_case] = lambda: (
+            mock_use_case
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/records/from-schedule",
+                json={
+                    "schedule_id": str(SCHEDULE_ID),
+                    "conducted_at": "2026-03-25T10:00:00Z",
+                },
+            )
+
+        assert response.status_code == 403
+
+    async def test_no_auth_returns_401(self) -> None:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/records/from-schedule",
+                json={
+                    "schedule_id": str(SCHEDULE_ID),
+                    "conducted_at": "2026-03-25T10:00:00Z",
+                },
+            )
+
+        assert response.status_code == 401
+
+
+# -----------------------------------------------------------------------
+# PUT /records/{id}/memo
+# -----------------------------------------------------------------------
+
+
+class TestUpdateMemo:
+    """Tests for PUT /records/{id}/memo."""
+
+    async def test_success_returns_200(self) -> None:
+        record_id = RecordId(value=RECORD_ID)
+        mock_use_case = AsyncMock(spec=UpdateMemoUseCase)
+        mock_use_case.execute.return_value = UpdateMemoOutput(
+            record_id=record_id,
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_update_memo_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.put(
+                f"/records/{RECORD_ID}/memo",
+                json={"memo": "Some memo content"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["record_id"] == str(RECORD_ID)
+        mock_use_case.execute.assert_awaited_once()
+
+    async def test_record_not_found_returns_404(self) -> None:
+        mock_use_case = AsyncMock(spec=UpdateMemoUseCase)
+        mock_use_case.execute.side_effect = UpdateMemoRecordNotFoundError(
+            RecordId(value=RECORD_ID)
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_update_memo_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.put(
+                f"/records/{RECORD_ID}/memo",
+                json={"memo": "Some memo content"},
+            )
+
+        assert response.status_code == 404
+
+    async def test_unauthorized_returns_403(self) -> None:
+        mock_use_case = AsyncMock(spec=UpdateMemoUseCase)
+        mock_use_case.execute.side_effect = UnauthorizedOperationError(
+            "Only the organizer can update the memo."
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_update_memo_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.put(
+                f"/records/{RECORD_ID}/memo",
+                json={"memo": "Some memo content"},
+            )
+
+        assert response.status_code == 403
+
+    async def test_no_auth_returns_401(self) -> None:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.put(
+                f"/records/{RECORD_ID}/memo",
+                json={"memo": "Some memo content"},
+            )
+
+        assert response.status_code == 401
+
+
+# -----------------------------------------------------------------------
+# POST /records/{id}/agendas/{agenda_id}/confirm
+# -----------------------------------------------------------------------
+
+
+class TestConfirmAgenda:
+    """Tests for POST /records/{id}/agendas/{agenda_id}/confirm."""
+
+    async def test_success_returns_200(self) -> None:
+        record_id = RecordId(value=RECORD_ID)
+        mock_use_case = AsyncMock(spec=ConfirmAgendaUseCase)
+        mock_use_case.execute.return_value = ConfirmAgendaOutput(
+            record_id=record_id,
+            agenda_id=AgendaId(value=AGENDA_ID),
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_confirm_agenda_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/agendas/{AGENDA_ID}/confirm",
+            )
+
+        assert response.status_code == 200
+        assert response.json()["record_id"] == str(RECORD_ID)
+        assert response.json()["agenda_id"] == str(AGENDA_ID)
+        mock_use_case.execute.assert_awaited_once()
+
+    async def test_record_not_found_returns_404(self) -> None:
+        mock_use_case = AsyncMock(spec=ConfirmAgendaUseCase)
+        mock_use_case.execute.side_effect = ConfirmAgendaRecordNotFoundError(
+            RecordId(value=RECORD_ID)
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_confirm_agenda_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/agendas/{AGENDA_ID}/confirm",
+            )
+
+        assert response.status_code == 404
+
+    async def test_agenda_already_confirmed_returns_409(self) -> None:
+        mock_use_case = AsyncMock(spec=ConfirmAgendaUseCase)
+        mock_use_case.execute.side_effect = AgendaAlreadyConfirmedError()
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_confirm_agenda_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/agendas/{AGENDA_ID}/confirm",
+            )
+
+        assert response.status_code == 409
+
+    async def test_unauthorized_returns_403(self) -> None:
+        mock_use_case = AsyncMock(spec=ConfirmAgendaUseCase)
+        mock_use_case.execute.side_effect = UnauthorizedOperationError(
+            "Only participants can confirm agendas."
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_confirm_agenda_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/agendas/{AGENDA_ID}/confirm",
+            )
+
+        assert response.status_code == 403
+
+    async def test_no_auth_returns_401(self) -> None:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/agendas/{AGENDA_ID}/confirm",
+            )
+
+        assert response.status_code == 401
+
+
+# -----------------------------------------------------------------------
+# POST /records/{id}/action-items
+# -----------------------------------------------------------------------
+
+
+class TestAddActionItem:
+    """Tests for POST /records/{id}/action-items."""
+
+    async def test_success_returns_201(self) -> None:
+        action_item_id = ActionItemId(value=ACTION_ITEM_ID)
+        mock_use_case = AsyncMock(spec=AddActionItemUseCase)
+        mock_use_case.execute.return_value = AddActionItemOutput(
+            action_item_id=action_item_id,
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_add_action_item_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/action-items",
+                json={"title": "Follow up on discussion"},
+            )
+
+        assert response.status_code == 201
+        assert response.json()["action_item_id"] == str(ACTION_ITEM_ID)
+        mock_use_case.execute.assert_awaited_once()
+
+    async def test_record_not_found_returns_404(self) -> None:
+        mock_use_case = AsyncMock(spec=AddActionItemUseCase)
+        mock_use_case.execute.side_effect = AddActionItemRecordNotFoundError(
+            RecordId(value=RECORD_ID)
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_add_action_item_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/action-items",
+                json={"title": "Follow up on discussion"},
+            )
+
+        assert response.status_code == 404
+
+    async def test_unauthorized_returns_403(self) -> None:
+        mock_use_case = AsyncMock(spec=AddActionItemUseCase)
+        mock_use_case.execute.side_effect = UnauthorizedOperationError(
+            "Only the organizer can add action items."
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_add_action_item_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/action-items",
+                json={"title": "Follow up on discussion"},
+            )
+
+        assert response.status_code == 403
+
+    async def test_no_auth_returns_401(self) -> None:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/action-items",
+                json={"title": "Follow up on discussion"},
+            )
+
+        assert response.status_code == 401
+
+
+# -----------------------------------------------------------------------
+# DELETE /records/{id}/action-items/{action_item_id}
+# -----------------------------------------------------------------------
+
+
+class TestDeleteActionItem:
+    """Tests for DELETE /records/{id}/action-items/{action_item_id}."""
+
+    async def test_success_returns_200(self) -> None:
+        action_item_id = ActionItemId(value=ACTION_ITEM_ID)
+        mock_use_case = AsyncMock(spec=DeleteActionItemUseCase)
+        mock_use_case.execute.return_value = DeleteActionItemOutput(
+            action_item_id=action_item_id,
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_delete_action_item_use_case] = lambda: (
+            mock_use_case
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.delete(
+                f"/records/{RECORD_ID}/action-items/{ACTION_ITEM_ID}",
+            )
+
+        assert response.status_code == 200
+        assert response.json()["action_item_id"] == str(ACTION_ITEM_ID)
+        mock_use_case.execute.assert_awaited_once()
+
+    async def test_unauthorized_returns_403(self) -> None:
+        mock_use_case = AsyncMock(spec=DeleteActionItemUseCase)
+        mock_use_case.execute.side_effect = UnauthorizedOperationError(
+            "Only the organizer can delete action items."
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_delete_action_item_use_case] = lambda: (
+            mock_use_case
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.delete(
+                f"/records/{RECORD_ID}/action-items/{ACTION_ITEM_ID}",
+            )
+
+        assert response.status_code == 403
+
+    async def test_record_already_published_returns_409(self) -> None:
+        mock_use_case = AsyncMock(spec=DeleteActionItemUseCase)
+        mock_use_case.execute.side_effect = RecordAlreadyPublishedError()
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_delete_action_item_use_case] = lambda: (
+            mock_use_case
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.delete(
+                f"/records/{RECORD_ID}/action-items/{ACTION_ITEM_ID}",
+            )
+
+        assert response.status_code == 409
+
+    async def test_no_auth_returns_401(self) -> None:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.delete(
+                f"/records/{RECORD_ID}/action-items/{ACTION_ITEM_ID}",
+            )
+
+        assert response.status_code == 401
+
+
+# -----------------------------------------------------------------------
+# POST /records/{id}/save-draft
+# -----------------------------------------------------------------------
+
+
+class TestSaveDraft:
+    """Tests for POST /records/{id}/save-draft."""
+
+    async def test_success_returns_200(self) -> None:
+        record_id = RecordId(value=RECORD_ID)
+        mock_use_case = AsyncMock(spec=SaveDraftUseCase)
+        mock_use_case.execute.return_value = SaveDraftOutput(
+            record_id=record_id,
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_save_draft_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/save-draft",
+            )
+
+        assert response.status_code == 200
+        assert response.json()["record_id"] == str(RECORD_ID)
+        mock_use_case.execute.assert_awaited_once()
+
+    async def test_record_not_found_returns_404(self) -> None:
+        mock_use_case = AsyncMock(spec=SaveDraftUseCase)
+        mock_use_case.execute.side_effect = SaveDraftRecordNotFoundError(
+            RecordId(value=RECORD_ID)
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_save_draft_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/save-draft",
+            )
+
+        assert response.status_code == 404
+
+    async def test_unauthorized_returns_403(self) -> None:
+        mock_use_case = AsyncMock(spec=SaveDraftUseCase)
+        mock_use_case.execute.side_effect = UnauthorizedOperationError(
+            "Only the organizer can save a draft."
+        )
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_save_draft_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/save-draft",
+            )
+
+        assert response.status_code == 403
+
+    async def test_record_already_published_returns_409(self) -> None:
+        mock_use_case = AsyncMock(spec=SaveDraftUseCase)
+        mock_use_case.execute.side_effect = RecordAlreadyPublishedError()
+
+        app = _build_app()
+        _override_auth(app)
+        app.dependency_overrides[get_save_draft_use_case] = lambda: mock_use_case
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/save-draft",
+            )
+
+        assert response.status_code == 409
+
+    async def test_no_auth_returns_401(self) -> None:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/records/{RECORD_ID}/save-draft",
             )
 
         assert response.status_code == 401


### PR DESCRIPTION
## 概要
1on1実施・記録画面に必要な6つのAPIエンドポイントを追加。

## エンドポイント
- `POST /records/from-schedule` - スケジュールから記録作成
- `PUT /records/{id}/memo` - メモ更新
- `POST /records/{id}/agendas/{agenda_id}/confirm` - アジェンダ確認
- `POST /records/{id}/action-items` - アクションアイテム追加
- `DELETE /records/{id}/action-items/{action_item_id}` - アクションアイテム削除
- `POST /records/{id}/save-draft` - 下書き保存

## 変更内容
- Router: 6エンドポイント追加
- Dependencies: 6ユースケース + 2リポジトリのDIプロバイダ追加
- Schemas: リクエスト/レスポンスのPydanticモデル追加
- ActionItemRepository に delete メソッド追加

## テスト
- [x] ユニットテスト全パス (856 passed)
- [x] ruff lint / format パス

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)