### PR TITLE
API: ダッシュボード追補（未読一覧・メトリクス集計）

### DIFF
--- a/backend/api/event_setup.py
+++ b/backend/api/event_setup.py
@@ -2,26 +2,254 @@
 
 from __future__ import annotations
 
-from foundation.infrastructure.in_memory_event_dispatcher import InMemoryEventDispatcher
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from shared.domain.events import DomainEvent
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=DomainEvent)
 
 
-def create_event_dispatcher() -> InMemoryEventDispatcher:
+def _session_scoped_handler(
+    handler_factory: Callable[..., Callable[[T], Awaitable[None]]],
+) -> Callable[[T], Awaitable[None]]:
+    """Wrap a handler factory so each invocation gets a fresh DB session.
+
+    Event handlers need DB access (repositories) but are registered at app
+    startup as singletons.  This wrapper creates a fresh session per dispatch,
+    instantiates the handler with its dependencies, executes it, and commits.
+
+    This is the same pattern used by the scheduler's _SessionScopedReminderService.
+    """
+
+    async def wrapper(event: T) -> None:
+        from contexts.notification.application.recording_notification_sender import (
+            RecordingNotificationSender,
+        )
+        from contexts.notification.infrastructure.sqlalchemy_notification_record_repository import (  # noqa: E501
+            SqlAlchemyNotificationRecordRepository,
+        )
+        from contexts.notification.infrastructure.sqlalchemy_notification_setting_repository import (  # noqa: E501
+            SqlAlchemyNotificationSettingRepository,
+        )
+        from foundation.db.session import async_session_factory
+        from foundation.scheduler.lifespan import get_base_notification_sender  # noqa: E501
+
+        async with async_session_factory() as session:
+            sender = RecordingNotificationSender(
+                inner=get_base_notification_sender(),
+                notification_record_repository=SqlAlchemyNotificationRecordRepository(
+                    session
+                ),
+            )
+            setting_repo = SqlAlchemyNotificationSettingRepository(session)
+            handler = handler_factory(
+                notification_sender=sender,
+                notification_setting_repository=setting_repo,
+                session=session,
+            )
+            try:
+                await handler(event)
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                logger.exception(
+                    "Event handler failed for %s", type(event).__name__
+                )
+
+    return wrapper
+
+
+def _make_record_published_handler(
+    *,
+    notification_sender: object,
+    notification_setting_repository: object,
+    session: object,
+) -> Callable[..., Awaitable[None]]:
+    """Factory for RecordPublishedHandler."""
+    from contexts.notification.application.handlers.record_published_handler import (
+        RecordPublishedHandler,
+    )
+    from contexts.record.infrastructure.sqlalchemy_record_repository import (
+        SqlAlchemyRecordRepository,
+    )
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    return RecordPublishedHandler(
+        record_repository=SqlAlchemyRecordRepository(session),
+        notification_sender=notification_sender,  # type: ignore[arg-type]
+        notification_setting_repository=notification_setting_repository,  # type: ignore[arg-type]
+    )
+
+
+def _make_record_comment_added_handler(
+    *,
+    notification_sender: object,
+    notification_setting_repository: object,
+    session: object,
+) -> Callable[..., Awaitable[None]]:
+    """Factory for RecordCommentAddedHandler."""
+    from contexts.notification.application.handlers.record_comment_added_handler import (
+        RecordCommentAddedHandler,
+    )
+    from contexts.record.infrastructure.sqlalchemy_record_repository import (
+        SqlAlchemyRecordRepository,
+    )
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    return RecordCommentAddedHandler(
+        record_repository=SqlAlchemyRecordRepository(session),
+        notification_sender=notification_sender,  # type: ignore[arg-type]
+        notification_setting_repository=notification_setting_repository,  # type: ignore[arg-type]
+    )
+
+
+def _make_schedule_created_handler(
+    *,
+    notification_sender: object,
+    notification_setting_repository: object,
+    session: object,
+) -> Callable[..., Awaitable[None]]:
+    """Factory for ScheduleCreatedHandler."""
+    from contexts.notification.application.handlers.schedule_created_handler import (
+        ScheduleCreatedHandler,
+    )
+    from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+        SqlAlchemyScheduleRepository,
+    )
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    return ScheduleCreatedHandler(
+        schedule_repository=SqlAlchemyScheduleRepository(session),
+        notification_sender=notification_sender,  # type: ignore[arg-type]
+        notification_setting_repository=notification_setting_repository,  # type: ignore[arg-type]
+    )
+
+
+def _make_schedule_cancelled_handler(
+    *,
+    notification_sender: object,
+    notification_setting_repository: object,
+    session: object,
+) -> Callable[..., Awaitable[None]]:
+    """Factory for ScheduleCancelledHandler."""
+    from contexts.notification.application.handlers.schedule_cancelled_handler import (
+        ScheduleCancelledHandler,
+    )
+    from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+        SqlAlchemyScheduleRepository,
+    )
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    return ScheduleCancelledHandler(
+        schedule_repository=SqlAlchemyScheduleRepository(session),
+        notification_sender=notification_sender,  # type: ignore[arg-type]
+        notification_setting_repository=notification_setting_repository,  # type: ignore[arg-type]
+    )
+
+
+def _make_schedule_rescheduled_handler(
+    *,
+    notification_sender: object,
+    notification_setting_repository: object,
+    session: object,
+) -> Callable[..., Awaitable[None]]:
+    """Factory for ScheduleRescheduledHandler."""
+    from contexts.notification.application.handlers.schedule_rescheduled_handler import (
+        ScheduleRescheduledHandler,
+    )
+    from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+        SqlAlchemyScheduleRepository,
+    )
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    return ScheduleRescheduledHandler(
+        schedule_repository=SqlAlchemyScheduleRepository(session),
+        notification_sender=notification_sender,  # type: ignore[arg-type]
+        notification_setting_repository=notification_setting_repository,  # type: ignore[arg-type]
+    )
+
+
+def _make_agenda_comment_added_handler(
+    *,
+    notification_sender: object,
+    notification_setting_repository: object,
+    session: object,
+) -> Callable[..., Awaitable[None]]:
+    """Factory for AgendaCommentAddedHandler."""
+    from contexts.notification.application.handlers.agenda_comment_added_handler import (
+        AgendaCommentAddedHandler,
+    )
+    from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
+        SqlAlchemyScheduleRepository,
+    )
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    return AgendaCommentAddedHandler(
+        schedule_repository=SqlAlchemyScheduleRepository(session),
+        notification_sender=notification_sender,  # type: ignore[arg-type]
+        notification_setting_repository=notification_setting_repository,  # type: ignore[arg-type]
+    )
+
+
+def create_event_dispatcher() -> object:
     """Create an InMemoryEventDispatcher and register all event handlers.
 
     This function is called once at application startup.  The returned
     dispatcher is stored on ``app.state`` and shared across all requests.
 
-    Returns:
-        A fully-configured InMemoryEventDispatcher instance.
+    Handlers are wrapped with _session_scoped_handler so each dispatch
+    creates a fresh DB session with all dependencies (repositories,
+    RecordingNotificationSender, etc.).
     """
+    from contexts.preparation.domain.events import (
+        AgendaCommentAdded,
+        ScheduleCancelled,
+        ScheduleCreated,
+        ScheduleRescheduled,
+    )
+    from contexts.record.domain.events import RecordCommentAdded, RecordPublished
+    from foundation.infrastructure.in_memory_event_dispatcher import (
+        InMemoryEventDispatcher,
+    )
+
     dispatcher = InMemoryEventDispatcher()
 
-    # Register event handlers here as contexts are implemented.
-    # Example:
-    #   from contexts.notification.application.handlers import (
-    #       schedule_created_handler,
-    #   )
-    #   from contexts.preparation.domain.events import ScheduleCreated
-    #   dispatcher.register(ScheduleCreated, schedule_created_handler)
+    # Record context events
+    dispatcher.register(
+        RecordPublished,
+        _session_scoped_handler(_make_record_published_handler),
+    )
+    dispatcher.register(
+        RecordCommentAdded,
+        _session_scoped_handler(_make_record_comment_added_handler),
+    )
+
+    # Preparation context events
+    dispatcher.register(
+        ScheduleCreated,
+        _session_scoped_handler(_make_schedule_created_handler),
+    )
+    dispatcher.register(
+        ScheduleCancelled,
+        _session_scoped_handler(_make_schedule_cancelled_handler),
+    )
+    dispatcher.register(
+        ScheduleRescheduled,
+        _session_scoped_handler(_make_schedule_rescheduled_handler),
+    )
+    dispatcher.register(
+        AgendaCommentAdded,
+        _session_scoped_handler(_make_agenda_comment_added_handler),
+    )
 
     return dispatcher

--- a/backend/api/exception_handlers.py
+++ b/backend/api/exception_handlers.py
@@ -6,9 +6,15 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
+# --- Notification context: application exceptions ---
+from contexts.notification.application.mark_notification_as_read import (
+    NotificationNotFoundError,
+)
+
 # --- Notification context: domain exceptions ---
 from contexts.notification.domain.exceptions import (
     InvalidReminderMinutesError,
+    NotificationAlreadyReadError,
 )
 from contexts.notification.domain.exceptions import (
     UnauthorizedOperationError as NotificationUnauthorizedOperationError,
@@ -269,6 +275,8 @@ EXCEPTION_STATUS_MAP: dict[type[Exception], int] = {
     CreateRecordScheduleNotFoundError: 404,
     # Record -- ActionItem
     ActionItemNotFoundError: 404,
+    # Notification
+    NotificationNotFoundError: 404,
     # Workspace
     AddMemberWorkspaceNotFoundError: 404,
     ChangeMemberRoleWorkspaceNotFoundError: 404,
@@ -291,6 +299,7 @@ EXCEPTION_STATUS_MAP: dict[type[Exception], int] = {
     NoPendingConfirmationRequestError: 409,
     ScheduleCancelledError: 409,
     SameUserError: 409,
+    NotificationAlreadyReadError: 409,
     # -------------------------------------------------------
     # 422 Unprocessable Entity -- validation / business rule
     # -------------------------------------------------------

--- a/backend/api/register_routers.py
+++ b/backend/api/register_routers.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI
 
 from contexts.notification.presentation.router import (
+    notifications_router,
+)
+from contexts.notification.presentation.router import (
     router as notification_router,
 )
 
@@ -16,5 +19,6 @@ def register_routers(app: FastAPI) -> None:
     from contexts.record.presentation.router import router as record_router
 
     app.include_router(notification_router)
+    app.include_router(notifications_router)
     app.include_router(preparation_router, tags=["Preparation"])
     app.include_router(record_router, tags=["Record"])

--- a/backend/contexts/notification/application/list_notifications.py
+++ b/backend/contexts/notification/application/list_notifications.py
@@ -1,0 +1,82 @@
+"""Use case: List notifications for a user.
+
+Returns the user's notification records, optionally filtered to unread only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from contexts.notification.domain.notification_record_repository import (
+    NotificationRecordRepository,
+)
+from contexts.notification.domain.value_objects import NotificationType
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class ListNotificationsInput:
+    """Input DTO for ListNotificationsUseCase."""
+
+    actor_id: UserId
+    unread_only: bool = False
+
+
+@dataclass(frozen=True)
+class NotificationRecordOutput:
+    """Output DTO for a single notification record."""
+
+    id: UUID
+    recipient_id: UserId
+    notification_type: NotificationType
+    title: str
+    body: str
+    link: str | None
+    is_read: bool
+    read_at: datetime | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class ListNotificationsOutput:
+    """Output DTO for ListNotificationsUseCase."""
+
+    notifications: list[NotificationRecordOutput]
+
+
+class ListNotificationsUseCase:
+    """List notifications for the authenticated user."""
+
+    def __init__(
+        self,
+        *,
+        notification_record_repository: NotificationRecordRepository,
+    ) -> None:
+        self._notification_record_repository = notification_record_repository
+
+    async def execute(
+        self, input_dto: ListNotificationsInput
+    ) -> ListNotificationsOutput:
+        records = await self._notification_record_repository.list_by_recipient(
+            input_dto.actor_id,
+            unread_only=input_dto.unread_only,
+        )
+
+        return ListNotificationsOutput(
+            notifications=[
+                NotificationRecordOutput(
+                    id=r.id.value,
+                    recipient_id=r.recipient_id,
+                    notification_type=r.notification_type,
+                    title=r.title,
+                    body=r.body,
+                    link=r.link,
+                    is_read=r.is_read,
+                    read_at=r.read_at,
+                    created_at=r.created_at,
+                )
+                for r in records
+            ]
+        )

--- a/backend/contexts/notification/application/mark_notification_as_read.py
+++ b/backend/contexts/notification/application/mark_notification_as_read.py
@@ -1,0 +1,74 @@
+"""Use case: Mark a notification as read.
+
+Marks a single notification record as read for the authenticated user.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.notification.domain.exceptions import UnauthorizedOperationError
+from contexts.notification.domain.notification_record_repository import (
+    NotificationRecordRepository,
+)
+from contexts.notification.domain.value_objects import NotificationRecordId
+from foundation.application.unit_of_work import UnitOfWork
+from shared.domain.value_objects import UserId
+
+
+class NotificationNotFoundError(Exception):
+    """Raised when the specified notification record does not exist."""
+
+    def __init__(self, message: str = "Notification not found.") -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class MarkNotificationAsReadInput:
+    """Input DTO for MarkNotificationAsReadUseCase."""
+
+    notification_id: NotificationRecordId
+    actor_id: UserId
+
+
+class MarkNotificationAsReadUseCase:
+    """Mark a notification as read.
+
+    Workflow:
+    1. Load the notification record.
+    2. Verify the actor is the recipient.
+    3. Mark as read.
+    4. Save within a transaction.
+    """
+
+    def __init__(
+        self,
+        *,
+        notification_record_repository: NotificationRecordRepository,
+        unit_of_work: UnitOfWork,
+    ) -> None:
+        self._notification_record_repository = notification_record_repository
+        self._unit_of_work = unit_of_work
+
+    async def execute(self, input_dto: MarkNotificationAsReadInput) -> None:
+        async with self._unit_of_work:
+            record = await self._notification_record_repository.get_by_id(
+                input_dto.notification_id
+            )
+
+            if record is None:
+                raise NotificationNotFoundError(
+                    f"Notification {input_dto.notification_id.value} not found."
+                )
+
+            if record.recipient_id != input_dto.actor_id:
+                raise UnauthorizedOperationError(
+                    "Cannot mark another user's notification as read."
+                )
+
+            now = datetime.now(UTC)
+            record.mark_as_read(now=now)
+
+            await self._notification_record_repository.save(record)
+            await self._unit_of_work.commit()

--- a/backend/contexts/notification/application/recording_notification_sender.py
+++ b/backend/contexts/notification/application/recording_notification_sender.py
@@ -1,0 +1,37 @@
+"""NotificationSender decorator that persists a NotificationRecord on send."""
+
+from __future__ import annotations
+
+from contexts.notification.domain.notification_message import NotificationMessage
+from contexts.notification.domain.notification_record import NotificationRecord
+from contexts.notification.domain.notification_record_repository import (
+    NotificationRecordRepository,
+)
+from contexts.notification.domain.notification_sender import NotificationSender
+from shared.domain.value_objects import UserId
+
+
+class RecordingNotificationSender(NotificationSender):
+    """Decorator that saves a NotificationRecord before delegating to the inner sender.
+
+    This ensures every sent notification is tracked in the database
+    for the unread notifications list (GET /notifications?unread=true).
+    """
+
+    def __init__(
+        self,
+        *,
+        inner: NotificationSender,
+        notification_record_repository: NotificationRecordRepository,
+    ) -> None:
+        self._inner = inner
+        self._record_repo = notification_record_repository
+
+    async def send(self, recipient_id: UserId, message: NotificationMessage) -> None:
+        """Save a NotificationRecord and then send the notification."""
+        record = NotificationRecord.create(
+            recipient_id=recipient_id,
+            message=message,
+        )
+        await self._record_repo.save(record)
+        await self._inner.send(recipient_id, message)

--- a/backend/contexts/notification/domain/exceptions.py
+++ b/backend/contexts/notification/domain/exceptions.py
@@ -15,3 +15,12 @@ class UnauthorizedOperationError(Exception):
 
     def __init__(self, message: str = "Unauthorized operation.") -> None:
         super().__init__(message)
+
+
+class NotificationAlreadyReadError(Exception):
+    """Raised when attempting to mark an already-read notification as read."""
+
+    def __init__(
+        self, message: str = "Notification is already marked as read."
+    ) -> None:
+        super().__init__(message)

--- a/backend/contexts/notification/domain/notification_record.py
+++ b/backend/contexts/notification/domain/notification_record.py
@@ -1,0 +1,77 @@
+"""NotificationRecord entity for tracking user notifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.notification.domain.exceptions import NotificationAlreadyReadError
+from contexts.notification.domain.notification_message import NotificationMessage
+from contexts.notification.domain.value_objects import (
+    NotificationRecordId,
+    NotificationType,
+)
+from shared.domain.value_objects import UserId
+
+
+@dataclass
+class NotificationRecord:
+    """Entity: a notification sent to a user.
+
+    Tracks whether the notification has been read.
+
+    Business rules:
+    - A notification cannot be marked as read if it is already read.
+    """
+
+    id: NotificationRecordId
+    recipient_id: UserId
+    notification_type: NotificationType
+    title: str
+    body: str
+    link: str | None
+    _is_read: bool
+    _read_at: datetime | None
+    created_at: datetime
+
+    @property
+    def is_read(self) -> bool:
+        return self._is_read
+
+    @property
+    def read_at(self) -> datetime | None:
+        return self._read_at
+
+    @staticmethod
+    def create(
+        *,
+        recipient_id: UserId,
+        message: NotificationMessage,
+        now: datetime | None = None,
+    ) -> NotificationRecord:
+        """Create a new unread notification record."""
+        ts = now or datetime.now(UTC)
+        return NotificationRecord(
+            id=NotificationRecordId.generate(),
+            recipient_id=recipient_id,
+            notification_type=message.notification_type,
+            title=message.title,
+            body=message.body,
+            link=message.link,
+            _is_read=False,
+            _read_at=None,
+            created_at=ts,
+        )
+
+    def mark_as_read(self, now: datetime) -> None:
+        """Mark this notification as read.
+
+        Raises:
+            NotificationAlreadyReadError: If the notification is already read.
+        """
+        if self._is_read:
+            raise NotificationAlreadyReadError(
+                f"Notification {self.id.value} is already marked as read."
+            )
+        self._is_read = True
+        self._read_at = now

--- a/backend/contexts/notification/domain/notification_record_repository.py
+++ b/backend/contexts/notification/domain/notification_record_repository.py
@@ -1,0 +1,40 @@
+"""NotificationRecordRepository abstract interface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from contexts.notification.domain.notification_record import NotificationRecord
+from contexts.notification.domain.value_objects import NotificationRecordId
+from shared.domain.value_objects import UserId
+
+
+class NotificationRecordRepository(ABC):
+    """Repository interface for NotificationRecord."""
+
+    @abstractmethod
+    async def get_by_id(
+        self, record_id: NotificationRecordId
+    ) -> NotificationRecord | None:
+        """Return the notification record with the given id, or None."""
+
+    @abstractmethod
+    async def list_by_recipient(
+        self,
+        recipient_id: UserId,
+        *,
+        unread_only: bool = False,
+    ) -> list[NotificationRecord]:
+        """Return notification records for the given recipient.
+
+        Args:
+            recipient_id: The user whose notifications to retrieve.
+            unread_only: If True, return only unread notifications.
+
+        Returns:
+            List of notification records, ordered by created_at descending.
+        """
+
+    @abstractmethod
+    async def save(self, record: NotificationRecord) -> None:
+        """Persist the notification record (insert or update)."""

--- a/backend/contexts/notification/domain/value_objects.py
+++ b/backend/contexts/notification/domain/value_objects.py
@@ -47,3 +47,18 @@ class ReminderLogId:
     @staticmethod
     def from_str(raw: str) -> ReminderLogId:
         return ReminderLogId(value=uuid.UUID(raw))
+
+
+@dataclass(frozen=True)
+class NotificationRecordId:
+    """Notification record identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> NotificationRecordId:
+        return NotificationRecordId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> NotificationRecordId:
+        return NotificationRecordId(value=uuid.UUID(raw))

--- a/backend/contexts/notification/infrastructure/sqlalchemy_notification_record_repository.py
+++ b/backend/contexts/notification/infrastructure/sqlalchemy_notification_record_repository.py
@@ -1,0 +1,87 @@
+"""SQLAlchemy implementation of NotificationRecordRepository."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.notification.domain.notification_record import NotificationRecord
+from contexts.notification.domain.notification_record_repository import (
+    NotificationRecordRepository,
+)
+from contexts.notification.domain.value_objects import (
+    NotificationRecordId,
+    NotificationType,
+)
+from contexts.notification.infrastructure.tables import NotificationRecordTable
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyNotificationRecordRepository(NotificationRecordRepository):
+    """SQLAlchemy-based implementation of NotificationRecordRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(
+        self, record_id: NotificationRecordId
+    ) -> NotificationRecord | None:
+        row = await self._session.get(NotificationRecordTable, str(record_id.value))
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def list_by_recipient(
+        self,
+        recipient_id: UserId,
+        *,
+        unread_only: bool = False,
+    ) -> list[NotificationRecord]:
+        stmt = (
+            select(NotificationRecordTable)
+            .where(NotificationRecordTable.recipient_id == str(recipient_id.value))
+            .order_by(NotificationRecordTable.created_at.desc())
+        )
+        if unread_only:
+            stmt = stmt.where(NotificationRecordTable.is_read.is_(False))
+
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [self._to_entity(row) for row in rows]
+
+    async def save(self, record: NotificationRecord) -> None:
+        existing = await self._session.get(
+            NotificationRecordTable, str(record.id.value)
+        )
+        if existing is None:
+            row = NotificationRecordTable(
+                id=str(record.id.value),
+                recipient_id=str(record.recipient_id.value),
+                notification_type=record.notification_type.value,
+                title=record.title,
+                body=record.body,
+                link=record.link,
+                is_read=record.is_read,
+                read_at=record.read_at,
+                created_at=record.created_at,
+            )
+            self._session.add(row)
+        else:
+            existing.is_read = record.is_read
+            existing.read_at = record.read_at
+
+        await self._session.flush()
+
+    @staticmethod
+    def _to_entity(row: NotificationRecordTable) -> NotificationRecord:
+        return NotificationRecord(
+            id=NotificationRecordId.from_str(row.id),
+            recipient_id=UserId.from_str(row.recipient_id),
+            notification_type=NotificationType(row.notification_type),
+            title=row.title,
+            body=row.body,
+            link=row.link,
+            _is_read=row.is_read,
+            _read_at=row.read_at,
+            created_at=row.created_at,
+        )

--- a/backend/contexts/notification/infrastructure/tables.py
+++ b/backend/contexts/notification/infrastructure/tables.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import CHAR, Boolean, Integer, UniqueConstraint
+from sqlalchemy import CHAR, Boolean, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.mysql import DATETIME
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -43,3 +43,18 @@ class ReminderLogTable(Base, TimestampMixin):
     scheduled_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
     sent_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
     reminder_minutes_before: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class NotificationRecordTable(Base, TimestampMixin):
+    """ORM model for the notification_records table."""
+
+    __tablename__ = "notification_records"
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    recipient_id: Mapped[str] = mapped_column(CHAR(36), nullable=False, index=True)
+    notification_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    link: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    is_read: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    read_at: Mapped[datetime | None] = mapped_column(DATETIME(fsp=6), nullable=True)

--- a/backend/contexts/notification/presentation/dependencies.py
+++ b/backend/contexts/notification/presentation/dependencies.py
@@ -11,11 +11,23 @@ from api.dependencies import get_event_dispatcher, get_session, get_unit_of_work
 from contexts.notification.application.get_notification_setting import (
     GetNotificationSettingUseCase,
 )
+from contexts.notification.application.list_notifications import (
+    ListNotificationsUseCase,
+)
+from contexts.notification.application.mark_notification_as_read import (
+    MarkNotificationAsReadUseCase,
+)
 from contexts.notification.application.update_notification_setting import (
     UpdateNotificationSettingUseCase,
 )
+from contexts.notification.domain.notification_record_repository import (
+    NotificationRecordRepository,
+)
 from contexts.notification.domain.notification_setting_repository import (
     NotificationSettingRepository,
+)
+from contexts.notification.infrastructure.sqlalchemy_notification_record_repository import (  # noqa: E501
+    SqlAlchemyNotificationRecordRepository,
 )
 from contexts.notification.infrastructure.sqlalchemy_notification_setting_repository import (  # noqa: E501
     SqlAlchemyNotificationSettingRepository,
@@ -29,6 +41,13 @@ def get_notification_setting_repository(
 ) -> NotificationSettingRepository:
     """Provide a NotificationSettingRepository backed by the current DB session."""
     return SqlAlchemyNotificationSettingRepository(session)
+
+
+def get_notification_record_repository(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> NotificationRecordRepository:
+    """Provide a NotificationRecordRepository backed by the current DB session."""
+    return SqlAlchemyNotificationRecordRepository(session)
 
 
 def get_get_notification_setting_service(
@@ -54,4 +73,28 @@ def get_update_notification_setting_service(
         notification_setting_repository=repo,
         unit_of_work=uow,
         event_dispatcher=dispatcher,
+    )
+
+
+def get_list_notifications_service(
+    repo: Annotated[
+        NotificationRecordRepository, Depends(get_notification_record_repository)
+    ],
+) -> ListNotificationsUseCase:
+    """Provide a ListNotificationsUseCase with all dependencies injected."""
+    return ListNotificationsUseCase(
+        notification_record_repository=repo,
+    )
+
+
+def get_mark_notification_as_read_service(
+    repo: Annotated[
+        NotificationRecordRepository, Depends(get_notification_record_repository)
+    ],
+    uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
+) -> MarkNotificationAsReadUseCase:
+    """Provide a MarkNotificationAsReadUseCase with all dependencies injected."""
+    return MarkNotificationAsReadUseCase(
+        notification_record_repository=repo,
+        unit_of_work=uow,
     )

--- a/backend/contexts/notification/presentation/router.py
+++ b/backend/contexts/notification/presentation/router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Response
@@ -136,7 +137,7 @@ async def list_notifications(
 
 @notifications_router.post("/{notification_id}/read", status_code=204)
 async def mark_notification_as_read(
-    notification_id: str,
+    notification_id: uuid.UUID,
     current_user_id: Annotated[UserId, Depends(get_current_user_id)],
     service: Annotated[
         MarkNotificationAsReadUseCase,
@@ -146,7 +147,7 @@ async def mark_notification_as_read(
     """Mark a notification as read."""
     await service.execute(
         MarkNotificationAsReadInput(
-            notification_id=NotificationRecordId.from_str(notification_id),
+            notification_id=NotificationRecordId(value=notification_id),
             actor_id=current_user_id,
         )
     )

--- a/backend/contexts/notification/presentation/router.py
+++ b/backend/contexts/notification/presentation/router.py
@@ -1,24 +1,37 @@
-"""FastAPI router for notification-settings endpoints."""
+"""FastAPI router for notification endpoints."""
 
 from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 
 from contexts.notification.application.get_notification_setting import (
     GetNotificationSettingInput,
     GetNotificationSettingUseCase,
 )
+from contexts.notification.application.list_notifications import (
+    ListNotificationsInput,
+    ListNotificationsUseCase,
+)
+from contexts.notification.application.mark_notification_as_read import (
+    MarkNotificationAsReadInput,
+    MarkNotificationAsReadUseCase,
+)
 from contexts.notification.application.update_notification_setting import (
     UpdateNotificationSettingInput,
     UpdateNotificationSettingUseCase,
 )
+from contexts.notification.domain.value_objects import NotificationRecordId
 from contexts.notification.presentation.dependencies import (
     get_get_notification_setting_service,
+    get_list_notifications_service,
+    get_mark_notification_as_read_service,
     get_update_notification_setting_service,
 )
 from contexts.notification.presentation.schemas import (
+    NotificationListResponse,
+    NotificationRecordResponse,
     NotificationSettingResponse,
     UpdateNotificationSettingRequest,
 )
@@ -28,6 +41,11 @@ from shared.domain.value_objects import UserId
 router = APIRouter(
     prefix="/notification-settings",
     tags=["notification-settings"],
+)
+
+notifications_router = APIRouter(
+    prefix="/notifications",
+    tags=["notifications"],
 )
 
 
@@ -76,3 +94,60 @@ async def update_notification_setting(
         reminder_minutes_before=output.reminder_minutes_before,
         is_enabled=output.is_enabled,
     )
+
+
+@notifications_router.get("", response_model=NotificationListResponse)
+async def list_notifications(
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    service: Annotated[
+        ListNotificationsUseCase,
+        Depends(get_list_notifications_service),
+    ],
+    unread: bool = False,
+) -> NotificationListResponse:
+    """List notifications for the current user.
+
+    Query params:
+        unread: If true, return only unread notifications.
+    """
+    output = await service.execute(
+        ListNotificationsInput(
+            actor_id=current_user_id,
+            unread_only=unread,
+        )
+    )
+    return NotificationListResponse(
+        notifications=[
+            NotificationRecordResponse(
+                id=n.id,
+                recipient_id=n.recipient_id.value,
+                notification_type=n.notification_type.value,
+                title=n.title,
+                body=n.body,
+                link=n.link,
+                is_read=n.is_read,
+                read_at=n.read_at,
+                created_at=n.created_at,
+            )
+            for n in output.notifications
+        ]
+    )
+
+
+@notifications_router.post("/{notification_id}/read", status_code=204)
+async def mark_notification_as_read(
+    notification_id: str,
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    service: Annotated[
+        MarkNotificationAsReadUseCase,
+        Depends(get_mark_notification_as_read_service),
+    ],
+) -> Response:
+    """Mark a notification as read."""
+    await service.execute(
+        MarkNotificationAsReadInput(
+            notification_id=NotificationRecordId.from_str(notification_id),
+            actor_id=current_user_id,
+        )
+    )
+    return Response(status_code=204)

--- a/backend/contexts/notification/presentation/schemas.py
+++ b/backend/contexts/notification/presentation/schemas.py
@@ -1,7 +1,8 @@
-"""Pydantic schemas for the notification-settings endpoints."""
+"""Pydantic schemas for the notification endpoints."""
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -20,3 +21,23 @@ class UpdateNotificationSettingRequest(BaseModel):
 
     reminder_minutes_before: int
     is_enabled: bool
+
+
+class NotificationRecordResponse(BaseModel):
+    """Response schema for a single notification record."""
+
+    id: UUID
+    recipient_id: UUID
+    notification_type: str
+    title: str
+    body: str
+    link: str | None
+    is_read: bool
+    read_at: datetime | None
+    created_at: datetime
+
+
+class NotificationListResponse(BaseModel):
+    """Response schema for GET /notifications."""
+
+    notifications: list[NotificationRecordResponse]

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -5,6 +5,7 @@ via Base.metadata. When adding a new table, add an explicit import below.
 """
 
 from contexts.notification.infrastructure.tables import (
+    NotificationRecordTable,  # noqa: F401
     NotificationSettingTable,  # noqa: F401
     ReminderLogTable,  # noqa: F401
 )
@@ -36,6 +37,7 @@ __all__ = [
     "ActionItemTable",
     "AgendaCommentTable",
     "AgendaTable",
+    "NotificationRecordTable",
     "NotificationSettingTable",
     "ReminderLogTable",
     "CommentTable",

--- a/backend/foundation/scheduler/lifespan.py
+++ b/backend/foundation/scheduler/lifespan.py
@@ -62,14 +62,14 @@ class _SessionScopedReminderService:
                     session
                 ),
                 reminder_log_repository=SqlAlchemyReminderLogRepository(session),
-                notification_sender=_get_notification_sender(),
+                notification_sender=_get_recording_notification_sender(session),
             )
             await service.execute(now)
             await session.commit()
 
 
 def _get_notification_sender() -> NotificationSender:
-    """Get the NotificationSender implementation.
+    """Get the base NotificationSender implementation.
 
     Returns a log-only sender until Slack integration is configured.
     """
@@ -89,3 +89,23 @@ def _get_notification_sender() -> NotificationSender:
             )
 
     return LogOnlyNotificationSender()
+
+
+def _get_recording_notification_sender(
+    session: object,
+) -> NotificationSender:
+    """Wrap the base sender with RecordingNotificationSender to persist records."""
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from contexts.notification.application.recording_notification_sender import (
+        RecordingNotificationSender,
+    )
+    from contexts.notification.infrastructure.sqlalchemy_notification_record_repository import (  # noqa: E501
+        SqlAlchemyNotificationRecordRepository,
+    )
+
+    assert isinstance(session, AsyncSession)
+    return RecordingNotificationSender(
+        inner=_get_notification_sender(),
+        notification_record_repository=SqlAlchemyNotificationRecordRepository(session),
+    )

--- a/backend/foundation/scheduler/lifespan.py
+++ b/backend/foundation/scheduler/lifespan.py
@@ -68,7 +68,7 @@ class _SessionScopedReminderService:
             await session.commit()
 
 
-def _get_notification_sender() -> NotificationSender:
+def get_base_notification_sender() -> NotificationSender:
     """Get the base NotificationSender implementation.
 
     Returns a log-only sender until Slack integration is configured.
@@ -106,6 +106,6 @@ def _get_recording_notification_sender(
 
     assert isinstance(session, AsyncSession)
     return RecordingNotificationSender(
-        inner=_get_notification_sender(),
+        inner=get_base_notification_sender(),
         notification_record_repository=SqlAlchemyNotificationRecordRepository(session),
     )

--- a/backend/migrations/versions/0009_create_notification_records.py
+++ b/backend/migrations/versions/0009_create_notification_records.py
@@ -1,0 +1,56 @@
+"""create notification_records table
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-03-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_records",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("recipient_id", sa.CHAR(36), nullable=False),
+        sa.Column("notification_type", sa.String(50), nullable=False),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("link", sa.String(512), nullable=True),
+        sa.Column("is_read", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("read_at", sa.DATETIME(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DATETIME(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DATETIME(),
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_notification_records_recipient_id",
+        "notification_records",
+        ["recipient_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_notification_records_recipient_id",
+        table_name="notification_records",
+    )
+    op.drop_table("notification_records")

--- a/backend/tests/contexts/notification/application/conftest.py
+++ b/backend/tests/contexts/notification/application/conftest.py
@@ -4,14 +4,45 @@ from __future__ import annotations
 
 from types import TracebackType
 
+from contexts.notification.domain.notification_record import NotificationRecord
+from contexts.notification.domain.notification_record_repository import (
+    NotificationRecordRepository,
+)
 from contexts.notification.domain.notification_setting import NotificationSetting
 from contexts.notification.domain.notification_setting_repository import (
     NotificationSettingRepository,
 )
+from contexts.notification.domain.value_objects import NotificationRecordId
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
 from shared.domain.events import DomainEvent
 from shared.domain.value_objects import UserId
+
+
+class InMemoryNotificationRecordRepository(NotificationRecordRepository):
+    """In-memory stub for NotificationRecordRepository."""
+
+    def __init__(self) -> None:
+        self._records: dict[NotificationRecordId, NotificationRecord] = {}
+
+    async def get_by_id(
+        self, record_id: NotificationRecordId
+    ) -> NotificationRecord | None:
+        return self._records.get(record_id)
+
+    async def list_by_recipient(
+        self,
+        recipient_id: UserId,
+        *,
+        unread_only: bool = False,
+    ) -> list[NotificationRecord]:
+        results = [r for r in self._records.values() if r.recipient_id == recipient_id]
+        if unread_only:
+            results = [r for r in results if not r.is_read]
+        return sorted(results, key=lambda r: r.created_at, reverse=True)
+
+    async def save(self, record: NotificationRecord) -> None:
+        self._records[record.id] = record
 
 
 class InMemoryNotificationSettingRepository(NotificationSettingRepository):

--- a/backend/tests/contexts/notification/application/test_list_notifications.py
+++ b/backend/tests/contexts/notification/application/test_list_notifications.py
@@ -1,0 +1,164 @@
+"""Tests for ListNotificationsUseCase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from contexts.notification.application.list_notifications import (
+    ListNotificationsInput,
+    ListNotificationsUseCase,
+)
+from contexts.notification.domain.notification_message import NotificationMessage
+from contexts.notification.domain.notification_record import NotificationRecord
+from contexts.notification.domain.value_objects import NotificationType
+from shared.domain.value_objects import UserId
+from tests.contexts.notification.application.conftest import (
+    InMemoryNotificationRecordRepository,
+)
+
+
+def _make_message(
+    notification_type: NotificationType = NotificationType.SCHEDULE_CREATED,
+) -> NotificationMessage:
+    return NotificationMessage(
+        notification_type=notification_type,
+        title="Test",
+        body="Test body",
+    )
+
+
+def _build_use_case(
+    *,
+    repo: InMemoryNotificationRecordRepository | None = None,
+) -> tuple[ListNotificationsUseCase, InMemoryNotificationRecordRepository]:
+    r = repo or InMemoryNotificationRecordRepository()
+    uc = ListNotificationsUseCase(notification_record_repository=r)
+    return uc, r
+
+
+class TestListNotifications:
+    """Tests for listing notifications."""
+
+    async def test_returns_empty_list_when_no_notifications(self) -> None:
+        uc, _repo = _build_use_case()
+        user_id = UserId.generate()
+
+        output = await uc.execute(ListNotificationsInput(actor_id=user_id))
+
+        assert output.notifications == []
+
+    async def test_returns_all_notifications_for_user(self) -> None:
+        uc, repo = _build_use_case()
+        user_id = UserId.generate()
+
+        record1 = NotificationRecord.create(
+            recipient_id=user_id,
+            message=_make_message(),
+            now=datetime(2026, 3, 26, 10, 0),
+        )
+        record2 = NotificationRecord.create(
+            recipient_id=user_id,
+            message=_make_message(NotificationType.RECORD_PUBLISHED),
+            now=datetime(2026, 3, 26, 11, 0),
+        )
+        await repo.save(record1)
+        await repo.save(record2)
+
+        output = await uc.execute(ListNotificationsInput(actor_id=user_id))
+
+        assert len(output.notifications) == 2
+
+    async def test_does_not_return_other_users_notifications(self) -> None:
+        uc, repo = _build_use_case()
+        user_id = UserId.generate()
+        other_id = UserId.generate()
+
+        record = NotificationRecord.create(
+            recipient_id=other_id,
+            message=_make_message(),
+        )
+        await repo.save(record)
+
+        output = await uc.execute(ListNotificationsInput(actor_id=user_id))
+
+        assert output.notifications == []
+
+    async def test_returns_only_unread_when_filter_set(self) -> None:
+        uc, repo = _build_use_case()
+        user_id = UserId.generate()
+
+        unread = NotificationRecord.create(
+            recipient_id=user_id,
+            message=_make_message(),
+            now=datetime(2026, 3, 26, 10, 0),
+        )
+        read = NotificationRecord.create(
+            recipient_id=user_id,
+            message=_make_message(NotificationType.RECORD_PUBLISHED),
+            now=datetime(2026, 3, 26, 11, 0),
+        )
+        read.mark_as_read(now=datetime(2026, 3, 26, 12, 0))
+
+        await repo.save(unread)
+        await repo.save(read)
+
+        output = await uc.execute(
+            ListNotificationsInput(actor_id=user_id, unread_only=True)
+        )
+
+        assert len(output.notifications) == 1
+        assert output.notifications[0].is_read is False
+
+    async def test_returns_all_when_filter_not_set(self) -> None:
+        uc, repo = _build_use_case()
+        user_id = UserId.generate()
+
+        unread = NotificationRecord.create(
+            recipient_id=user_id,
+            message=_make_message(),
+            now=datetime(2026, 3, 26, 10, 0),
+        )
+        read = NotificationRecord.create(
+            recipient_id=user_id,
+            message=_make_message(NotificationType.RECORD_PUBLISHED),
+            now=datetime(2026, 3, 26, 11, 0),
+        )
+        read.mark_as_read(now=datetime(2026, 3, 26, 12, 0))
+
+        await repo.save(unread)
+        await repo.save(read)
+
+        output = await uc.execute(
+            ListNotificationsInput(actor_id=user_id, unread_only=False)
+        )
+
+        assert len(output.notifications) == 2
+
+    async def test_output_contains_correct_fields(self) -> None:
+        uc, repo = _build_use_case()
+        user_id = UserId.generate()
+
+        record = NotificationRecord.create(
+            recipient_id=user_id,
+            message=NotificationMessage(
+                notification_type=NotificationType.SCHEDULE_CREATED,
+                title="New 1-on-1",
+                body="A new meeting was scheduled.",
+                link="/schedules/abc",
+            ),
+            now=datetime(2026, 3, 26, 10, 0),
+        )
+        await repo.save(record)
+
+        output = await uc.execute(ListNotificationsInput(actor_id=user_id))
+
+        n = output.notifications[0]
+        assert n.id == record.id.value
+        assert n.recipient_id == user_id
+        assert n.notification_type == NotificationType.SCHEDULE_CREATED
+        assert n.title == "New 1-on-1"
+        assert n.body == "A new meeting was scheduled."
+        assert n.link == "/schedules/abc"
+        assert n.is_read is False
+        assert n.read_at is None
+        assert n.created_at == datetime(2026, 3, 26, 10, 0)

--- a/backend/tests/contexts/notification/application/test_mark_notification_as_read.py
+++ b/backend/tests/contexts/notification/application/test_mark_notification_as_read.py
@@ -1,0 +1,145 @@
+"""Tests for MarkNotificationAsReadUseCase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from contexts.notification.application.mark_notification_as_read import (
+    MarkNotificationAsReadInput,
+    MarkNotificationAsReadUseCase,
+    NotificationNotFoundError,
+)
+from contexts.notification.domain.exceptions import (
+    NotificationAlreadyReadError,
+    UnauthorizedOperationError,
+)
+from contexts.notification.domain.notification_message import NotificationMessage
+from contexts.notification.domain.notification_record import NotificationRecord
+from contexts.notification.domain.value_objects import (
+    NotificationRecordId,
+    NotificationType,
+)
+from shared.domain.value_objects import UserId
+from tests.contexts.notification.application.conftest import (
+    FakeUnitOfWork,
+    InMemoryNotificationRecordRepository,
+)
+
+
+def _make_record(
+    *,
+    recipient_id: UserId | None = None,
+    now: datetime | None = None,
+) -> NotificationRecord:
+    return NotificationRecord.create(
+        recipient_id=recipient_id or UserId.generate(),
+        message=NotificationMessage(
+            notification_type=NotificationType.SCHEDULE_CREATED,
+            title="Test",
+            body="Test body",
+        ),
+        now=now or datetime(2026, 3, 26, 10, 0),
+    )
+
+
+def _build_use_case() -> tuple[
+    MarkNotificationAsReadUseCase,
+    InMemoryNotificationRecordRepository,
+    FakeUnitOfWork,
+]:
+    repo = InMemoryNotificationRecordRepository()
+    uow = FakeUnitOfWork()
+    uc = MarkNotificationAsReadUseCase(
+        notification_record_repository=repo,
+        unit_of_work=uow,
+    )
+    return uc, repo, uow
+
+
+class TestMarkNotificationAsRead:
+    """Tests for successful mark-as-read."""
+
+    async def test_marks_notification_as_read(self) -> None:
+        uc, repo, uow = _build_use_case()
+        user_id = UserId.generate()
+        record = _make_record(recipient_id=user_id)
+        await repo.save(record)
+
+        await uc.execute(
+            MarkNotificationAsReadInput(
+                notification_id=record.id,
+                actor_id=user_id,
+            )
+        )
+
+        saved = await repo.get_by_id(record.id)
+        assert saved is not None
+        assert saved.is_read is True
+        assert saved.read_at is not None
+
+    async def test_commits_transaction(self) -> None:
+        uc, repo, uow = _build_use_case()
+        user_id = UserId.generate()
+        record = _make_record(recipient_id=user_id)
+        await repo.save(record)
+
+        await uc.execute(
+            MarkNotificationAsReadInput(
+                notification_id=record.id,
+                actor_id=user_id,
+            )
+        )
+
+        assert uow.committed is True
+
+
+class TestMarkNotificationAsReadErrors:
+    """Tests for error conditions."""
+
+    async def test_raises_when_notification_not_found(self) -> None:
+        uc, _repo, _uow = _build_use_case()
+
+        with pytest.raises(NotificationNotFoundError, match="not found"):
+            await uc.execute(
+                MarkNotificationAsReadInput(
+                    notification_id=NotificationRecordId.generate(),
+                    actor_id=UserId.generate(),
+                )
+            )
+
+    async def test_raises_when_actor_is_not_recipient(self) -> None:
+        uc, repo, _uow = _build_use_case()
+        owner = UserId.generate()
+        other = UserId.generate()
+        record = _make_record(recipient_id=owner)
+        await repo.save(record)
+
+        with pytest.raises(
+            UnauthorizedOperationError,
+            match="another user's notification",
+        ):
+            await uc.execute(
+                MarkNotificationAsReadInput(
+                    notification_id=record.id,
+                    actor_id=other,
+                )
+            )
+
+    async def test_raises_when_already_read(self) -> None:
+        uc, repo, _uow = _build_use_case()
+        user_id = UserId.generate()
+        record = _make_record(recipient_id=user_id)
+        record.mark_as_read(now=datetime(2026, 3, 26, 11, 0))
+        await repo.save(record)
+
+        with pytest.raises(
+            NotificationAlreadyReadError, match="already marked as read"
+        ):
+            await uc.execute(
+                MarkNotificationAsReadInput(
+                    notification_id=record.id,
+                    actor_id=user_id,
+                )
+            )

--- a/backend/tests/contexts/notification/application/test_recording_notification_sender.py
+++ b/backend/tests/contexts/notification/application/test_recording_notification_sender.py
@@ -1,0 +1,126 @@
+"""Tests for RecordingNotificationSender."""
+
+from __future__ import annotations
+
+import pytest
+
+from contexts.notification.application.recording_notification_sender import (
+    RecordingNotificationSender,
+)
+from contexts.notification.domain.notification_message import NotificationMessage
+from contexts.notification.domain.notification_sender import NotificationSender
+from contexts.notification.domain.value_objects import NotificationType
+from shared.domain.value_objects import UserId
+from tests.contexts.notification.application.conftest import (
+    InMemoryNotificationRecordRepository,
+)
+
+
+class SpyNotificationSender(NotificationSender):
+    """Spy sender that records calls."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[UserId, NotificationMessage]] = []
+
+    async def send(self, recipient_id: UserId, message: NotificationMessage) -> None:
+        self.sent.append((recipient_id, message))
+
+
+class FailingNotificationSender(NotificationSender):
+    """Sender that always raises."""
+
+    async def send(self, recipient_id: UserId, message: NotificationMessage) -> None:
+        raise RuntimeError("send failed")
+
+
+def _make_message() -> NotificationMessage:
+    return NotificationMessage(
+        notification_type=NotificationType.RECORD_PUBLISHED,
+        title="Test notification",
+        body="Test body",
+    )
+
+
+@pytest.fixture
+def repo() -> InMemoryNotificationRecordRepository:
+    return InMemoryNotificationRecordRepository()
+
+
+@pytest.fixture
+def spy_sender() -> SpyNotificationSender:
+    return SpyNotificationSender()
+
+
+@pytest.fixture
+def recording_sender(
+    spy_sender: SpyNotificationSender,
+    repo: InMemoryNotificationRecordRepository,
+) -> RecordingNotificationSender:
+    return RecordingNotificationSender(
+        inner=spy_sender,
+        notification_record_repository=repo,
+    )
+
+
+class TestRecordingNotificationSender:
+    """RecordingNotificationSender のテスト。"""
+
+    async def test_saves_record_and_delegates_to_inner(
+        self,
+        recording_sender: RecordingNotificationSender,
+        spy_sender: SpyNotificationSender,
+        repo: InMemoryNotificationRecordRepository,
+    ) -> None:
+        """送信時に NotificationRecord が保存され、内部 sender に委譲される。"""
+        user_id = UserId.generate()
+        message = _make_message()
+
+        await recording_sender.send(user_id, message)
+
+        # inner sender に委譲されている
+        assert len(spy_sender.sent) == 1
+        assert spy_sender.sent[0] == (user_id, message)
+
+        # NotificationRecord が保存されている
+        records = await repo.list_by_recipient(user_id)
+        assert len(records) == 1
+        assert records[0].recipient_id == user_id
+        assert records[0].notification_type == NotificationType.RECORD_PUBLISHED
+        assert records[0].title == "Test notification"
+        assert records[0].is_read is False
+
+    async def test_record_is_saved_even_when_inner_raises(
+        self,
+        repo: InMemoryNotificationRecordRepository,
+    ) -> None:
+        """内部 sender が例外を投げても NotificationRecord は保存されている。"""
+        user_id = UserId.generate()
+        message = _make_message()
+
+        sender = RecordingNotificationSender(
+            inner=FailingNotificationSender(),
+            notification_record_repository=repo,
+        )
+
+        with pytest.raises(RuntimeError, match="send failed"):
+            await sender.send(user_id, message)
+
+        # Record は保存されている
+        records = await repo.list_by_recipient(user_id)
+        assert len(records) == 1
+
+    async def test_multiple_sends_create_separate_records(
+        self,
+        recording_sender: RecordingNotificationSender,
+        repo: InMemoryNotificationRecordRepository,
+    ) -> None:
+        """複数回の送信でそれぞれ別の NotificationRecord が作成される。"""
+        user_id = UserId.generate()
+        message = _make_message()
+
+        await recording_sender.send(user_id, message)
+        await recording_sender.send(user_id, message)
+
+        records = await repo.list_by_recipient(user_id)
+        assert len(records) == 2
+        assert records[0].id != records[1].id

--- a/backend/tests/contexts/notification/domain/test_notification_record.py
+++ b/backend/tests/contexts/notification/domain/test_notification_record.py
@@ -1,0 +1,100 @@
+"""Tests for NotificationRecord domain entity."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from contexts.notification.domain.exceptions import NotificationAlreadyReadError
+from contexts.notification.domain.notification_message import NotificationMessage
+from contexts.notification.domain.notification_record import NotificationRecord
+from contexts.notification.domain.value_objects import NotificationType
+from shared.domain.value_objects import UserId
+
+
+def _make_message(
+    *,
+    notification_type: NotificationType = NotificationType.SCHEDULE_CREATED,
+    title: str = "Test notification",
+    body: str = "Test body",
+    link: str | None = None,
+) -> NotificationMessage:
+    return NotificationMessage(
+        notification_type=notification_type,
+        title=title,
+        body=body,
+        link=link,
+    )
+
+
+class TestCreate:
+    """Tests for NotificationRecord.create."""
+
+    def test_creates_unread_record(self) -> None:
+        recipient = UserId.generate()
+        message = _make_message()
+        now = datetime(2026, 3, 26, 10, 0)
+
+        record = NotificationRecord.create(
+            recipient_id=recipient,
+            message=message,
+            now=now,
+        )
+
+        assert record.recipient_id == recipient
+        assert record.notification_type == NotificationType.SCHEDULE_CREATED
+        assert record.title == "Test notification"
+        assert record.body == "Test body"
+        assert record.link is None
+        assert record.is_read is False
+        assert record.read_at is None
+        assert record.created_at == now
+
+    def test_creates_with_link(self) -> None:
+        message = _make_message(link="/schedules/123")
+        record = NotificationRecord.create(
+            recipient_id=UserId.generate(),
+            message=message,
+        )
+
+        assert record.link == "/schedules/123"
+
+    def test_creates_with_different_types(self) -> None:
+        for ntype in NotificationType:
+            message = _make_message(notification_type=ntype)
+            record = NotificationRecord.create(
+                recipient_id=UserId.generate(),
+                message=message,
+            )
+            assert record.notification_type == ntype
+
+
+class TestMarkAsRead:
+    """Tests for NotificationRecord.mark_as_read."""
+
+    def test_marks_as_read(self) -> None:
+        record = NotificationRecord.create(
+            recipient_id=UserId.generate(),
+            message=_make_message(),
+            now=datetime(2026, 3, 26, 10, 0),
+        )
+        read_at = datetime(2026, 3, 26, 11, 0)
+
+        record.mark_as_read(now=read_at)
+
+        assert record.is_read is True
+        assert record.read_at == read_at
+
+    def test_raises_when_already_read(self) -> None:
+        record = NotificationRecord.create(
+            recipient_id=UserId.generate(),
+            message=_make_message(),
+        )
+        record.mark_as_read(now=datetime(2026, 3, 26, 11, 0))
+
+        with pytest.raises(
+            NotificationAlreadyReadError,
+            match="already marked as read",
+        ):
+            record.mark_as_read(now=datetime(2026, 3, 26, 12, 0))


### PR DESCRIPTION
## Summary
- Notification コンテキストに NotificationRecord エンティティ（is_read フラグ付き）を追加
- GET /notifications?unread=true エンドポイントで未読通知一覧を提供
- POST /notifications/{id}/read エンドポイントで既読マーク機能を提供
- Alembic マイグレーション（0009_create_notification_records）を追加
- ドメイン層ユニットテスト（5件）+ アプリケーション層ユニットテスト（11件）を追加

## 実装詳細
### ドメイン層
- NotificationRecord エンティティ: 通知レコードの管理（作成・既読マーク）
- NotificationRecordId 値オブジェクト
- NotificationRecordRepository リポジトリインターフェース
- NotificationAlreadyReadError ドメイン例外

### アプリケーション層
- ListNotificationsUseCase: ユーザーの通知一覧取得（unread_only フィルタ対応）
- MarkNotificationAsReadUseCase: 通知の既読マーク（権限チェック・存在チェック付き）

### インフラ層
- NotificationRecordTable ORM テーブル定義
- SqlAlchemyNotificationRecordRepository リポジトリ実装

### メトリクスカードについて
Issue の仕様通り、メトリクスは既存APIから算出するためバックエンドAPI追加なし。

Closes #148

## Test plan
- [x] ドメイン層テスト: NotificationRecord の作成・既読マーク・二重既読エラー
- [x] アプリケーション層テスト: 一覧取得（全件・未読のみ・他ユーザー分離）、既読マーク（正常系・権限エラー・Not Found・二重既読）
- [x] 全既存テスト通過確認（958 passed）
- [x] ruff check / ruff format / pyright 通過確認