### PR TITLE
fix: 設定画面から繰り返しUIを除去

### DIFF
--- a/frontend/src/features/scheduling/components/CounterpartScheduleBlock.tsx
+++ b/frontend/src/features/scheduling/components/CounterpartScheduleBlock.tsx
@@ -7,8 +7,6 @@ export interface CounterpartScheduleData {
   startDate: string;
   startTime: string;
   durationMinutes: number;
-  recurrenceType: string;
-  recurrenceDayOfWeek: string;
 }
 
 interface CounterpartScheduleBlockProps {
@@ -23,21 +21,6 @@ const DURATION_OPTIONS = [
   { value: 90, label: "90分" },
 ];
 
-const RECURRENCE_OPTIONS = [
-  { value: "weekly", label: "毎週" },
-  { value: "biweekly", label: "隔週" },
-  { value: "monthly", label: "毎月" },
-];
-
-const DAY_OF_WEEK_OPTIONS = [
-  { value: "monday", label: "月曜" },
-  { value: "tuesday", label: "火曜" },
-  { value: "wednesday", label: "水曜" },
-  { value: "thursday", label: "木曜" },
-  { value: "friday", label: "金曜" },
-  { value: "saturday", label: "土曜" },
-  { value: "sunday", label: "日曜" },
-];
 
 export function CounterpartScheduleBlock({
   data,
@@ -103,37 +86,6 @@ export function CounterpartScheduleBlock({
               </option>
             ))}
           </select>
-        </div>
-        <div className="flex min-w-[200px] flex-[2] flex-col gap-1">
-          <label className="text-xs text-muted-foreground">繰り返し</label>
-          <div className="flex gap-2">
-            <select
-              className="h-8 flex-1 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
-              value={data.recurrenceType}
-              onChange={(e) =>
-                handleFieldChange("recurrenceType", e.target.value)
-              }
-            >
-              {RECURRENCE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-            <select
-              className="h-8 flex-1 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
-              value={data.recurrenceDayOfWeek}
-              onChange={(e) =>
-                handleFieldChange("recurrenceDayOfWeek", e.target.value)
-              }
-            >
-              {DAY_OF_WEEK_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/features/scheduling/components/ScheduleGroupForm.tsx
+++ b/frontend/src/features/scheduling/components/ScheduleGroupForm.tsx
@@ -55,8 +55,6 @@ export function ScheduleGroupForm({
         startDate: getDefaultDate(),
         startTime: "10:00",
         durationMinutes: 60,
-        recurrenceType: "weekly",
-        recurrenceDayOfWeek: "friday",
       },
     ]);
     setNewCounterpartId("");


### PR DESCRIPTION
## Summary
- `CounterpartScheduleBlock` から `recurrenceType`/`recurrenceDayOfWeek` フィールドとUIを除去
- `ScheduleGroupForm` のデフォルト値から繰り返し関連を除去

## 背景
PR #154 で繰り返し（毎週/隔週/毎月）のUIが含まれていたが、API側（#128）に対応するフィールドがなく、繰り返しはスコープ外。Issue #143 の仕様に「繰り返し」が含まれていたことが原因。

## 削除内容
- `recurrenceType` / `recurrenceDayOfWeek` プロパティ（型定義・UI・デフォルト値）
- `RECURRENCE_OPTIONS` / `DAY_OF_WEEK_OPTIONS` 定数

🤖 Generated with [Claude Code](https://claude.com/claude-code)