### PR TITLE
Record: latest_activity_at の追加

### DIFF
--- a/backend/contexts/record/domain/record.py
+++ b/backend/contexts/record/domain/record.py
@@ -15,6 +15,7 @@ from contexts.record.domain.events import (
 from contexts.record.domain.exceptions import (
     AgendaAlreadyConfirmedError,
     RecordAlreadyPublishedError,
+    RecordNotPublishedError,
     UnauthorizedOperationError,
 )
 from contexts.record.domain.memo import Memo
@@ -213,6 +214,7 @@ class Record:
 
     def notify_comment_added(self, now: datetime) -> None:
         """Update content timestamp when a comment is added."""
+        self._assert_published()
         self._latest_activity_at = now
         self._updated_at = now
 
@@ -249,3 +251,7 @@ class Record:
     def _assert_draft(self) -> None:
         if self._status != RecordStatus.DRAFT:
             raise RecordAlreadyPublishedError("Record is already published.")
+
+    def _assert_published(self) -> None:
+        if self._status != RecordStatus.PUBLISHED:
+            raise RecordNotPublishedError("Record is not published.")

--- a/backend/contexts/record/domain/record.py
+++ b/backend/contexts/record/domain/record.py
@@ -53,6 +53,7 @@ class Record:
     conducted_at: datetime
     created_at: datetime
     _updated_at: datetime
+    _latest_activity_at: datetime | None
     _events: list[_RecordEvent] = field(default_factory=list, repr=False)
 
     @property
@@ -74,6 +75,10 @@ class Record:
     @property
     def updated_at(self) -> datetime:
         return self._updated_at
+
+    @property
+    def latest_activity_at(self) -> datetime | None:
+        return self._latest_activity_at
 
     @staticmethod
     def create(
@@ -99,6 +104,7 @@ class Record:
             conducted_at=conducted_at,
             created_at=ts,
             _updated_at=ts,
+            _latest_activity_at=None,
         )
         record._events.append(
             RecordCreated(
@@ -169,6 +175,7 @@ class Record:
         self._assert_draft()
         self._status = RecordStatus.PUBLISHED
         self._updated_at = now
+        self._latest_activity_at = now
         self._events.append(
             RecordPublished(
                 occurred_at=now,
@@ -203,6 +210,11 @@ class Record:
                 viewer_ids=tuple(deduplicated),
             )
         )
+
+    def notify_comment_added(self, now: datetime) -> None:
+        """Update content timestamp when a comment is added."""
+        self._latest_activity_at = now
+        self._updated_at = now
 
     def is_visible_to(self, user_id: UserId) -> bool:
         """Check if the record is visible to a given user.

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -161,6 +161,7 @@ class SqlAlchemyRecordRepository(RecordRepository):
             memo=entity.memo.value,
             status=entity.status.value,
             conducted_at=entity.conducted_at,
+            latest_activity_at=entity.latest_activity_at,
             created_at=entity.created_at,
             updated_at=entity.updated_at,
         )
@@ -193,6 +194,7 @@ class SqlAlchemyRecordRepository(RecordRepository):
         existing.schedule_id = (
             str(entity.schedule_id.value) if entity.schedule_id else None
         )
+        existing.latest_activity_at = entity.latest_activity_at
         existing.updated_at = entity.updated_at
 
         # Replace viewers: delete all, then re-insert
@@ -245,4 +247,5 @@ class SqlAlchemyRecordRepository(RecordRepository):
             conducted_at=row.conducted_at,
             created_at=row.created_at,
             _updated_at=row.updated_at,
+            _latest_activity_at=row.latest_activity_at,
         )

--- a/backend/contexts/record/infrastructure/tables.py
+++ b/backend/contexts/record/infrastructure/tables.py
@@ -27,6 +27,9 @@ class RecordTable(Base, TimestampMixin):
     memo: Mapped[str] = mapped_column(TEXT, nullable=False)
     status: Mapped[str] = mapped_column(VARCHAR(20), nullable=False)
     conducted_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)
+    latest_activity_at: Mapped[datetime | None] = mapped_column(
+        DATETIME(fsp=6), nullable=True
+    )
 
     viewers: Mapped[list["RecordViewerTable"]] = relationship(
         back_populates="record",

--- a/backend/migrations/versions/0010_add_latest_activity_at_to_records.py
+++ b/backend/migrations/versions/0010_add_latest_activity_at_to_records.py
@@ -1,0 +1,54 @@
+"""add latest_activity_at to records
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-03-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010"
+down_revision: str | None = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add nullable column
+    op.add_column(
+        "records",
+        sa.Column("latest_activity_at", sa.DATETIME(fsp=6), nullable=True),
+    )
+
+    # Backfill: set latest_activity_at for published records using updated_at
+    op.execute(
+        """
+        UPDATE records
+        SET latest_activity_at = updated_at
+        WHERE status = 'published' AND latest_activity_at IS NULL
+        """
+    )
+
+    # Backfill: override with latest comment created_at if newer
+    op.execute(
+        """
+        UPDATE records r
+        SET latest_activity_at = (
+            SELECT MAX(c.created_at)
+            FROM comments c
+            WHERE c.record_id = r.id
+        )
+        WHERE r.status = 'published'
+          AND EXISTS (
+            SELECT 1 FROM comments c
+            WHERE c.record_id = r.id AND c.created_at > r.latest_activity_at
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("records", "latest_activity_at")

--- a/backend/tests/contexts/record/domain/test_record.py
+++ b/backend/tests/contexts/record/domain/test_record.py
@@ -14,6 +14,7 @@ from contexts.record.domain.events import (
 from contexts.record.domain.exceptions import (
     AgendaAlreadyConfirmedError,
     RecordAlreadyPublishedError,
+    RecordNotPublishedError,
     UnauthorizedOperationError,
 )
 from contexts.record.domain.memo import Memo
@@ -240,6 +241,13 @@ class TestRecordNotifyCommentAdded:
         record.notify_comment_added(now=comment_time)
 
         assert record.updated_at == comment_time
+
+    def test_rejects_comment_on_draft_record(self) -> None:
+        """DRAFT status record should reject notify_comment_added."""
+        record = _make_record()
+
+        with pytest.raises(RecordNotPublishedError):
+            record.notify_comment_added(now=datetime(2026, 3, 20, 12, 0))
 
     def test_successive_comments_update_latest_activity_at(self) -> None:
         organizer = UserId.generate()

--- a/backend/tests/contexts/record/domain/test_record.py
+++ b/backend/tests/contexts/record/domain/test_record.py
@@ -45,6 +45,10 @@ class TestRecordCreate:
         assert record.status == RecordStatus.DRAFT
         assert record.memo == Memo("")
 
+    def test_latest_activity_at_is_none_on_creation(self) -> None:
+        record = _make_record()
+        assert record.latest_activity_at is None
+
     def test_creates_without_schedule_id(self) -> None:
         record = _make_record()
         assert record.schedule_id is None
@@ -175,6 +179,15 @@ class TestRecordPublish:
         assert record.status == RecordStatus.PUBLISHED
         assert record.updated_at == now
 
+    def test_publish_sets_latest_activity_at(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        now = datetime(2026, 3, 20, 11, 0)
+
+        record.publish(actor_id=organizer, now=now)
+
+        assert record.latest_activity_at == now
+
     def test_non_organizer_cannot_publish(self) -> None:
         organizer = UserId.generate()
         other = UserId.generate()
@@ -203,6 +216,43 @@ class TestRecordPublish:
         pub_events = [e for e in events if isinstance(e, RecordPublished)]
         assert len(pub_events) == 1
         assert pub_events[0].occurred_at == now
+
+
+class TestRecordNotifyCommentAdded:
+    def test_updates_latest_activity_at(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        publish_time = datetime(2026, 3, 20, 11, 0)
+        record.publish(actor_id=organizer, now=publish_time)
+
+        comment_time = datetime(2026, 3, 20, 12, 0)
+        record.notify_comment_added(now=comment_time)
+
+        assert record.latest_activity_at == comment_time
+
+    def test_updates_updated_at(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        publish_time = datetime(2026, 3, 20, 11, 0)
+        record.publish(actor_id=organizer, now=publish_time)
+
+        comment_time = datetime(2026, 3, 20, 12, 0)
+        record.notify_comment_added(now=comment_time)
+
+        assert record.updated_at == comment_time
+
+    def test_successive_comments_update_latest_activity_at(self) -> None:
+        organizer = UserId.generate()
+        record = _make_record(organizer_id=organizer)
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 11, 0))
+
+        first_comment = datetime(2026, 3, 20, 12, 0)
+        record.notify_comment_added(now=first_comment)
+
+        second_comment = datetime(2026, 3, 20, 13, 0)
+        record.notify_comment_added(now=second_comment)
+
+        assert record.latest_activity_at == second_comment
 
 
 class TestRecordConfirmAgenda:


### PR DESCRIPTION
## 概要

未読管理のため、Record エンティティに `latest_activity_at` を追加する。

Closes #157

## 変更内容

### ドメインモデル (`backend/contexts/record/domain/record.py`)
- `_latest_activity_at: datetime | None` フィールドを追加（公開前は `None`）
- `latest_activity_at` プロパティを追加
- `publish()` メソッド内で `_latest_activity_at = now` を設定
- `notify_comment_added(now)` メソッドを追加（コメント追加時に `latest_activity_at` と `updated_at` を更新）

### インフラ層
- `RecordTable` に `latest_activity_at` カラム（`DATETIME(6) NULL`）を追加
- リポジトリの `_insert` / `_update` / `_to_entity` を更新

### マイグレーション (`0010_add_latest_activity_at_to_records.py`)
- `records` テーブルに `latest_activity_at` カラムを追加
- 既存の公開済み Record に対して `updated_at` ベースでバックフィル
- コメントがある場合は最新コメントの `created_at` で上書き

### テスト
- `publish` 時に `latest_activity_at` が設定されることを確認
- `notify_comment_added` で `latest_activity_at` が更新されることを確認
- 連続コメントで最新の値に更新されることを確認
- 作成時は `latest_activity_at` が `None` であることを確認

## 設計根拠

`docs/design/unread_management.md` セクション 4, 8 に基づく実装。

## テスト計画

- [x] ドメイン層ユニットテスト（DB不要）: 全46テスト通過
- [x] 全非integrationテスト: 966テスト通過
- [x] ruff check / ruff format: 対象ファイルすべてパス
- [x] pyright: 対象ファイルすべてパス
