### PR TITLE
Record: ReadStatus ドメインモデル・リポジトリ実装

### DIFF
--- a/backend/contexts/record/domain/read_status.py
+++ b/backend/contexts/record/domain/read_status.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from contexts.record.domain.value_objects import ReadStatusId, RecordId
+from shared.domain.value_objects import UserId
+
+
+@dataclass
+class ReadStatus:
+    """Tracks when a user last viewed a Record.
+
+    Not an aggregate root. Used to determine unread status by comparing
+    last_viewed_at against Record.latest_activity_at.
+    """
+
+    id: ReadStatusId
+    record_id: RecordId
+    user_id: UserId
+    _last_viewed_at: datetime
+
+    @property
+    def last_viewed_at(self) -> datetime:
+        return self._last_viewed_at
+
+    @staticmethod
+    def create(
+        *,
+        record_id: RecordId,
+        user_id: UserId,
+        now: datetime | None = None,
+    ) -> ReadStatus:
+        """Create a new ReadStatus with last_viewed_at set to now."""
+        ts = now or datetime.now(UTC)
+        return ReadStatus(
+            id=ReadStatusId.generate(),
+            record_id=record_id,
+            user_id=user_id,
+            _last_viewed_at=ts,
+        )
+
+    def mark_viewed(self, now: datetime) -> None:
+        """Update the last viewed timestamp."""
+        self._last_viewed_at = now

--- a/backend/contexts/record/domain/read_status_repository.py
+++ b/backend/contexts/record/domain/read_status_repository.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from contexts.record.domain.read_status import ReadStatus
+from contexts.record.domain.value_objects import ReadStatusId, RecordId
+from foundation.domain.base_repository import BaseRepository
+from shared.domain.value_objects import UserId
+
+
+class ReadStatusRepository(BaseRepository[ReadStatus, ReadStatusId]):
+    """Repository interface for ReadStatus entities."""
+
+    # get_by_id + save inherited from BaseRepository
+
+    @abstractmethod
+    async def find_by_record_and_user(
+        self, record_id: RecordId, user_id: UserId
+    ) -> ReadStatus | None:
+        """Find the ReadStatus for a specific Record and user combination."""
+
+    @abstractmethod
+    async def delete_by_record_and_user(
+        self, record_id: RecordId, user_id: UserId
+    ) -> None:
+        """Delete the ReadStatus for a specific Record and user.
+
+        Used when a Viewer is removed from a Record.
+        No-op if no matching ReadStatus exists.
+        """

--- a/backend/contexts/record/domain/value_objects.py
+++ b/backend/contexts/record/domain/value_objects.py
@@ -86,6 +86,21 @@ class CommentId:
         return CommentId(value=uuid.UUID(raw))
 
 
+@dataclass(frozen=True)
+class ReadStatusId:
+    """ReadStatus identifier (UUID-based value object)."""
+
+    value: uuid.UUID
+
+    @staticmethod
+    def generate() -> ReadStatusId:
+        return ReadStatusId(value=uuid.uuid4())
+
+    @staticmethod
+    def from_str(raw: str) -> ReadStatusId:
+        return ReadStatusId(value=uuid.UUID(raw))
+
+
 class RecordStatus(Enum):
     """Record status: Draft -> Published (one-way transition)."""
 

--- a/backend/contexts/record/infrastructure/sqlalchemy_read_status_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_read_status_repository.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from sqlalchemy import and_, delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.record.domain.read_status import ReadStatus
+from contexts.record.domain.read_status_repository import ReadStatusRepository
+from contexts.record.domain.value_objects import ReadStatusId, RecordId
+from contexts.record.infrastructure.tables import ReadStatusTable
+from shared.domain.value_objects import UserId
+
+
+class SqlAlchemyReadStatusRepository(ReadStatusRepository):
+    """SQLAlchemy-based implementation of ReadStatusRepository."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_id(self, entity_id: ReadStatusId) -> ReadStatus | None:
+        stmt = select(ReadStatusTable).where(ReadStatusTable.id == str(entity_id.value))
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def save(self, entity: ReadStatus) -> None:
+        existing = await self._session.get(ReadStatusTable, str(entity.id.value))
+        if existing is None:
+            await self._insert(entity)
+        else:
+            self._update(entity, existing)
+            await self._session.flush()
+
+    async def find_by_record_and_user(
+        self, record_id: RecordId, user_id: UserId
+    ) -> ReadStatus | None:
+        stmt = select(ReadStatusTable).where(
+            and_(
+                ReadStatusTable.record_id == str(record_id.value),
+                ReadStatusTable.user_id == str(user_id.value),
+            )
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_entity(row)
+
+    async def delete_by_record_and_user(
+        self, record_id: RecordId, user_id: UserId
+    ) -> None:
+        stmt = delete(ReadStatusTable).where(
+            and_(
+                ReadStatusTable.record_id == str(record_id.value),
+                ReadStatusTable.user_id == str(user_id.value),
+            )
+        )
+        await self._session.execute(stmt)
+        await self._session.flush()
+
+    async def _insert(self, entity: ReadStatus) -> None:
+        row = ReadStatusTable(
+            id=str(entity.id.value),
+            record_id=str(entity.record_id.value),
+            user_id=str(entity.user_id.value),
+            last_viewed_at=entity.last_viewed_at,
+        )
+        self._session.add(row)
+        await self._session.flush()
+
+    @staticmethod
+    def _update(entity: ReadStatus, existing: ReadStatusTable) -> None:
+        existing.last_viewed_at = entity.last_viewed_at
+
+    @staticmethod
+    def _to_entity(row: ReadStatusTable) -> ReadStatus:
+        return ReadStatus(
+            id=ReadStatusId.from_str(row.id),
+            record_id=RecordId.from_str(row.record_id),
+            user_id=UserId.from_str(row.user_id),
+            _last_viewed_at=row.last_viewed_at,
+        )

--- a/backend/contexts/record/infrastructure/tables.py
+++ b/backend/contexts/record/infrastructure/tables.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import CHAR, TEXT, VARCHAR, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy import CHAR, TEXT, VARCHAR, Boolean, ForeignKey, Index, UniqueConstraint
 from sqlalchemy.dialects.mysql import DATETIME
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -136,3 +136,38 @@ class ActionItemTable(Base, TimestampMixin):
     )
     title: Mapped[str] = mapped_column(VARCHAR(200), nullable=False)
     is_completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+
+class ReadStatusTable(Base, TimestampMixin):
+    """ORM model for the record_read_statuses table."""
+
+    __tablename__ = "record_read_statuses"
+    __table_args__ = (
+        UniqueConstraint(
+            "record_id",
+            "user_id",
+            name="uq_record_read_statuses_record_id_user_id",
+        ),
+        Index("idx_record_read_statuses_user_id", "user_id"),
+    )
+
+    id: Mapped[str] = mapped_column(CHAR(36), primary_key=True)
+    record_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "records.id",
+            ondelete="CASCADE",
+            name="fk_record_read_statuses_record_id",
+        ),
+        nullable=False,
+    )
+    user_id: Mapped[str] = mapped_column(
+        CHAR(36),
+        ForeignKey(
+            "users.id",
+            ondelete="CASCADE",
+            name="fk_record_read_statuses_user_id",
+        ),
+        nullable=False,
+    )
+    last_viewed_at: Mapped[datetime] = mapped_column(DATETIME(fsp=6), nullable=False)

--- a/backend/foundation/db/models.py
+++ b/backend/foundation/db/models.py
@@ -23,6 +23,7 @@ from contexts.preparation.infrastructure.tables import (
 from contexts.record.infrastructure.tables import (
     ActionItemTable,  # noqa: F401
     CommentTable,  # noqa: F401
+    ReadStatusTable,  # noqa: F401
     RecordConfirmedAgendaTable,  # noqa: F401
     RecordTable,  # noqa: F401
     RecordViewerTable,  # noqa: F401
@@ -36,6 +37,7 @@ from shared.infrastructure.tables import UserTable  # noqa: F401
 __all__ = [
     "ActionItemTable",
     "AgendaCommentTable",
+    "ReadStatusTable",
     "AgendaTable",
     "NotificationRecordTable",
     "NotificationSettingTable",

--- a/backend/migrations/versions/0011_create_record_read_statuses.py
+++ b/backend/migrations/versions/0011_create_record_read_statuses.py
@@ -1,0 +1,61 @@
+"""create record_read_statuses table
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-03-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import DATETIME
+
+# revision identifiers, used by Alembic.
+revision: str = "0011"
+down_revision: str | None = "0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "record_read_statuses",
+        sa.Column("id", sa.CHAR(36), nullable=False),
+        sa.Column("record_id", sa.CHAR(36), nullable=False),
+        sa.Column("user_id", sa.CHAR(36), nullable=False),
+        sa.Column("last_viewed_at", DATETIME(fsp=6), nullable=False),
+        sa.Column("created_at", DATETIME(fsp=6), nullable=False),
+        sa.Column("updated_at", DATETIME(fsp=6), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["record_id"],
+            ["records.id"],
+            name="fk_record_read_statuses_record_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_record_read_statuses_user_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "record_id",
+            "user_id",
+            name="uq_record_read_statuses_record_id_user_id",
+        ),
+    )
+    op.create_index(
+        "idx_record_read_statuses_user_id",
+        "record_read_statuses",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_record_read_statuses_user_id",
+        table_name="record_read_statuses",
+    )
+    op.drop_table("record_read_statuses")

--- a/backend/tests/contexts/record/domain/test_read_status.py
+++ b/backend/tests/contexts/record/domain/test_read_status.py
@@ -1,0 +1,75 @@
+from datetime import UTC, datetime
+
+from contexts.record.domain.read_status import ReadStatus
+from contexts.record.domain.value_objects import ReadStatusId, RecordId
+from shared.domain.value_objects import UserId
+
+
+class TestCreate:
+    """ReadStatus.create() factory method."""
+
+    def test_create_sets_fields(self) -> None:
+        record_id = RecordId.generate()
+        user_id = UserId.generate()
+        now = datetime(2026, 3, 20, 10, 0, tzinfo=UTC)
+
+        rs = ReadStatus.create(record_id=record_id, user_id=user_id, now=now)
+
+        assert rs.record_id == record_id
+        assert rs.user_id == user_id
+        assert rs.last_viewed_at == now
+        assert isinstance(rs.id, ReadStatusId)
+
+    def test_create_generates_unique_ids(self) -> None:
+        record_id = RecordId.generate()
+        user_id = UserId.generate()
+
+        rs1 = ReadStatus.create(record_id=record_id, user_id=user_id)
+        rs2 = ReadStatus.create(record_id=record_id, user_id=user_id)
+
+        assert rs1.id != rs2.id
+
+    def test_create_defaults_to_utc_now(self) -> None:
+        before = datetime.now(UTC)
+        rs = ReadStatus.create(
+            record_id=RecordId.generate(),
+            user_id=UserId.generate(),
+        )
+        after = datetime.now(UTC)
+
+        assert before <= rs.last_viewed_at <= after
+
+
+class TestMarkViewed:
+    """ReadStatus.mark_viewed() updates last_viewed_at."""
+
+    def test_mark_viewed_updates_timestamp(self) -> None:
+        initial_time = datetime(2026, 3, 20, 10, 0, tzinfo=UTC)
+        new_time = datetime(2026, 3, 20, 15, 0, tzinfo=UTC)
+
+        rs = ReadStatus.create(
+            record_id=RecordId.generate(),
+            user_id=UserId.generate(),
+            now=initial_time,
+        )
+        assert rs.last_viewed_at == initial_time
+
+        rs.mark_viewed(now=new_time)
+
+        assert rs.last_viewed_at == new_time
+
+    def test_mark_viewed_can_be_called_multiple_times(self) -> None:
+        rs = ReadStatus.create(
+            record_id=RecordId.generate(),
+            user_id=UserId.generate(),
+            now=datetime(2026, 3, 20, 10, 0, tzinfo=UTC),
+        )
+
+        second = datetime(2026, 3, 20, 12, 0, tzinfo=UTC)
+        third = datetime(2026, 3, 20, 14, 0, tzinfo=UTC)
+
+        rs.mark_viewed(now=second)
+        assert rs.last_viewed_at == second
+
+        rs.mark_viewed(now=third)
+        assert rs.last_viewed_at == third

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_read_status_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_read_status_repository.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from contexts.record.domain.read_status import ReadStatus
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import ReadStatusId, RecordId
+from contexts.record.infrastructure.sqlalchemy_read_status_repository import (
+    SqlAlchemyReadStatusRepository,
+)
+from contexts.record.infrastructure.sqlalchemy_record_repository import (
+    SqlAlchemyRecordRepository,
+)
+from shared.domain.value_objects import UserId
+from shared.infrastructure.tables import UserTable
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_user(session: AsyncSession) -> UserId:
+    """Insert a user row and return its UserId (needed for FK constraints)."""
+    user_id = UserId.generate()
+    session.add(UserTable(id=str(user_id.value)))
+    await session.flush()
+    return user_id
+
+
+async def _create_record(
+    session: AsyncSession, organizer: UserId, counterpart: UserId
+) -> Record:
+    """Create and persist a Record (needed for FK constraints)."""
+    record = Record.create(
+        organizer_id=organizer,
+        counterpart_id=counterpart,
+        conducted_at=datetime(2026, 3, 20, 14, 0),
+        now=datetime(2026, 3, 20, 10, 0),
+    )
+    repo = SqlAlchemyRecordRepository(session)
+    await repo.save(record)
+    await session.flush()
+    return record
+
+
+class TestSaveAndGetById:
+    """save() -> get_by_id() round-trip."""
+
+    async def test_save_and_restore_read_status(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyReadStatusRepository(session)
+        rs = ReadStatus.create(
+            record_id=record.id,
+            user_id=organizer,
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(rs)
+        await session.commit()
+
+        loaded = await repo.get_by_id(rs.id)
+
+        assert loaded is not None
+        assert loaded.id == rs.id
+        assert loaded.record_id == record.id
+        assert loaded.user_id == organizer
+        assert loaded.last_viewed_at == datetime(2026, 3, 20, 15, 0)
+
+    async def test_get_by_id_returns_none_for_missing(
+        self, session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyReadStatusRepository(session)
+        result = await repo.get_by_id(ReadStatusId.generate())
+        assert result is None
+
+
+class TestSaveUpdate:
+    """save() updates an existing ReadStatus."""
+
+    async def test_save_updates_last_viewed_at(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyReadStatusRepository(session)
+        rs = ReadStatus.create(
+            record_id=record.id,
+            user_id=organizer,
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(rs)
+        await session.commit()
+
+        rs.mark_viewed(now=datetime(2026, 3, 20, 18, 0))
+        await repo.save(rs)
+        await session.commit()
+
+        loaded = await repo.get_by_id(rs.id)
+        assert loaded is not None
+        assert loaded.last_viewed_at == datetime(2026, 3, 20, 18, 0)
+
+
+class TestFindByRecordAndUser:
+    """find_by_record_and_user() queries."""
+
+    async def test_find_existing(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyReadStatusRepository(session)
+        rs = ReadStatus.create(
+            record_id=record.id,
+            user_id=organizer,
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(rs)
+        await session.commit()
+
+        found = await repo.find_by_record_and_user(record.id, organizer)
+        assert found is not None
+        assert found.id == rs.id
+
+    async def test_find_returns_none_when_no_match(self, session: AsyncSession) -> None:
+        repo = SqlAlchemyReadStatusRepository(session)
+        result = await repo.find_by_record_and_user(
+            RecordId.generate(), UserId.generate()
+        )
+        assert result is None
+
+
+class TestDeleteByRecordAndUser:
+    """delete_by_record_and_user() removes the matching row."""
+
+    async def test_delete_existing(self, session: AsyncSession) -> None:
+        organizer = await _create_user(session)
+        counterpart = await _create_user(session)
+        record = await _create_record(session, organizer, counterpart)
+
+        repo = SqlAlchemyReadStatusRepository(session)
+        rs = ReadStatus.create(
+            record_id=record.id,
+            user_id=organizer,
+            now=datetime(2026, 3, 20, 15, 0),
+        )
+        await repo.save(rs)
+        await session.commit()
+
+        await repo.delete_by_record_and_user(record.id, organizer)
+        await session.commit()
+
+        found = await repo.find_by_record_and_user(record.id, organizer)
+        assert found is None
+
+    async def test_delete_nonexistent_is_noop(self, session: AsyncSession) -> None:
+        """delete_by_record_and_user is a no-op when no matching row exists."""
+        repo = SqlAlchemyReadStatusRepository(session)
+        # Should not raise
+        await repo.delete_by_record_and_user(RecordId.generate(), UserId.generate())


### PR DESCRIPTION
## 概要

Issue #158 の実装。未読管理の中核となる `ReadStatus` エンティティとリポジトリを実装する。

`docs/design/unread_management.md` セクション7, 8 の設計に基づく。

## 変更内容

### ドメイン層
- `ReadStatusId` 値オブジェクト（`value_objects.py` に追加）
- `ReadStatus` エンティティ（`id`, `record_id`, `user_id`, `last_viewed_at`）
  - `create()` ファクトリメソッド
  - `mark_viewed()` で閲覧日時を更新
- `ReadStatusRepository` インターフェース（`find_by_record_and_user`, `save`, `delete_by_record_and_user`）

### インフラ層
- `ReadStatusTable` ORM モデル
  - `UNIQUE(record_id, user_id)` 制約
  - `idx_record_read_statuses_user_id` インデックス
  - FK: `record_id -> records.id ON DELETE CASCADE`, `user_id -> users.id ON DELETE CASCADE`
- `SqlAlchemyReadStatusRepository` 実装（insert/update 自動判別の save パターン）
- Alembic マイグレーション 0011: `record_read_statuses` テーブル作成
- `foundation/db/models.py` に `ReadStatusTable` を登録

### テスト
- ドメイン層ユニットテスト: `ReadStatus.create()`, `mark_viewed()`（5件）
- インテグレーションテスト: リポジトリの CRUD テスト（6件）

## 依存

- PR #164（#157: Record に `latest_activity_at` 追加）をベースにしている

## テスト計画

- [x] ドメイン層ユニットテスト（pytest、DB不要）
- [ ] インテグレーションテスト（テスト用 MariaDB コンテナ）
- [x] ruff check / ruff format
- [x] pyright 型チェック


Generated with [Claude Code](https://claude.com/claude-code)
