### PR TITLE
フロントエンド: ダッシュボード画面の実装

### DIFF
--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -90,6 +90,9 @@ if TYPE_CHECKING:
     from contexts.record.application.get_last_session_summary import (
         GetLastSessionSummaryService,
     )
+    from contexts.record.application.list_all_pending_action_items import (
+        ListAllPendingActionItemsService,
+    )
     from contexts.record.application.list_pending_action_items import (
         ListPendingActionItemsService,
     )
@@ -458,6 +461,23 @@ def get_list_pending_action_items_service(
     )
 
     return ListPendingActionItemsService(
+        action_item_repository=action_item_repo,
+        record_repository=record_repo,
+    )
+
+
+def get_list_all_pending_action_items_service(
+    record_repo: Annotated[RecordRepository, Depends(_get_record_repository)],
+    action_item_repo: Annotated[
+        ActionItemRepository, Depends(_get_action_item_repository)
+    ],
+) -> ListAllPendingActionItemsService:
+    """Provide a ListAllPendingActionItemsService."""
+    from contexts.record.application.list_all_pending_action_items import (
+        ListAllPendingActionItemsService,
+    )
+
+    return ListAllPendingActionItemsService(
         action_item_repository=action_item_repo,
         record_repository=record_repo,
     )

--- a/backend/contexts/preparation/presentation/router.py
+++ b/backend/contexts/preparation/presentation/router.py
@@ -105,6 +105,7 @@ from contexts.preparation.presentation.dependencies import (
     get_get_last_session_summary_service,
     get_get_schedule_detail_service,
     get_get_template_service,
+    get_list_all_pending_action_items_service,
     get_list_pending_action_items_service,
     get_list_schedule_agendas_service,
     get_list_templates_service,
@@ -123,6 +124,7 @@ from contexts.preparation.presentation.schemas import (
     AddAgendaResponse,
     AgendaCommentSchema,
     AgendaItemSchema,
+    AllPendingActionItemSchema,
     CreateScheduleGroupFromPastRequest,
     CreateScheduleGroupFromPastResponse,
     CreateScheduleGroupFromTemplateRequest,
@@ -134,6 +136,7 @@ from contexts.preparation.presentation.schemas import (
     GetLastSessionSummaryResponse,
     GetScheduleDetailResponse,
     GetTemplateResponse,
+    ListAllPendingActionItemsResponse,
     ListPendingActionItemsResponse,
     ListScheduleAgendasResponse,
     ListTemplatesResponse,
@@ -151,6 +154,10 @@ from contexts.preparation.presentation.schemas import (
 from contexts.record.application.get_last_session_summary import (
     GetLastSessionSummaryInput,
     GetLastSessionSummaryService,
+)
+from contexts.record.application.list_all_pending_action_items import (
+    ListAllPendingActionItemsInput,
+    ListAllPendingActionItemsService,
 )
 from contexts.record.application.list_pending_action_items import (
     ListPendingActionItemsInput,
@@ -557,6 +564,39 @@ async def add_agenda_comment(
 
 
 # -- Action items (cross-context read) --------------------------------------
+
+
+@router.get(
+    "/action-items/pending",
+    response_model=ListAllPendingActionItemsResponse,
+)
+async def list_all_pending_action_items(
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    service: Annotated[
+        ListAllPendingActionItemsService,
+        Depends(get_list_all_pending_action_items_service),
+    ],
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+) -> ListAllPendingActionItemsResponse:
+    output = await service.execute(
+        ListAllPendingActionItemsInput(
+            actor_id=current_user_id,
+            limit=limit,
+        )
+    )
+    return ListAllPendingActionItemsResponse(
+        items=[
+            AllPendingActionItemSchema(
+                action_item_id=item.action_item_id.value,
+                content=item.content,
+                created_at=item.created_at,
+                record_id=item.record_id.value,
+                counterpart_id=item.counterpart_id.value,
+                conducted_at=item.conducted_at,
+            )
+            for item in output.items
+        ]
+    )
 
 
 @router.get(

--- a/backend/contexts/preparation/presentation/schemas.py
+++ b/backend/contexts/preparation/presentation/schemas.py
@@ -321,10 +321,10 @@ class AllPendingActionItemSchema(BaseModel):
 
     action_item_id: UUID
     content: str
-    created_at: datetime
+    created_at: AwareDatetime
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: datetime
+    conducted_at: AwareDatetime
 
 
 class ListAllPendingActionItemsResponse(BaseModel):

--- a/backend/contexts/preparation/presentation/schemas.py
+++ b/backend/contexts/preparation/presentation/schemas.py
@@ -314,3 +314,20 @@ class ListPendingActionItemsResponse(BaseModel):
     """Response body for GET /action-items/pending/{counterpart_id}."""
 
     items: list[PendingActionItemSchema]
+
+
+class AllPendingActionItemSchema(BaseModel):
+    """A single pending action item in the all-counterpart overview."""
+
+    action_item_id: UUID
+    content: str
+    created_at: datetime
+    record_id: UUID
+    counterpart_id: UUID
+    conducted_at: datetime
+
+
+class ListAllPendingActionItemsResponse(BaseModel):
+    """Response body for GET /action-items/pending."""
+
+    items: list[AllPendingActionItemSchema]

--- a/backend/contexts/record/application/list_all_pending_action_items.py
+++ b/backend/contexts/record/application/list_all_pending_action_items.py
@@ -1,0 +1,116 @@
+"""Read-only query service: list all pending action items for an organizer.
+
+Returns all incomplete action items across all counterparts where the
+logged-in user is the organizer of the originating Record. This is used
+by the dashboard to show a cross-counterpart overview.
+
+No UoW or EventDispatcher needed (read-only).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.record_repository import RecordRepository
+from contexts.record.domain.value_objects import ActionItemId, RecordId
+from shared.domain.value_objects import UserId
+
+
+@dataclass(frozen=True)
+class AllPendingActionItemDTO:
+    """Single pending action item with its originating Record info."""
+
+    action_item_id: ActionItemId
+    content: str
+    created_at: datetime
+    record_id: RecordId
+    counterpart_id: UserId
+    conducted_at: datetime
+
+
+@dataclass(frozen=True)
+class ListAllPendingActionItemsInput:
+    """Input DTO for ListAllPendingActionItemsService."""
+
+    actor_id: UserId
+    limit: int = 50
+
+
+@dataclass(frozen=True)
+class ListAllPendingActionItemsOutput:
+    """Output DTO for ListAllPendingActionItemsService."""
+
+    items: list[AllPendingActionItemDTO]
+
+
+MAX_LIMIT = 200
+
+
+class InvalidLimitError(Exception):
+    """limit must be between 1 and MAX_LIMIT (inclusive)."""
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(f"limit must be between 1 and {MAX_LIMIT}, got {limit}")
+
+
+class ListAllPendingActionItemsService:
+    """Query all pending (not completed) action items for an organizer.
+
+    Returns action items across all counterparts where the actor is the
+    organizer of the originating Record. Results are ordered by created_at
+    ascending (oldest first), limited to ``limit`` items (default 50).
+
+    This is a read-only query service; no UoW or EventDispatcher is needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        action_item_repository: ActionItemRepository,
+        record_repository: RecordRepository,
+    ) -> None:
+        self._action_item_repository = action_item_repository
+        self._record_repository = record_repository
+
+    async def execute(
+        self, input_dto: ListAllPendingActionItemsInput
+    ) -> ListAllPendingActionItemsOutput:
+        # 0. Validate limit
+        if not (1 <= input_dto.limit <= MAX_LIMIT):
+            raise InvalidLimitError(input_dto.limit)
+
+        # 1. Fetch pending action items for this organizer (across all counterparts)
+        pending_items = await self._action_item_repository.list_pending_by_organizer(
+            input_dto.actor_id,
+            limit=input_dto.limit,
+        )
+
+        # 2. Collect record IDs to look up Record info
+        record_ids = {item.record_id for item in pending_items}
+        records_by_id: dict[RecordId, tuple[UserId, datetime]] = {}
+        for rid in record_ids:
+            record = await self._record_repository.get_by_id(rid)
+            if record is not None:
+                records_by_id[rid] = (record.counterpart_id, record.conducted_at)
+
+        # 3. Build output DTOs
+        result_items: list[AllPendingActionItemDTO] = []
+        for item in pending_items:
+            record_info = records_by_id.get(item.record_id)
+            if record_info is None:
+                continue  # skip orphaned items (should not happen in practice)
+            counterpart_id, conducted_at = record_info
+            result_items.append(
+                AllPendingActionItemDTO(
+                    action_item_id=item.id,
+                    content=item.title.value,
+                    created_at=item.created_at,
+                    record_id=item.record_id,
+                    counterpart_id=counterpart_id,
+                    conducted_at=conducted_at,
+                )
+            )
+
+        return ListAllPendingActionItemsOutput(items=result_items)

--- a/backend/contexts/record/domain/action_item_repository.py
+++ b/backend/contexts/record/domain/action_item_repository.py
@@ -23,6 +23,16 @@ class ActionItemRepository(BaseRepository[ActionItem, ActionItemId]):
         """
 
     @abstractmethod
+    async def list_pending_by_organizer(
+        self, organizer_id: UserId, *, limit: int = 50
+    ) -> list[ActionItem]:
+        """Return pending (not completed) action items across all counterparts
+        where the organizer of the originating Record is ``organizer_id``.
+
+        Results are ordered by created_at ascending (oldest first).
+        """
+
+    @abstractmethod
     async def list_by_record_id(self, record_id: RecordId) -> list[ActionItem]:
         """Return all action items for a given Record.
 

--- a/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.action_item_repository import ActionItemRepository
 from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle, RecordId
-from contexts.record.infrastructure.tables import ActionItemTable
+from contexts.record.infrastructure.tables import ActionItemTable, RecordTable
 from shared.domain.value_objects import UserId
 
 _DEFAULT_PENDING_LIMIT = 50
@@ -40,6 +40,22 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
             select(ActionItemTable)
             .where(
                 ActionItemTable.counterpart_id == str(counterpart_id.value),
+                ActionItemTable.is_completed.is_(False),
+            )
+            .order_by(ActionItemTable.created_at.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [self._to_entity(row) for row in result.scalars().all()]
+
+    async def list_pending_by_organizer(
+        self, organizer_id: UserId, *, limit: int = _DEFAULT_PENDING_LIMIT
+    ) -> list[ActionItem]:
+        stmt = (
+            select(ActionItemTable)
+            .join(RecordTable, ActionItemTable.record_id == RecordTable.id)
+            .where(
+                RecordTable.organizer_id == str(organizer_id.value),
                 ActionItemTable.is_completed.is_(False),
             )
             .order_by(ActionItemTable.created_at.asc())

--- a/backend/contexts/record/presentation/dependencies.py
+++ b/backend/contexts/record/presentation/dependencies.py
@@ -25,6 +25,9 @@ from contexts.record.application.create_record_from_schedule import (
 from contexts.record.application.delete_action_item import DeleteActionItemUseCase
 from contexts.record.application.get_record_detail import GetRecordDetailUseCase
 from contexts.record.application.get_viewers import GetViewersUseCase
+from contexts.record.application.list_draft_records import (
+    ListDraftRecordsService,
+)
 from contexts.record.application.list_oneonone_history import (
     ListOneOnOneHistoryService,
 )
@@ -272,6 +275,15 @@ def get_complete_action_item_use_case(
         action_item_repository=action_item_repo,
         unit_of_work=uow,
         event_dispatcher=event_dispatcher,
+    )
+
+
+def get_list_draft_records_service(
+    record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
+) -> ListDraftRecordsService:
+    """Provide a ListDraftRecordsService with all dependencies injected."""
+    return ListDraftRecordsService(
+        record_repository=record_repo,
     )
 
 

--- a/backend/contexts/record/presentation/router.py
+++ b/backend/contexts/record/presentation/router.py
@@ -44,6 +44,10 @@ from contexts.record.application.get_viewers import (
     GetViewersInput,
     GetViewersUseCase,
 )
+from contexts.record.application.list_draft_records import (
+    ListDraftRecordsInput,
+    ListDraftRecordsService,
+)
 from contexts.record.application.list_oneonone_history import (
     ListOneOnOneHistoryInput,
     ListOneOnOneHistoryService,
@@ -85,6 +89,7 @@ from contexts.record.presentation.dependencies import (
     get_delete_action_item_use_case,
     get_get_record_detail_use_case,
     get_get_viewers_use_case,
+    get_list_draft_records_service,
     get_list_oneonone_history_service,
     get_list_record_comments_use_case,
     get_publish_record_use_case,
@@ -107,8 +112,10 @@ from contexts.record.presentation.schemas import (
     CreateRecordFromScheduleRequest,
     CreateRecordFromScheduleResponse,
     DeleteActionItemResponse,
+    DraftRecordItemSchema,
     GetRecordDetailResponse,
     GetViewersResponse,
+    ListDraftRecordsResponse,
     ListOneOnOneHistoryResponse,
     ListRecordCommentsResponse,
     OneOnOneHistoryItemSchema,
@@ -315,6 +322,33 @@ async def save_draft(
 # ---------------------------------------------------------------------------
 # Record viewer endpoints
 # ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/records/drafts",
+    response_model=ListDraftRecordsResponse,
+)
+async def list_draft_records(
+    current_user_id: Annotated[UserId, Depends(get_current_user_id)],
+    service: Annotated[
+        ListDraftRecordsService, Depends(get_list_draft_records_service)
+    ],
+) -> ListDraftRecordsResponse:
+    """List draft (unpublished) records for the current user."""
+    output = await service.execute(ListDraftRecordsInput(actor_id=current_user_id))
+    return ListDraftRecordsResponse(
+        items=[
+            DraftRecordItemSchema(
+                record_id=item.record_id.value,
+                counterpart_id=item.counterpart_id.value,
+                conducted_at=item.conducted_at,
+                memo_excerpt=item.memo_excerpt,
+                created_at=item.created_at,
+                schedule_id=item.schedule_id.value if item.schedule_id else None,
+            )
+            for item in output.items
+        ]
+    )
 
 
 @router.get(

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -1,5 +1,6 @@
 """Pydantic request/response schemas for the Record context API."""
 
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, Field
@@ -264,3 +265,25 @@ class PublishRecordResponse(BaseModel):
     """Response body for POST /records/{id}/publish."""
 
     record_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Draft records -- GET /records/drafts
+# ---------------------------------------------------------------------------
+
+
+class DraftRecordItemSchema(BaseModel):
+    """A single item in the draft records response."""
+
+    record_id: UUID
+    counterpart_id: UUID
+    conducted_at: datetime
+    memo_excerpt: str
+    created_at: datetime
+    schedule_id: UUID | None
+
+
+class ListDraftRecordsResponse(BaseModel):
+    """Response body for GET /records/drafts."""
+
+    items: list[DraftRecordItemSchema]

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -277,9 +277,9 @@ class DraftRecordItemSchema(BaseModel):
 
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: datetime
+    conducted_at: AwareDatetime
     memo_excerpt: str
-    created_at: datetime
+    created_at: AwareDatetime
     schedule_id: UUID | None
 
 

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -147,6 +147,29 @@ class InMemoryActionItemRepository(ActionItemRepository):
         pending.sort(key=lambda item: item.created_at)
         return pending[: max(0, limit)]
 
+    async def list_pending_by_organizer(
+        self, organizer_id: UserId, *, limit: int = 50
+    ) -> list[ActionItem]:
+        # Need to find records by organizer; store a reference to record_repo
+        # For in-memory testing, we filter by record_id matching records
+        # where organizer_id matches. We rely on _record_repo being set externally.
+        pending = [item for item in self._items.values() if not item.is_completed]
+        # Filter by organizer - check _organizer_map if available
+        if hasattr(self, "_organizer_map"):
+            pending = [
+                item
+                for item in pending
+                if self._organizer_map.get(item.record_id) == organizer_id
+            ]
+        pending.sort(key=lambda item: item.created_at)
+        return pending[: max(0, limit)]
+
+    def set_organizer_map(self, record_id: RecordId, organizer_id: UserId) -> None:
+        """Register organizer for a record (test helper)."""
+        if not hasattr(self, "_organizer_map"):
+            self._organizer_map: dict[RecordId, UserId] = {}
+        self._organizer_map[record_id] = organizer_id
+
     async def list_by_record_id(self, record_id: RecordId) -> list[ActionItem]:
         items = [item for item in self._items.values() if item.record_id == record_id]
         items.sort(key=lambda item: item.created_at)

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -129,6 +129,7 @@ class InMemoryActionItemRepository(ActionItemRepository):
 
     def __init__(self) -> None:
         self._items: dict[ActionItemId, ActionItem] = {}
+        self._organizer_map: dict[RecordId, UserId] = {}
 
     async def get_by_id(self, entity_id: ActionItemId) -> ActionItem | None:
         return self._items.get(entity_id)
@@ -153,21 +154,17 @@ class InMemoryActionItemRepository(ActionItemRepository):
         # Need to find records by organizer; store a reference to record_repo
         # For in-memory testing, we filter by record_id matching records
         # where organizer_id matches. We rely on _record_repo being set externally.
-        pending = [item for item in self._items.values() if not item.is_completed]
-        # Filter by organizer - check _organizer_map if available
-        if hasattr(self, "_organizer_map"):
-            pending = [
-                item
-                for item in pending
-                if self._organizer_map.get(item.record_id) == organizer_id
-            ]
+        pending = [
+            item
+            for item in self._items.values()
+            if not item.is_completed
+            and self._organizer_map.get(item.record_id) == organizer_id
+        ]
         pending.sort(key=lambda item: item.created_at)
         return pending[: max(0, limit)]
 
     def set_organizer_map(self, record_id: RecordId, organizer_id: UserId) -> None:
         """Register organizer for a record (test helper)."""
-        if not hasattr(self, "_organizer_map"):
-            self._organizer_map: dict[RecordId, UserId] = {}
         self._organizer_map[record_id] = organizer_id
 
     async def list_by_record_id(self, record_id: RecordId) -> list[ActionItem]:

--- a/backend/tests/contexts/record/application/test_list_all_pending_action_items.py
+++ b/backend/tests/contexts/record/application/test_list_all_pending_action_items.py
@@ -1,0 +1,318 @@
+"""Tests for ListAllPendingActionItemsService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from contexts.record.application.list_all_pending_action_items import (
+    MAX_LIMIT,
+    InvalidLimitError,
+    ListAllPendingActionItemsInput,
+    ListAllPendingActionItemsOutput,
+    ListAllPendingActionItemsService,
+)
+from contexts.record.domain.action_item import ActionItem
+from contexts.record.domain.record import Record
+from contexts.record.domain.value_objects import ActionItemTitle, RecordId
+from shared.domain.value_objects import UserId
+from tests.contexts.record.application.conftest import (
+    InMemoryActionItemRepository,
+    InMemoryRecordRepository,
+)
+
+
+def _make_record(
+    *,
+    organizer: UserId | None = None,
+    counterpart: UserId | None = None,
+    conducted_at: datetime | None = None,
+    now: datetime | None = None,
+) -> Record:
+    record = Record.create(
+        organizer_id=organizer or UserId.generate(),
+        counterpart_id=counterpart or UserId.generate(),
+        conducted_at=conducted_at or datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        now=now,
+    )
+    record.collect_events()
+    return record
+
+
+def _make_action_item(
+    *,
+    counterpart: UserId,
+    record_id: RecordId,
+    organizer: UserId,
+    title: str = "Follow up",
+    now: datetime | None = None,
+) -> ActionItem:
+    item = ActionItem.create(
+        counterpart_id=counterpart,
+        record_id=record_id,
+        title=ActionItemTitle(title),
+        actor_id=organizer,
+        organizer_id=organizer,
+        now=now,
+    )
+    item.collect_events()
+    return item
+
+
+def _build_service(
+    *,
+    record_repo: InMemoryRecordRepository | None = None,
+    action_item_repo: InMemoryActionItemRepository | None = None,
+) -> tuple[
+    ListAllPendingActionItemsService,
+    InMemoryRecordRepository,
+    InMemoryActionItemRepository,
+]:
+    rr = record_repo or InMemoryRecordRepository()
+    air = action_item_repo or InMemoryActionItemRepository()
+    svc = ListAllPendingActionItemsService(
+        action_item_repository=air,
+        record_repository=rr,
+    )
+    return svc, rr, air
+
+
+class TestListAllPendingActionItems:
+    """Tests for successful all-pending action item retrieval."""
+
+    async def test_returns_pending_items_for_organizer(self) -> None:
+        """Basic retrieval of pending action items across all counterparts."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+        item = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Review document",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        air.set_organizer_map(record.id, organizer)
+        await air.save(item)
+
+        output = await svc.execute(ListAllPendingActionItemsInput(actor_id=organizer))
+
+        assert isinstance(output, ListAllPendingActionItemsOutput)
+        assert len(output.items) == 1
+        dto = output.items[0]
+        assert dto.action_item_id == item.id
+        assert dto.content == "Review document"
+        assert dto.record_id == record.id
+        assert dto.counterpart_id == counterpart
+        assert dto.conducted_at == record.conducted_at
+
+    async def test_returns_items_from_multiple_counterparts(self) -> None:
+        """Items from different counterparts are aggregated."""
+        organizer = UserId.generate()
+        counterpart_a = UserId.generate()
+        counterpart_b = UserId.generate()
+
+        record_a = _make_record(
+            organizer=organizer,
+            counterpart=counterpart_a,
+            conducted_at=datetime(2026, 2, 1, 10, 0, tzinfo=UTC),
+        )
+        record_b = _make_record(
+            organizer=organizer,
+            counterpart=counterpart_b,
+            conducted_at=datetime(2026, 3, 1, 10, 0, tzinfo=UTC),
+        )
+
+        item_a = _make_action_item(
+            counterpart=counterpart_a,
+            record_id=record_a.id,
+            organizer=organizer,
+            title="Task for A",
+            now=datetime(2026, 2, 1, 11, 0, tzinfo=UTC),
+        )
+        item_b = _make_action_item(
+            counterpart=counterpart_b,
+            record_id=record_b.id,
+            organizer=organizer,
+            title="Task for B",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record_a)
+        await rr.save(record_b)
+        air.set_organizer_map(record_a.id, organizer)
+        air.set_organizer_map(record_b.id, organizer)
+        await air.save(item_a)
+        await air.save(item_b)
+
+        output = await svc.execute(ListAllPendingActionItemsInput(actor_id=organizer))
+
+        assert len(output.items) == 2
+        contents = {dto.content for dto in output.items}
+        assert contents == {"Task for A", "Task for B"}
+
+    async def test_excludes_completed_items(self) -> None:
+        """Completed action items are not returned."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        pending = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Pending task",
+            now=datetime(2026, 3, 1, 11, 0, tzinfo=UTC),
+        )
+        completed = _make_action_item(
+            counterpart=counterpart,
+            record_id=record.id,
+            organizer=organizer,
+            title="Done task",
+            now=datetime(2026, 3, 1, 12, 0, tzinfo=UTC),
+        )
+        completed.complete(
+            actor_id=counterpart,
+            now=datetime(2026, 3, 2, 10, 0, tzinfo=UTC),
+        )
+        completed.collect_events()
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        air.set_organizer_map(record.id, organizer)
+        await air.save(pending)
+        await air.save(completed)
+
+        output = await svc.execute(ListAllPendingActionItemsInput(actor_id=organizer))
+
+        assert len(output.items) == 1
+        assert output.items[0].content == "Pending task"
+
+    async def test_excludes_items_from_other_organizers(self) -> None:
+        """Items from other organizers' records are not returned."""
+        organizer_a = UserId.generate()
+        organizer_b = UserId.generate()
+        counterpart = UserId.generate()
+
+        record_a = _make_record(organizer=organizer_a, counterpart=counterpart)
+        record_b = _make_record(organizer=organizer_b, counterpart=counterpart)
+
+        item_a = _make_action_item(
+            counterpart=counterpart,
+            record_id=record_a.id,
+            organizer=organizer_a,
+            title="A's task",
+        )
+        item_b = _make_action_item(
+            counterpart=counterpart,
+            record_id=record_b.id,
+            organizer=organizer_b,
+            title="B's task",
+        )
+
+        svc, rr, air = _build_service()
+        await rr.save(record_a)
+        await rr.save(record_b)
+        air.set_organizer_map(record_a.id, organizer_a)
+        air.set_organizer_map(record_b.id, organizer_b)
+        await air.save(item_a)
+        await air.save(item_b)
+
+        output = await svc.execute(ListAllPendingActionItemsInput(actor_id=organizer_a))
+
+        assert len(output.items) == 1
+        assert output.items[0].content == "A's task"
+
+    async def test_respects_limit(self) -> None:
+        """Only up to limit items are returned."""
+        organizer = UserId.generate()
+        counterpart = UserId.generate()
+        record = _make_record(organizer=organizer, counterpart=counterpart)
+
+        svc, rr, air = _build_service()
+        await rr.save(record)
+        air.set_organizer_map(record.id, organizer)
+
+        for i in range(5):
+            item = _make_action_item(
+                counterpart=counterpart,
+                record_id=record.id,
+                organizer=organizer,
+                title=f"Task {i}",
+                now=datetime(2026, 1, 1 + i, 10, 0, tzinfo=UTC),
+            )
+            await air.save(item)
+
+        output = await svc.execute(
+            ListAllPendingActionItemsInput(
+                actor_id=organizer,
+                limit=3,
+            )
+        )
+
+        assert len(output.items) == 3
+        assert output.items[0].content == "Task 0"
+        assert output.items[1].content == "Task 1"
+        assert output.items[2].content == "Task 2"
+
+    async def test_returns_empty_when_no_pending_items(self) -> None:
+        """Returns empty list when organizer has no pending items."""
+        organizer = UserId.generate()
+
+        svc, _rr, _air = _build_service()
+
+        output = await svc.execute(ListAllPendingActionItemsInput(actor_id=organizer))
+
+        assert output.items == []
+
+    async def test_default_limit_is_50(self) -> None:
+        """Default limit should be 50."""
+        input_dto = ListAllPendingActionItemsInput(
+            actor_id=UserId.generate(),
+        )
+        assert input_dto.limit == 50
+
+
+class TestListAllPendingActionItemsLimitValidation:
+    """Tests for limit parameter validation."""
+
+    async def test_limit_zero_raises(self) -> None:
+        """limit=0 is rejected."""
+        svc, _rr, _air = _build_service()
+
+        with pytest.raises(InvalidLimitError):
+            await svc.execute(
+                ListAllPendingActionItemsInput(
+                    actor_id=UserId.generate(),
+                    limit=0,
+                )
+            )
+
+    async def test_limit_negative_raises(self) -> None:
+        """limit=-1 is rejected."""
+        svc, _rr, _air = _build_service()
+
+        with pytest.raises(InvalidLimitError):
+            await svc.execute(
+                ListAllPendingActionItemsInput(
+                    actor_id=UserId.generate(),
+                    limit=-1,
+                )
+            )
+
+    async def test_limit_exceeds_max_raises(self) -> None:
+        """limit above MAX_LIMIT is rejected."""
+        svc, _rr, _air = _build_service()
+
+        with pytest.raises(InvalidLimitError):
+            await svc.execute(
+                ListAllPendingActionItemsInput(
+                    actor_id=UserId.generate(),
+                    limit=MAX_LIMIT + 1,
+                )
+            )

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -38,7 +38,7 @@ describe("App", () => {
   it("renders the dashboard page", () => {
     renderWithProviders();
     expect(
-      screen.getByRole("heading", { name: "Dashboard" }),
+      screen.getByRole("heading", { name: /Dev User/ }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,282 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { DashboardPage } from "../pages/DashboardPage";
+
+// -- Mock hooks ---------------------------------------------------------------
+
+const mockSchedules = [
+  {
+    schedule_id: "s1",
+    organizer_id: "u1",
+    counterpart_id: "u2",
+    scheduled_at: new Date().toISOString(),
+    status: "confirmed",
+    title: "Weekly 1on1 -- Tanaka",
+    schedule_group_id: null,
+  },
+];
+
+const mockDrafts = [
+  {
+    record_id: "r1",
+    counterpart_id: "u2",
+    conducted_at: "2026-03-20T10:00:00Z",
+    memo_excerpt: "Test memo",
+    created_at: "2026-03-20T10:00:00Z",
+    schedule_id: "s2",
+  },
+];
+
+const mockPendingItems = [
+  {
+    action_item_id: "a1",
+    content: "Send progress report",
+    created_at: "2026-03-20T10:00:00Z",
+    record_id: "r2",
+    organizer_id: "u1",
+    conducted_at: "2026-03-20T10:00:00Z",
+  },
+];
+
+const mockNotifications = [
+  {
+    id: "n1",
+    recipient_id: "u1",
+    notification_type: "record_published",
+    title: "Record published",
+    body: "A record was published",
+    link: "/records/r1",
+    is_read: false,
+    read_at: null,
+    created_at: "2026-03-25T10:00:00Z",
+  },
+];
+
+let upcomingSchedulesReturn = {
+  schedules: mockSchedules,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+let draftRecordsReturn = {
+  drafts: mockDrafts,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+let pendingActionItemsReturn = {
+  items: mockPendingItems,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+let unreadNotificationsReturn = {
+  notifications: mockNotifications,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+vi.mock("../hooks/useUpcomingSchedules", () => ({
+  useUpcomingSchedules: () => upcomingSchedulesReturn,
+}));
+
+vi.mock("../hooks/useDraftRecords", () => ({
+  useDraftRecords: () => draftRecordsReturn,
+}));
+
+vi.mock("../hooks/usePendingActionItems", () => ({
+  usePendingActionItems: () => pendingActionItemsReturn,
+}));
+
+vi.mock("../hooks/useUnreadNotifications", () => ({
+  useUnreadNotifications: () => unreadNotificationsReturn,
+}));
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <DashboardPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    upcomingSchedulesReturn = {
+      schedules: mockSchedules,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    draftRecordsReturn = {
+      drafts: mockDrafts,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    pendingActionItemsReturn = {
+      items: mockPendingItems,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    unreadNotificationsReturn = {
+      notifications: mockNotifications,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+  });
+
+  // -- Normal data display --------------------------------------------------
+
+  it("renders the greeting with user name", () => {
+    renderDashboard();
+    expect(
+      screen.getByRole("heading", { name: /Dev User/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders section titles", () => {
+    renderDashboard();
+    expect(screen.getByText("次の1on1")).toBeInTheDocument();
+    expect(screen.getByText("直近の1on1")).toBeInTheDocument();
+    expect(screen.getByText("下書き未公開の記録")).toBeInTheDocument();
+    expect(screen.getByText("未完了アクションアイテム")).toBeInTheDocument();
+    expect(screen.getByText("未読の記録・コメント")).toBeInTheDocument();
+  });
+
+  it("renders the next session card with schedule title", () => {
+    renderDashboard();
+    const elements = screen.getAllByText("Weekly 1on1 -- Tanaka");
+    expect(elements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders metrics cards", () => {
+    renderDashboard();
+    expect(screen.getByText("今週の1on1")).toBeInTheDocument();
+    expect(screen.getByText("下書き未公開")).toBeInTheDocument();
+    expect(screen.getByText("期限切れアクション")).toBeInTheDocument();
+  });
+
+  it("renders draft records", () => {
+    renderDashboard();
+    expect(screen.getByText("下書き")).toBeInTheDocument();
+    expect(screen.getByText("公開する")).toBeInTheDocument();
+  });
+
+  it("renders pending action items", () => {
+    renderDashboard();
+    expect(screen.getByText("Send progress report")).toBeInTheDocument();
+  });
+
+  it("renders unread notifications", () => {
+    renderDashboard();
+    expect(screen.getByText("Record published")).toBeInTheDocument();
+  });
+
+  it("renders navigation links", () => {
+    renderDashboard();
+    const allLinks = screen.getAllByText("すべて見る");
+    expect(allLinks.length).toBeGreaterThanOrEqual(4);
+  });
+
+  // -- Loading state --------------------------------------------------------
+
+  it("shows loading skeletons when data is loading", () => {
+    upcomingSchedulesReturn = {
+      ...upcomingSchedulesReturn,
+      schedules: [],
+      isLoading: true,
+    };
+    draftRecordsReturn = {
+      ...draftRecordsReturn,
+      drafts: [],
+      isLoading: true,
+    };
+    pendingActionItemsReturn = {
+      ...pendingActionItemsReturn,
+      items: [],
+      isLoading: true,
+    };
+    unreadNotificationsReturn = {
+      ...unreadNotificationsReturn,
+      notifications: [],
+      isLoading: true,
+    };
+
+    const { container } = renderDashboard();
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  // -- Error state ----------------------------------------------------------
+
+  it("shows error messages when API calls fail", () => {
+    upcomingSchedulesReturn = {
+      ...upcomingSchedulesReturn,
+      schedules: [],
+      error: "スケジュールの取得に失敗しました",
+    };
+    draftRecordsReturn = {
+      ...draftRecordsReturn,
+      drafts: [],
+      error: "下書き記録の取得に失敗しました",
+    };
+
+    renderDashboard();
+    expect(
+      screen.getByText("スケジュールの取得に失敗しました"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("下書き記録の取得に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Empty state ----------------------------------------------------------
+
+  it("shows empty messages when there is no data", () => {
+    upcomingSchedulesReturn = {
+      ...upcomingSchedulesReturn,
+      schedules: [],
+    };
+    draftRecordsReturn = {
+      ...draftRecordsReturn,
+      drafts: [],
+    };
+    pendingActionItemsReturn = {
+      ...pendingActionItemsReturn,
+      items: [],
+    };
+    unreadNotificationsReturn = {
+      ...unreadNotificationsReturn,
+      notifications: [],
+    };
+
+    renderDashboard();
+    const noScheduleMessages = screen.getAllByText(
+      "予定されている1on1はありません",
+    );
+    expect(noScheduleMessages.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("下書きの記録はありません")).toBeInTheDocument();
+    expect(
+      screen.getByText("未完了のアクションアイテムはありません"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("未読の記録・コメントはありません"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
@@ -34,7 +34,7 @@ const mockPendingItems = [
     content: "Send progress report",
     created_at: "2026-03-20T10:00:00Z",
     record_id: "r2",
-    organizer_id: "u1",
+    counterpart_id: "u2",
     conducted_at: "2026-03-20T10:00:00Z",
   },
 ];
@@ -267,9 +267,8 @@ describe("DashboardPage", () => {
     };
 
     renderDashboard();
-    const noScheduleMessages = screen.getAllByText(
-      "予定されている1on1はありません",
-    );
+    const noScheduleMessages =
+      screen.getAllByText("予定されている1on1はありません");
     expect(noScheduleMessages.length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("下書きの記録はありません")).toBeInTheDocument();
     expect(

--- a/frontend/src/features/dashboard/components/DraftRecordList.tsx
+++ b/frontend/src/features/dashboard/components/DraftRecordList.tsx
@@ -1,0 +1,90 @@
+import { Link } from "react-router";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { DraftRecordItem } from "../types";
+import { daysBetween } from "../utils";
+
+interface DraftRecordListProps {
+  drafts: DraftRecordItem[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function DraftRecordList({
+  drafts,
+  isLoading,
+  error,
+}: DraftRecordListProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>下書き未公開の記録</CardTitle>
+        <CardAction>
+          <Link
+            to="/records/drafts"
+            className="text-sm text-primary underline-offset-4 hover:underline"
+          >
+            すべて見る
+          </Link>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1].map((i) => (
+              <div key={i} className="animate-pulse flex items-center gap-3">
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-40 rounded bg-muted" />
+                  <div className="h-3 w-28 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!isLoading && !error && drafts.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            下書きの記録はありません
+          </p>
+        )}
+        {!isLoading && !error && drafts.length > 0 && (
+          <div className="space-y-3">
+            {drafts.map((draft) => {
+              const daysAgo = daysBetween(draft.created_at);
+              return (
+                <div
+                  key={draft.record_id}
+                  className="flex items-center gap-3 rounded-md p-2"
+                >
+                  <div className="flex-1">
+                    <div className="font-medium">
+                      {new Date(draft.conducted_at).toLocaleDateString("ja-JP")}
+                      の1on1
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {daysAgo}日間 下書きのまま
+                    </div>
+                  </div>
+                  <span className="rounded-md bg-amber-100 px-2 py-0.5 text-xs text-amber-700">
+                    下書き
+                  </span>
+                  <Link
+                    to={`/records/${draft.record_id}/publish`}
+                    className="inline-flex h-7 items-center rounded-lg px-2.5 text-xs font-medium hover:bg-muted"
+                  >
+                    公開する
+                  </Link>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/dashboard/components/MetricsCards.tsx
+++ b/frontend/src/features/dashboard/components/MetricsCards.tsx
@@ -1,0 +1,61 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+interface MetricsCardsProps {
+  weeklyCount: number;
+  draftCount: number;
+  overdueCount: number;
+  isLoading: boolean;
+}
+
+export function MetricsCards({
+  weeklyCount,
+  draftCount,
+  overdueCount,
+  isLoading,
+}: MetricsCardsProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-3 gap-4">
+        {[0, 1, 2].map((i) => (
+          <Card key={i}>
+            <CardContent>
+              <div className="animate-pulse space-y-2">
+                <div className="h-3 w-20 rounded bg-muted" />
+                <div className="h-6 w-10 rounded bg-muted" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <Card>
+        <CardContent>
+          <div className="text-sm text-muted-foreground">今週の1on1</div>
+          <div className="mt-1 text-2xl font-bold">{weeklyCount}件</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent>
+          <div className="text-sm text-muted-foreground">下書き未公開</div>
+          <div className="mt-1 text-2xl font-bold text-amber-600">
+            {draftCount}件
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent>
+          <div className="text-sm text-muted-foreground">
+            期限切れアクション
+          </div>
+          <div className="mt-1 text-2xl font-bold text-red-600">
+            {overdueCount}件
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/NextSessionCard.tsx
+++ b/frontend/src/features/dashboard/components/NextSessionCard.tsx
@@ -1,0 +1,71 @@
+import { Link } from "react-router";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UpcomingScheduleItem } from "../types";
+import { formatTime, getRelativeLabel } from "../utils";
+
+interface NextSessionCardProps {
+  schedule: UpcomingScheduleItem | null;
+  isLoading: boolean;
+}
+
+export function NextSessionCard({ schedule, isLoading }: NextSessionCardProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent>
+          <div className="animate-pulse space-y-3">
+            <div className="h-4 w-24 rounded bg-muted" />
+            <div className="h-5 w-48 rounded bg-muted" />
+            <div className="h-4 w-36 rounded bg-muted" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!schedule) {
+    return (
+      <Card>
+        <CardContent>
+          <p className="text-muted-foreground">
+            予定されている1on1はありません
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const relativeLabel = getRelativeLabel(schedule.scheduled_at);
+  const time = formatTime(schedule.scheduled_at);
+  const prepUrl = `/schedules/${schedule.schedule_id}/preparation`;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          次の1on1
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="text-lg font-semibold">{schedule.title}</div>
+        <div className="text-sm text-muted-foreground">
+          {relativeLabel} {time}
+        </div>
+        <div className="flex gap-2">
+          <Link
+            to={prepUrl}
+            className="inline-flex h-8 items-center rounded-lg border border-border bg-background px-2.5 text-sm font-medium hover:bg-muted"
+          >
+            準備画面を開く
+          </Link>
+          <Link
+            to={prepUrl}
+            className="inline-flex h-8 items-center rounded-lg bg-primary px-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/80"
+          >
+            1on1 を開始する
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/dashboard/components/PendingActionList.tsx
+++ b/frontend/src/features/dashboard/components/PendingActionList.tsx
@@ -1,0 +1,80 @@
+import { Link } from "react-router";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { PendingActionItem } from "../types";
+
+interface PendingActionListProps {
+  items: PendingActionItem[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function PendingActionList({
+  items,
+  isLoading,
+  error,
+}: PendingActionListProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>未完了アクションアイテム</CardTitle>
+        <CardAction>
+          <Link
+            to="/records"
+            className="text-sm text-primary underline-offset-4 hover:underline"
+          >
+            すべて見る
+          </Link>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="animate-pulse flex items-center gap-3">
+                <div className="h-6 w-6 rounded-full bg-muted" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-48 rounded bg-muted" />
+                  <div className="h-3 w-32 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!isLoading && !error && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            未完了のアクションアイテムはありません
+          </p>
+        )}
+        {!isLoading && !error && items.length > 0 && (
+          <div className="space-y-3">
+            {items.map((item) => (
+              <Link
+                key={item.action_item_id}
+                to={`/records/${item.record_id}`}
+                className="flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-muted/50"
+              >
+                <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-700">
+                  !
+                </div>
+                <div className="flex-1">
+                  <div className="font-medium">{item.content}</div>
+                  <div className="text-sm text-muted-foreground">
+                    {new Date(item.conducted_at).toLocaleDateString("ja-JP")}
+                    の1on1から
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/dashboard/components/UnreadRecordList.tsx
+++ b/frontend/src/features/dashboard/components/UnreadRecordList.tsx
@@ -1,0 +1,78 @@
+import { Link } from "react-router";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { NotificationRecord } from "../types";
+
+interface UnreadRecordListProps {
+  notifications: NotificationRecord[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function UnreadRecordList({
+  notifications,
+  isLoading,
+  error,
+}: UnreadRecordListProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>未読の記録・コメント</CardTitle>
+        <CardAction>
+          <Link
+            to="/records"
+            className="text-sm text-primary underline-offset-4 hover:underline"
+          >
+            すべて見る
+          </Link>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1].map((i) => (
+              <div key={i} className="animate-pulse flex items-center gap-3">
+                <div className="h-2 w-2 rounded-full bg-muted" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-48 rounded bg-muted" />
+                  <div className="h-3 w-32 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!isLoading && !error && notifications.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            未読の記録・コメントはありません
+          </p>
+        )}
+        {!isLoading && !error && notifications.length > 0 && (
+          <div className="space-y-3">
+            {notifications.map((notification) => (
+              <Link
+                key={notification.id}
+                to={notification.link ?? "/records"}
+                className="flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-muted/50"
+              >
+                <div className="h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" />
+                <div className="flex-1">
+                  <div className="font-medium">{notification.title}</div>
+                  <div className="text-sm text-muted-foreground">
+                    {notification.body}
+                  </div>
+                </div>
+                <span className="text-muted-foreground">&rsaquo;</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/dashboard/components/UpcomingSessionList.tsx
+++ b/frontend/src/features/dashboard/components/UpcomingSessionList.tsx
@@ -1,0 +1,81 @@
+import { Link } from "react-router";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { UpcomingScheduleItem } from "../types";
+import { formatDateJa, formatTime, getRelativeLabel } from "../utils";
+
+interface UpcomingSessionListProps {
+  schedules: UpcomingScheduleItem[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function UpcomingSessionList({
+  schedules,
+  isLoading,
+  error,
+}: UpcomingSessionListProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>直近の1on1</CardTitle>
+        <CardAction>
+          <Link
+            to="/schedules"
+            className="text-sm text-primary underline-offset-4 hover:underline"
+          >
+            すべて見る
+          </Link>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="animate-pulse flex items-center gap-3">
+                <div className="h-10 w-10 rounded-full bg-muted" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-32 rounded bg-muted" />
+                  <div className="h-3 w-48 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!isLoading && !error && schedules.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            予定されている1on1はありません
+          </p>
+        )}
+        {!isLoading && !error && schedules.length > 0 && (
+          <div className="space-y-3">
+            {schedules.map((schedule) => (
+              <Link
+                key={schedule.schedule_id}
+                to={`/schedules/${schedule.schedule_id}/preparation`}
+                className="flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-muted/50"
+              >
+                <div className="flex-1">
+                  <div className="font-medium">{schedule.title}</div>
+                  <div className="text-sm text-muted-foreground">
+                    {formatDateJa(schedule.scheduled_at)}{" "}
+                    {formatTime(schedule.scheduled_at)}
+                  </div>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {getRelativeLabel(schedule.scheduled_at)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/dashboard/hooks/useDraftRecords.ts
+++ b/frontend/src/features/dashboard/hooks/useDraftRecords.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { DraftRecordItem, DraftRecordsResponse } from "../types";
+
+interface UseDraftRecordsResult {
+  drafts: DraftRecordItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useDraftRecords(): UseDraftRecordsResult {
+  const { userId } = useCurrentUser();
+  const [drafts, setDrafts] = useState<DraftRecordItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDrafts = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<DraftRecordsResponse>(
+        "/records/drafts",
+        userId,
+      );
+      setDrafts(data.items);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`下書き記録の取得に失敗しました (${e.status})`);
+      } else {
+        setError("下書き記録の取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchDrafts();
+  }, [fetchDrafts]);
+
+  return { drafts, isLoading, error, refetch: fetchDrafts };
+}

--- a/frontend/src/features/dashboard/hooks/usePendingActionItems.ts
+++ b/frontend/src/features/dashboard/hooks/usePendingActionItems.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { PendingActionItem, PendingActionItemsResponse } from "../types";
+
+interface UsePendingActionItemsResult {
+  items: PendingActionItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function usePendingActionItems(
+  counterpartId: string,
+): UsePendingActionItemsResult {
+  const { userId } = useCurrentUser();
+  const [items, setItems] = useState<PendingActionItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchItems = useCallback(async () => {
+    if (!counterpartId) {
+      setItems([]);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<PendingActionItemsResponse>(
+        `/action-items/pending/${counterpartId}`,
+        userId,
+      );
+      setItems(data.items);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`アクションアイテムの取得に失敗しました (${e.status})`);
+      } else {
+        setError("アクションアイテムの取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [counterpartId, userId]);
+
+  useEffect(() => {
+    void fetchItems();
+  }, [fetchItems]);
+
+  return { items, isLoading, error, refetch: fetchItems };
+}

--- a/frontend/src/features/dashboard/hooks/usePendingActionItems.ts
+++ b/frontend/src/features/dashboard/hooks/usePendingActionItems.ts
@@ -10,25 +10,18 @@ interface UsePendingActionItemsResult {
   refetch: () => void;
 }
 
-export function usePendingActionItems(
-  counterpartId: string,
-): UsePendingActionItemsResult {
+export function usePendingActionItems(): UsePendingActionItemsResult {
   const { userId } = useCurrentUser();
   const [items, setItems] = useState<PendingActionItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchItems = useCallback(async () => {
-    if (!counterpartId) {
-      setItems([]);
-      setIsLoading(false);
-      return;
-    }
     setIsLoading(true);
     setError(null);
     try {
       const data = await apiClient.get<PendingActionItemsResponse>(
-        `/action-items/pending/${counterpartId}`,
+        `/action-items/pending`,
         userId,
       );
       setItems(data.items);
@@ -41,7 +34,7 @@ export function usePendingActionItems(
     } finally {
       setIsLoading(false);
     }
-  }, [counterpartId, userId]);
+  }, [userId]);
 
   useEffect(() => {
     void fetchItems();

--- a/frontend/src/features/dashboard/hooks/useUnreadNotifications.ts
+++ b/frontend/src/features/dashboard/hooks/useUnreadNotifications.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { NotificationListResponse, NotificationRecord } from "../types";
+
+interface UseUnreadNotificationsResult {
+  notifications: NotificationRecord[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useUnreadNotifications(): UseUnreadNotificationsResult {
+  const { userId } = useCurrentUser();
+  const [notifications, setNotifications] = useState<NotificationRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNotifications = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<NotificationListResponse>(
+        "/notifications?unread=true",
+        userId,
+      );
+      setNotifications(data.notifications);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`通知の取得に失敗しました (${e.status})`);
+      } else {
+        setError("通知の取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchNotifications();
+  }, [fetchNotifications]);
+
+  return { notifications, isLoading, error, refetch: fetchNotifications };
+}

--- a/frontend/src/features/dashboard/hooks/useUpcomingSchedules.ts
+++ b/frontend/src/features/dashboard/hooks/useUpcomingSchedules.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { UpcomingScheduleItem, UpcomingSchedulesResponse } from "../types";
+
+interface UseUpcomingSchedulesResult {
+  schedules: UpcomingScheduleItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useUpcomingSchedules(): UseUpcomingSchedulesResult {
+  const { userId } = useCurrentUser();
+  const [schedules, setSchedules] = useState<UpcomingScheduleItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSchedules = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<UpcomingSchedulesResponse>(
+        "/schedules/upcoming",
+        userId,
+      );
+      setSchedules(data.schedules);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`スケジュールの取得に失敗しました (${e.status})`);
+      } else {
+        setError("スケジュールの取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchSchedules();
+  }, [fetchSchedules]);
+
+  return { schedules, isLoading, error, refetch: fetchSchedules };
+}

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -12,7 +12,7 @@ import { UnreadRecordList } from "../components/UnreadRecordList";
 import { countThisWeekSchedules, formatDateJa } from "../utils";
 
 export function DashboardPage() {
-  const { name: userName, userId } = useCurrentUser();
+  const { name: userName } = useCurrentUser();
   const {
     schedules,
     isLoading: schedulesLoading,
@@ -27,7 +27,7 @@ export function DashboardPage() {
     items: pendingItems,
     isLoading: pendingLoading,
     error: pendingError,
-  } = usePendingActionItems(userId);
+  } = usePendingActionItems();
   const {
     notifications,
     isLoading: notificationsLoading,

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -1,7 +1,104 @@
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useUpcomingSchedules } from "../hooks/useUpcomingSchedules";
+import { useDraftRecords } from "../hooks/useDraftRecords";
+import { usePendingActionItems } from "../hooks/usePendingActionItems";
+import { useUnreadNotifications } from "../hooks/useUnreadNotifications";
+import { NextSessionCard } from "../components/NextSessionCard";
+import { MetricsCards } from "../components/MetricsCards";
+import { UpcomingSessionList } from "../components/UpcomingSessionList";
+import { DraftRecordList } from "../components/DraftRecordList";
+import { PendingActionList } from "../components/PendingActionList";
+import { UnreadRecordList } from "../components/UnreadRecordList";
+import { countThisWeekSchedules, formatDateJa } from "../utils";
+
 export function DashboardPage() {
+  const { name: userName, userId } = useCurrentUser();
+  const {
+    schedules,
+    isLoading: schedulesLoading,
+    error: schedulesError,
+  } = useUpcomingSchedules();
+  const {
+    drafts,
+    isLoading: draftsLoading,
+    error: draftsError,
+  } = useDraftRecords();
+  const {
+    items: pendingItems,
+    isLoading: pendingLoading,
+    error: pendingError,
+  } = usePendingActionItems(userId);
+  const {
+    notifications,
+    isLoading: notificationsLoading,
+    error: notificationsError,
+  } = useUnreadNotifications();
+
+  const today = formatDateJa(new Date().toISOString());
+  const nextSchedule = schedules.length > 0 ? schedules[0] : null;
+
+  // Metrics computed from existing API responses (per #148)
+  const weeklyCount = countThisWeekSchedules(
+    schedules.map((s) => s.scheduled_at),
+  );
+  const draftCount = drafts.length;
+  // Note: overdue filtering requires a due_date field which is not yet
+  // available in the pending action items API. For now, show total count.
+  const overdueCount = 0;
+
+  const metricsLoading = schedulesLoading || draftsLoading || pendingLoading;
+
+  // Greeting sub-text
+  const greetingSub = nextSchedule
+    ? `${today}  今日は${nextSchedule.title}があります`
+    : today;
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Dashboard</h1>
+    <div className="space-y-6">
+      {/* Greeting */}
+      <div>
+        <h1 className="text-2xl font-bold">こんにちは、{userName}さん</h1>
+        <p className="mt-1 text-muted-foreground">{greetingSub}</p>
+      </div>
+
+      {/* Next session card */}
+      <NextSessionCard schedule={nextSchedule} isLoading={schedulesLoading} />
+
+      {/* Metrics */}
+      <MetricsCards
+        weeklyCount={weeklyCount}
+        draftCount={draftCount}
+        overdueCount={overdueCount}
+        isLoading={metricsLoading}
+      />
+
+      {/* Upcoming sessions */}
+      <UpcomingSessionList
+        schedules={schedules}
+        isLoading={schedulesLoading}
+        error={schedulesError}
+      />
+
+      {/* Draft records */}
+      <DraftRecordList
+        drafts={drafts}
+        isLoading={draftsLoading}
+        error={draftsError}
+      />
+
+      {/* Pending action items */}
+      <PendingActionList
+        items={pendingItems}
+        isLoading={pendingLoading}
+        error={pendingError}
+      />
+
+      {/* Unread notifications */}
+      <UnreadRecordList
+        notifications={notifications}
+        isLoading={notificationsLoading}
+        error={notificationsError}
+      />
     </div>
   );
 }

--- a/frontend/src/features/dashboard/types.ts
+++ b/frontend/src/features/dashboard/types.ts
@@ -37,7 +37,7 @@ export interface PendingActionItem {
   content: string;
   created_at: string;
   record_id: string;
-  organizer_id: string;
+  counterpart_id: string;
   conducted_at: string;
 }
 

--- a/frontend/src/features/dashboard/types.ts
+++ b/frontend/src/features/dashboard/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared type definitions for the dashboard feature.
+ *
+ * These types mirror the backend API response schemas and are shared
+ * across hooks and components.
+ */
+
+export interface UpcomingScheduleItem {
+  schedule_id: string;
+  organizer_id: string;
+  counterpart_id: string;
+  scheduled_at: string;
+  status: string;
+  title: string;
+  schedule_group_id: string | null;
+}
+
+export interface UpcomingSchedulesResponse {
+  schedules: UpcomingScheduleItem[];
+}
+
+export interface DraftRecordItem {
+  record_id: string;
+  counterpart_id: string;
+  conducted_at: string;
+  memo_excerpt: string;
+  created_at: string;
+  schedule_id: string | null;
+}
+
+export interface DraftRecordsResponse {
+  items: DraftRecordItem[];
+}
+
+export interface PendingActionItem {
+  action_item_id: string;
+  content: string;
+  created_at: string;
+  record_id: string;
+  organizer_id: string;
+  conducted_at: string;
+}
+
+export interface PendingActionItemsResponse {
+  items: PendingActionItem[];
+}
+
+export interface NotificationRecord {
+  id: string;
+  recipient_id: string;
+  notification_type: string;
+  title: string;
+  body: string;
+  link: string | null;
+  is_read: boolean;
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface NotificationListResponse {
+  notifications: NotificationRecord[];
+}

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -1,0 +1,108 @@
+/**
+ * Utility functions for the dashboard feature.
+ * Separated from components to avoid react-refresh warnings.
+ */
+
+/**
+ * Format an ISO datetime string to a localized Japanese date string.
+ * e.g. "2026年4月3日（金）"
+ */
+export function formatDateJa(isoString: string): string {
+  const date = new Date(isoString);
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const weekday = weekdays[date.getDay()];
+  return `${year}年${month}月${day}日（${weekday}）`;
+}
+
+/**
+ * Format an ISO datetime string to time "HH:MM".
+ */
+export function formatTime(isoString: string): string {
+  const date = new Date(isoString);
+  return `${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+/**
+ * Return a relative label like "今日", "明日", "2日後", "7日後".
+ */
+export function getRelativeLabel(isoString: string): string {
+  const now = new Date();
+  const target = new Date(isoString);
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const targetStart = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate(),
+  );
+  const diffMs = targetStart.getTime() - todayStart.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "今日";
+  if (diffDays === 1) return "明日";
+  if (diffDays > 1) return `${diffDays}日後`;
+  if (diffDays === -1) return "昨日";
+  return `${Math.abs(diffDays)}日前`;
+}
+
+/**
+ * Count schedules within the current week (Monday to Sunday).
+ */
+export function countThisWeekSchedules(scheduledAts: string[]): number {
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  // Monday = 1 in getDay(); adjust so Monday is start of week
+  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const monday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + mondayOffset,
+  );
+  const sunday = new Date(
+    monday.getFullYear(),
+    monday.getMonth(),
+    monday.getDate() + 7,
+  );
+
+  return scheduledAts.filter((isoString) => {
+    const d = new Date(isoString);
+    return d >= monday && d < sunday;
+  }).length;
+}
+
+/**
+ * Calculate the number of days between two dates.
+ */
+export function daysBetween(isoString: string, referenceDate?: Date): number {
+  const ref = referenceDate ?? new Date();
+  const target = new Date(isoString);
+  const refStart = new Date(ref.getFullYear(), ref.getMonth(), ref.getDate());
+  const targetStart = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate(),
+  );
+  const diffMs = refStart.getTime() - targetStart.getTime();
+  return Math.round(diffMs / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Get the relative badge variant based on days until the schedule.
+ */
+export function getScheduleBadgeVariant(
+  isoString: string,
+): "success" | "warning" | "default" {
+  const label = getRelativeLabel(isoString);
+  if (label === "今日") return "success";
+  if (label === "明日") return "warning";
+  return "default";
+}
+
+/**
+ * Get the initial character of a name for avatar display.
+ */
+export function getNameInitial(name: string): string {
+  return name.charAt(0);
+}


### PR DESCRIPTION
Closes #142

## 既知の制約・TODO

- **N+1 クエリ**: `ListAllPendingActionItemsService` で record_id ごとに `get_by_id` を呼んでいる。limit=200 で実害は小さいが、将来的に `get_by_ids` バッチ取得への置換を検討（未読管理系 Issue で対応予定）
- **overdueCount = 0 固定**: アクションアイテムの due_date フィールドが未実装のためハードコード。#148 で解消予定