### PR TITLE
フロントエンド: 準備画面の実装

### DIFF
--- a/frontend/src/features/dashboard/types.ts
+++ b/frontend/src/features/dashboard/types.ts
@@ -5,6 +5,14 @@
  * across hooks and components.
  */
 
+// Re-export shared action item types for use within this feature.
+// Dashboard uses AllPendingActionItem (all-counterpart endpoint) but
+// aliases it as PendingActionItem for backward compatibility within this feature.
+export type {
+  AllPendingActionItem as PendingActionItem,
+  AllPendingActionItemsResponse as PendingActionItemsResponse,
+} from "@/types/action-item";
+
 export interface UpcomingScheduleItem {
   schedule_id: string;
   organizer_id: string;
@@ -30,19 +38,6 @@ export interface DraftRecordItem {
 
 export interface DraftRecordsResponse {
   items: DraftRecordItem[];
-}
-
-export interface PendingActionItem {
-  action_item_id: string;
-  content: string;
-  created_at: string;
-  record_id: string;
-  counterpart_id: string;
-  conducted_at: string;
-}
-
-export interface PendingActionItemsResponse {
-  items: PendingActionItem[];
 }
 
 export interface NotificationRecord {

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -1,51 +1,11 @@
 /**
  * Utility functions for the dashboard feature.
  * Separated from components to avoid react-refresh warnings.
+ *
+ * Date formatting utilities are re-exported from the shared utils/date module.
  */
 
-/**
- * Format an ISO datetime string to a localized Japanese date string.
- * e.g. "2026年4月3日（金）"
- */
-export function formatDateJa(isoString: string): string {
-  const date = new Date(isoString);
-  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const weekday = weekdays[date.getDay()];
-  return `${year}年${month}月${day}日（${weekday}）`;
-}
-
-/**
- * Format an ISO datetime string to time "HH:MM".
- */
-export function formatTime(isoString: string): string {
-  const date = new Date(isoString);
-  return `${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}`;
-}
-
-/**
- * Return a relative label like "今日", "明日", "2日後", "7日後".
- */
-export function getRelativeLabel(isoString: string): string {
-  const now = new Date();
-  const target = new Date(isoString);
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const targetStart = new Date(
-    target.getFullYear(),
-    target.getMonth(),
-    target.getDate(),
-  );
-  const diffMs = targetStart.getTime() - todayStart.getTime();
-  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) return "今日";
-  if (diffDays === 1) return "明日";
-  if (diffDays > 1) return `${diffDays}日後`;
-  if (diffDays === -1) return "昨日";
-  return `${Math.abs(diffDays)}日前`;
-}
+export { getRelativeLabel, formatDateJa, formatTime } from "@/utils/date";
 
 /**
  * Count schedules within the current week (Monday to Sunday).

--- a/frontend/src/features/preparation/__tests__/PreparationPage.test.tsx
+++ b/frontend/src/features/preparation/__tests__/PreparationPage.test.tsx
@@ -403,4 +403,125 @@ describe("PreparationPage", () => {
     renderPage();
     expect(screen.getByText("1on1の開始に失敗しました")).toBeInTheDocument();
   });
+
+  // -- Input preserved on error ---------------------------------------------
+
+  it("does not clear agenda input when addAgenda fails", async () => {
+    mockAddAgenda.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const input = screen.getByPlaceholderText("アジェンダを追加...");
+    await user.type(input, "失敗するアジェンダ");
+    const addButton = screen.getByRole("button", { name: "追加" });
+    await user.click(addButton);
+
+    await waitFor(() => {
+      expect(mockAddAgenda).toHaveBeenCalledWith("失敗するアジェンダ");
+    });
+
+    expect(input).toHaveValue("失敗するアジェンダ");
+  });
+
+  it("clears agenda input when addAgenda succeeds", async () => {
+    mockAddAgenda.mockResolvedValueOnce({ agenda_id: "a-new" });
+    const user = userEvent.setup();
+    renderPage();
+
+    const input = screen.getByPlaceholderText("アジェンダを追加...");
+    await user.type(input, "成功するアジェンダ");
+    const addButton = screen.getByRole("button", { name: "追加" });
+    await user.click(addButton);
+
+    await waitFor(() => {
+      expect(input).toHaveValue("");
+    });
+  });
+
+  it("does not clear comment input when addComment fails", async () => {
+    mockAddComment.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    // Open comment thread for the second agenda (has 1 comment)
+    const commentButtons = screen.getAllByRole("button", {
+      name: /^(\d+|コメント)$/,
+    });
+    const commentToggle = commentButtons.find((btn) => btn.textContent === "1");
+    await user.click(commentToggle!);
+
+    const commentInput = screen.getByPlaceholderText("コメントを追加...");
+    await user.type(commentInput, "失敗するコメント");
+    const submitButton = screen.getByRole("button", { name: "送信" });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockAddComment).toHaveBeenCalled();
+    });
+
+    expect(commentInput).toHaveValue("失敗するコメント");
+  });
+
+  // -- Mutation error display -----------------------------------------------
+
+  it("shows addAgenda error message", () => {
+    addAgendaReturn = {
+      ...addAgendaReturn,
+      error: "アジェンダの追加に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("アジェンダの追加に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows deleteAgenda error message", () => {
+    deleteAgendaReturn = {
+      ...deleteAgendaReturn,
+      error: "アジェンダの削除に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("アジェンダの削除に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows addComment error message in comment thread", async () => {
+    addAgendaCommentReturn = {
+      ...addAgendaCommentReturn,
+      error: "コメントの追加に失敗しました (500)",
+    };
+
+    const user = userEvent.setup();
+    renderPage();
+
+    // Open comment thread
+    const commentButtons = screen.getAllByRole("button", {
+      name: /^(\d+|コメント)$/,
+    });
+    const commentToggle = commentButtons.find((btn) => btn.textContent === "1");
+    await user.click(commentToggle!);
+
+    expect(
+      screen.getByText("コメントの追加に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Start button disabled on schedule error ------------------------------
+
+  it("disables start button when schedule fetch fails", () => {
+    scheduleDetailReturn = {
+      ...scheduleDetailReturn,
+      schedule: null,
+      error: "スケジュールの取得に失敗しました",
+    };
+
+    renderPage();
+    const startButton = screen.getByRole("button", {
+      name: "1on1 を開始する",
+    });
+    expect(startButton).toBeDisabled();
+  });
 });

--- a/frontend/src/features/preparation/__tests__/PreparationPage.test.tsx
+++ b/frontend/src/features/preparation/__tests__/PreparationPage.test.tsx
@@ -1,0 +1,406 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PreparationPage } from "../pages/PreparationPage";
+import type { ScheduleDetail, AgendaItem, PendingActionItem } from "../types";
+
+// -- Mock data ----------------------------------------------------------------
+
+const mockSchedule: ScheduleDetail = {
+  schedule_id: "s1",
+  organizer_id: "org-user-id-00001",
+  counterpart_id: "cp-user-id-000001",
+  title: "Weekly 1on1 -- Tanaka",
+  scheduled_at: new Date(Date.now() + 3 * 86400000).toISOString(),
+  status: "confirmed",
+  schedule_group_id: null,
+  created_at: "2026-03-20T10:00:00Z",
+  updated_at: "2026-03-20T10:00:00Z",
+};
+
+const mockAgendas: AgendaItem[] = [
+  {
+    agenda_id: "a1",
+    topic: "前回のアクションアイテム確認",
+    added_by: "org-user-id-00001",
+    added_by_tag: "template",
+    comments: [],
+    created_at: "2026-03-20T10:00:00Z",
+  },
+  {
+    agenda_id: "a2",
+    topic: "来季の目標設定",
+    added_by: "cp-user-id-000001",
+    added_by_tag: "counterpart",
+    comments: [
+      {
+        comment_id: "c1",
+        author_id: "cp-user-id-000001",
+        body: "現在の達成率は60%ほどです。",
+        created_at: "2026-03-31T10:00:00Z",
+      },
+    ],
+    created_at: "2026-03-20T10:00:00Z",
+  },
+];
+
+const mockPendingItems: PendingActionItem[] = [
+  {
+    action_item_id: "ai1",
+    content: "進捗共有メールを送る",
+    created_at: "2026-03-20T10:00:00Z",
+    record_id: "r1",
+    organizer_id: "org-user-id-00001",
+    conducted_at: "2026-03-20T10:00:00Z",
+  },
+];
+
+// -- Mock hooks ---------------------------------------------------------------
+
+let scheduleDetailReturn = {
+  schedule: mockSchedule as ScheduleDetail | null,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+let scheduleAgendasReturn = {
+  agendas: mockAgendas,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+const mockAddAgenda = vi.fn().mockResolvedValue({ agenda_id: "a3" });
+let addAgendaReturn = {
+  addAgenda: mockAddAgenda,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockDeleteAgenda = vi.fn().mockResolvedValue(true);
+let deleteAgendaReturn = {
+  deleteAgenda: mockDeleteAgenda,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockAddComment = vi.fn().mockResolvedValue({ comment_id: "c2" });
+let addAgendaCommentReturn = {
+  addComment: mockAddComment,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+let pendingActionItemsReturn = {
+  items: mockPendingItems,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+const mockStartSession = vi.fn().mockResolvedValue({ record_id: "rec-001" });
+let startSessionReturn = {
+  startSession: mockStartSession,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+vi.mock("../hooks/useScheduleDetail", () => ({
+  useScheduleDetail: () => scheduleDetailReturn,
+}));
+
+vi.mock("../hooks/useScheduleAgendas", () => ({
+  useScheduleAgendas: () => scheduleAgendasReturn,
+}));
+
+vi.mock("../hooks/useAddAgenda", () => ({
+  useAddAgenda: () => addAgendaReturn,
+}));
+
+vi.mock("../hooks/useDeleteAgenda", () => ({
+  useDeleteAgenda: () => deleteAgendaReturn,
+}));
+
+vi.mock("../hooks/useAddAgendaComment", () => ({
+  useAddAgendaComment: () => addAgendaCommentReturn,
+}));
+
+vi.mock("../hooks/usePendingActionItems", () => ({
+  usePendingActionItems: () => pendingActionItemsReturn,
+}));
+
+vi.mock("../hooks/useStartSession", () => ({
+  useStartSession: () => startSessionReturn,
+}));
+
+// -- Helpers ------------------------------------------------------------------
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/schedules/s1/preparation"]}>
+      <Routes>
+        <Route
+          path="schedules/:scheduleId/preparation"
+          element={<PreparationPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("PreparationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scheduleDetailReturn = {
+      schedule: mockSchedule,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    scheduleAgendasReturn = {
+      agendas: mockAgendas,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    addAgendaReturn = {
+      addAgenda: mockAddAgenda,
+      isSubmitting: false,
+      error: null,
+    };
+    deleteAgendaReturn = {
+      deleteAgenda: mockDeleteAgenda,
+      isSubmitting: false,
+      error: null,
+    };
+    addAgendaCommentReturn = {
+      addComment: mockAddComment,
+      isSubmitting: false,
+      error: null,
+    };
+    pendingActionItemsReturn = {
+      items: mockPendingItems,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    startSessionReturn = {
+      startSession: mockStartSession,
+      isSubmitting: false,
+      error: null,
+    };
+  });
+
+  // -- Normal data display --------------------------------------------------
+
+  it("renders the schedule title", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Weekly 1on1 -- Tanaka/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the basic info card", () => {
+    renderPage();
+    expect(screen.getByText("基本情報")).toBeInTheDocument();
+    expect(screen.getByText("confirmed")).toBeInTheDocument();
+  });
+
+  it("renders agenda items", () => {
+    renderPage();
+    expect(screen.getByText("アジェンダ")).toBeInTheDocument();
+    expect(
+      screen.getByText("前回のアクションアイテム確認"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("来季の目標設定")).toBeInTheDocument();
+  });
+
+  it("renders agenda tags", () => {
+    renderPage();
+    expect(screen.getByText("テンプレート")).toBeInTheDocument();
+    expect(screen.getByText("カウンターパートが追加")).toBeInTheDocument();
+  });
+
+  it("renders pending action items", () => {
+    renderPage();
+    expect(screen.getByText("未完了アクションアイテム")).toBeInTheDocument();
+    expect(screen.getByText("進捗共有メールを送る")).toBeInTheDocument();
+  });
+
+  it("renders the start session button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: "1on1 を開始する" }),
+    ).toBeInTheDocument();
+  });
+
+  // -- Loading state --------------------------------------------------------
+
+  it("shows loading skeletons when schedule is loading", () => {
+    scheduleDetailReturn = {
+      ...scheduleDetailReturn,
+      schedule: null,
+      isLoading: true,
+    };
+    scheduleAgendasReturn = {
+      ...scheduleAgendasReturn,
+      agendas: [],
+      isLoading: true,
+    };
+    pendingActionItemsReturn = {
+      ...pendingActionItemsReturn,
+      items: [],
+      isLoading: true,
+    };
+
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  // -- Error state ----------------------------------------------------------
+
+  it("shows error messages when API calls fail", () => {
+    scheduleDetailReturn = {
+      ...scheduleDetailReturn,
+      schedule: null,
+      error: "スケジュールの取得に失敗しました",
+    };
+    scheduleAgendasReturn = {
+      ...scheduleAgendasReturn,
+      agendas: [],
+      error: "アジェンダの取得に失敗しました",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("スケジュールの取得に失敗しました"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("アジェンダの取得に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Add agenda -----------------------------------------------------------
+
+  it("calls addAgenda when submitting a new agenda", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const input = screen.getByPlaceholderText("アジェンダを追加...");
+    await user.type(input, "新しいアジェンダ");
+    const addButton = screen.getByRole("button", { name: "追加" });
+    await user.click(addButton);
+
+    expect(mockAddAgenda).toHaveBeenCalledWith("新しいアジェンダ");
+  });
+
+  // -- Delete agenda --------------------------------------------------------
+
+  it("calls deleteAgenda when clicking delete button", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const deleteButtons = screen.getAllByRole("button", {
+      name: /を削除$/,
+    });
+    await user.click(deleteButtons[0]);
+
+    expect(mockDeleteAgenda).toHaveBeenCalledWith("a1");
+  });
+
+  // -- Start session --------------------------------------------------------
+
+  it("navigates to recording page when starting session", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const startButton = screen.getByRole("button", {
+      name: "1on1 を開始する",
+    });
+    await user.click(startButton);
+
+    await waitFor(() => {
+      expect(mockStartSession).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/records/rec-001/recording");
+    });
+  });
+
+  // -- Comment display ------------------------------------------------------
+
+  it("shows comments when clicking comment toggle", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // The second agenda has 1 comment; its comment toggle button shows "1"
+    const commentButtons = screen.getAllByRole("button", {
+      name: /^(\d+|コメント)$/,
+    });
+    // Click the one for "来季の目標設定" which has 1 comment
+    const commentToggle = commentButtons.find((btn) => btn.textContent === "1");
+    expect(commentToggle).toBeDefined();
+    await user.click(commentToggle!);
+
+    expect(screen.getByText("現在の達成率は60%ほどです。")).toBeInTheDocument();
+  });
+
+  // -- Empty state ----------------------------------------------------------
+
+  it("shows empty message when no agendas", () => {
+    scheduleAgendasReturn = {
+      ...scheduleAgendasReturn,
+      agendas: [],
+    };
+
+    renderPage();
+    expect(screen.getByText("アジェンダはまだありません")).toBeInTheDocument();
+  });
+
+  it("shows empty message when no pending action items", () => {
+    pendingActionItemsReturn = {
+      ...pendingActionItemsReturn,
+      items: [],
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("未完了のアクションアイテムはありません"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Start session error --------------------------------------------------
+
+  it("shows error when start session fails", () => {
+    startSessionReturn = {
+      ...startSessionReturn,
+      error: "1on1の開始に失敗しました",
+    };
+
+    renderPage();
+    expect(screen.getByText("1on1の開始に失敗しました")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/preparation/__tests__/hooks.test.ts
+++ b/frontend/src/features/preparation/__tests__/hooks.test.ts
@@ -1,0 +1,391 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApiError } from "@/api/client";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("@/api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    apiClient: {
+      get: (...args: unknown[]) => mockGet(...args),
+      post: (...args: unknown[]) => mockPost(...args),
+      delete: (...args: unknown[]) => mockDelete(...args),
+    },
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// -- useScheduleDetail --------------------------------------------------------
+
+describe("useScheduleDetail", () => {
+  it("fetches schedule detail on mount and returns data", async () => {
+    const mockSchedule = {
+      schedule_id: "s1",
+      organizer_id: "org1",
+      counterpart_id: "cp1",
+      title: "Test 1on1",
+      scheduled_at: "2026-04-01T10:00:00Z",
+      status: "confirmed",
+      schedule_group_id: null,
+      created_at: "2026-03-20T10:00:00Z",
+      updated_at: "2026-03-20T10:00:00Z",
+    };
+    mockGet.mockResolvedValueOnce(mockSchedule);
+
+    const { useScheduleDetail } = await import("../hooks/useScheduleDetail");
+    const { result } = renderHook(() => useScheduleDetail("s1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith("/schedules/s1", TEST_USER_ID);
+    expect(result.current.schedule).toEqual(mockSchedule);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when API call fails with ApiError", async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(404, "Not Found", {}));
+
+    const { useScheduleDetail } = await import("../hooks/useScheduleDetail");
+    const { result } = renderHook(() => useScheduleDetail("s1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.schedule).toBeNull();
+    expect(result.current.error).toBe("スケジュールの取得に失敗しました (404)");
+  });
+
+  it("sets generic error when a non-ApiError is thrown", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network failure"));
+
+    const { useScheduleDetail } = await import("../hooks/useScheduleDetail");
+    const { result } = renderHook(() => useScheduleDetail("s1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("スケジュールの取得に失敗しました");
+  });
+});
+
+// -- useScheduleAgendas -------------------------------------------------------
+
+describe("useScheduleAgendas", () => {
+  it("fetches agendas on mount and returns data", async () => {
+    const mockAgendas = {
+      agendas: [
+        {
+          agenda_id: "a1",
+          topic: "Topic 1",
+          added_by: "org1",
+          added_by_tag: "organizer",
+          comments: [],
+          created_at: "2026-03-20T10:00:00Z",
+        },
+      ],
+    };
+    mockGet.mockResolvedValueOnce(mockAgendas);
+
+    const { useScheduleAgendas } = await import("../hooks/useScheduleAgendas");
+    const { result } = renderHook(() => useScheduleAgendas("s1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith("/schedules/s1/agendas", TEST_USER_ID);
+    expect(result.current.agendas).toEqual(mockAgendas.agendas);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when API call fails with ApiError", async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(500, "Server Error", {}));
+
+    const { useScheduleAgendas } = await import("../hooks/useScheduleAgendas");
+    const { result } = renderHook(() => useScheduleAgendas("s1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.agendas).toEqual([]);
+    expect(result.current.error).toBe("アジェンダの取得に失敗しました (500)");
+  });
+
+  it("sets generic error when a non-ApiError is thrown", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network failure"));
+
+    const { useScheduleAgendas } = await import("../hooks/useScheduleAgendas");
+    const { result } = renderHook(() => useScheduleAgendas("s1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("アジェンダの取得に失敗しました");
+  });
+});
+
+// -- useAddAgenda -------------------------------------------------------------
+
+describe("useAddAgenda", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { agenda_id: "a-new" };
+    mockPost.mockResolvedValueOnce(mockResponse);
+
+    const { useAddAgenda } = await import("../hooks/useAddAgenda");
+    const { result } = renderHook(() => useAddAgenda("s1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.addAgenda("New topic");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/schedules/s1/agendas",
+      TEST_USER_ID,
+      {
+        topic: "New topic",
+      },
+    );
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useAddAgenda } = await import("../hooks/useAddAgenda");
+    const { result } = renderHook(() => useAddAgenda("s1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.addAgenda("Bad topic");
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("アジェンダの追加に失敗しました (400)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new Error("network"));
+
+    const { useAddAgenda } = await import("../hooks/useAddAgenda");
+    const { result } = renderHook(() => useAddAgenda("s1"));
+
+    await act(async () => {
+      await result.current.addAgenda("topic");
+    });
+
+    expect(result.current.error).toBe("アジェンダの追加に失敗しました");
+  });
+});
+
+// -- useDeleteAgenda ----------------------------------------------------------
+
+describe("useDeleteAgenda", () => {
+  it("calls API and returns true on success", async () => {
+    mockDelete.mockResolvedValueOnce(undefined);
+
+    const { useDeleteAgenda } = await import("../hooks/useDeleteAgenda");
+    const { result } = renderHook(() => useDeleteAgenda("s1"));
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.deleteAgenda("a1");
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/schedules/s1/agendas/a1",
+      TEST_USER_ID,
+    );
+    expect(success).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns false on ApiError", async () => {
+    mockDelete.mockRejectedValueOnce(new ApiError(403, "Forbidden", {}));
+
+    const { useDeleteAgenda } = await import("../hooks/useDeleteAgenda");
+    const { result } = renderHook(() => useDeleteAgenda("s1"));
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.deleteAgenda("a1");
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe("アジェンダの削除に失敗しました (403)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockDelete.mockRejectedValueOnce(new Error("network"));
+
+    const { useDeleteAgenda } = await import("../hooks/useDeleteAgenda");
+    const { result } = renderHook(() => useDeleteAgenda("s1"));
+
+    await act(async () => {
+      await result.current.deleteAgenda("a1");
+    });
+
+    expect(result.current.error).toBe("アジェンダの削除に失敗しました");
+  });
+});
+
+// -- useAddAgendaComment ------------------------------------------------------
+
+describe("useAddAgendaComment", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { comment_id: "c-new" };
+    mockPost.mockResolvedValueOnce(mockResponse);
+
+    const { useAddAgendaComment } =
+      await import("../hooks/useAddAgendaComment");
+    const { result } = renderHook(() => useAddAgendaComment());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.addComment("a1", "Great point");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/agendas/a1/comments",
+      TEST_USER_ID,
+      { body: "Great point" },
+    );
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(422, "Unprocessable", {}));
+
+    const { useAddAgendaComment } =
+      await import("../hooks/useAddAgendaComment");
+    const { result } = renderHook(() => useAddAgendaComment());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.addComment("a1", "");
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("コメントの追加に失敗しました (422)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new Error("network"));
+
+    const { useAddAgendaComment } =
+      await import("../hooks/useAddAgendaComment");
+    const { result } = renderHook(() => useAddAgendaComment());
+
+    await act(async () => {
+      await result.current.addComment("a1", "body");
+    });
+
+    expect(result.current.error).toBe("コメントの追加に失敗しました");
+  });
+});
+
+// -- usePendingActionItems ----------------------------------------------------
+
+describe("usePendingActionItems", () => {
+  it("fetches pending items on mount and returns data", async () => {
+    const mockItems = {
+      items: [
+        {
+          action_item_id: "ai1",
+          content: "Follow up on report",
+          created_at: "2026-03-20T10:00:00Z",
+          record_id: "r1",
+          organizer_id: "org1",
+          conducted_at: "2026-03-20T10:00:00Z",
+        },
+      ],
+    };
+    mockGet.mockResolvedValueOnce(mockItems);
+
+    const { usePendingActionItems } =
+      await import("../hooks/usePendingActionItems");
+    const { result } = renderHook(() => usePendingActionItems("cp1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/action-items/pending/cp1",
+      TEST_USER_ID,
+    );
+    expect(result.current.items).toEqual(mockItems.items);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns empty items when counterpartId is null", async () => {
+    const { usePendingActionItems } =
+      await import("../hooks/usePendingActionItems");
+    const { result } = renderHook(() => usePendingActionItems(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("sets error when API call fails with ApiError", async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(500, "Server Error", {}));
+
+    const { usePendingActionItems } =
+      await import("../hooks/usePendingActionItems");
+    const { result } = renderHook(() => usePendingActionItems("cp1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.error).toBe(
+      "アクションアイテムの取得に失敗しました (500)",
+    );
+  });
+
+  it("sets generic error when a non-ApiError is thrown", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network failure"));
+
+    const { usePendingActionItems } =
+      await import("../hooks/usePendingActionItems");
+    const { result } = renderHook(() => usePendingActionItems("cp1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("アクションアイテムの取得に失敗しました");
+  });
+});

--- a/frontend/src/features/preparation/components/AgendaCommentThread.tsx
+++ b/frontend/src/features/preparation/components/AgendaCommentThread.tsx
@@ -6,22 +6,26 @@ import { formatCommentDate } from "../utils";
 
 interface AgendaCommentThreadProps {
   comments: AgendaComment[];
-  onAddComment: (body: string) => Promise<void>;
+  onAddComment: (body: string) => Promise<boolean>;
   isSubmitting: boolean;
+  error?: string | null;
 }
 
 export function AgendaCommentThread({
   comments,
   onAddComment,
   isSubmitting,
+  error,
 }: AgendaCommentThreadProps) {
   const [commentText, setCommentText] = useState("");
 
   const handleSubmit = async () => {
     const trimmed = commentText.trim();
     if (!trimmed) return;
-    await onAddComment(trimmed);
-    setCommentText("");
+    const success = await onAddComment(trimmed);
+    if (success) {
+      setCommentText("");
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -47,6 +51,11 @@ export function AgendaCommentThread({
           </div>
         </div>
       ))}
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
       <div className="flex gap-2">
         <Input
           value={commentText}

--- a/frontend/src/features/preparation/components/AgendaCommentThread.tsx
+++ b/frontend/src/features/preparation/components/AgendaCommentThread.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { AgendaComment } from "../types";
+import { formatCommentDate } from "../utils";
+
+interface AgendaCommentThreadProps {
+  comments: AgendaComment[];
+  onAddComment: (body: string) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+export function AgendaCommentThread({
+  comments,
+  onAddComment,
+  isSubmitting,
+}: AgendaCommentThreadProps) {
+  const [commentText, setCommentText] = useState("");
+
+  const handleSubmit = async () => {
+    const trimmed = commentText.trim();
+    if (!trimmed) return;
+    await onAddComment(trimmed);
+    setCommentText("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleSubmit();
+    }
+  };
+
+  return (
+    <div className="mt-2 space-y-2 border-t pt-2">
+      {comments.map((comment) => (
+        <div key={comment.comment_id} className="flex items-start gap-2">
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium">
+            {comment.author_id.slice(0, 1).toUpperCase()}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-xs text-muted-foreground">
+              {comment.author_id.slice(0, 8)}{" "}
+              {formatCommentDate(comment.created_at)}
+            </div>
+            <div className="text-sm">{comment.body}</div>
+          </div>
+        </div>
+      ))}
+      <div className="flex gap-2">
+        <Input
+          value={commentText}
+          onChange={(e) => setCommentText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="コメントを追加..."
+          className="flex-1"
+          disabled={isSubmitting}
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => void handleSubmit()}
+          disabled={isSubmitting || !commentText.trim()}
+        >
+          送信
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/preparation/components/AgendaList.tsx
+++ b/frontend/src/features/preparation/components/AgendaList.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { AgendaItem } from "../types";
+import { getAddedByTagLabel } from "../utils";
+import { AgendaCommentThread } from "./AgendaCommentThread";
+
+interface AgendaListProps {
+  agendas: AgendaItem[];
+  isLoading: boolean;
+  error: string | null;
+  onAddAgenda: (topic: string) => Promise<void>;
+  onDeleteAgenda: (agendaId: string) => Promise<void>;
+  onAddComment: (agendaId: string, body: string) => Promise<void>;
+  isAddingAgenda: boolean;
+  isAddingComment: boolean;
+}
+
+export function AgendaList({
+  agendas,
+  isLoading,
+  error,
+  onAddAgenda,
+  onDeleteAgenda,
+  onAddComment,
+  isAddingAgenda,
+  isAddingComment,
+}: AgendaListProps) {
+  const [newTopic, setNewTopic] = useState("");
+  const [expandedAgendaIds, setExpandedAgendaIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const handleAddAgenda = async () => {
+    const trimmed = newTopic.trim();
+    if (!trimmed) return;
+    await onAddAgenda(trimmed);
+    setNewTopic("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleAddAgenda();
+    }
+  };
+
+  const toggleComments = (agendaId: string) => {
+    setExpandedAgendaIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(agendaId)) {
+        next.delete(agendaId);
+      } else {
+        next.add(agendaId);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>アジェンダ</CardTitle>
+        <CardDescription>
+          オーガナイザー・カウンターパートどちらでも追加・コメント可
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="animate-pulse flex items-center gap-3">
+                <div className="flex-1 space-y-1">
+                  <div className="h-4 w-48 rounded bg-muted" />
+                  <div className="h-3 w-24 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!isLoading && !error && (
+          <div className="space-y-2">
+            {agendas.map((agenda) => (
+              <div key={agenda.agenda_id} className="rounded-md border p-3">
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium">{agenda.topic}</span>
+                    <span className="ml-2 inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                      {getAddedByTagLabel(agenda.added_by_tag)}
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => toggleComments(agenda.agenda_id)}
+                  >
+                    {agenda.comments.length > 0
+                      ? `${agenda.comments.length}`
+                      : "コメント"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => void onDeleteAgenda(agenda.agenda_id)}
+                    aria-label={`${agenda.topic}を削除`}
+                  >
+                    x
+                  </Button>
+                </div>
+                {expandedAgendaIds.has(agenda.agenda_id) && (
+                  <AgendaCommentThread
+                    comments={agenda.comments}
+                    onAddComment={(body) =>
+                      onAddComment(agenda.agenda_id, body)
+                    }
+                    isSubmitting={isAddingComment}
+                  />
+                )}
+              </div>
+            ))}
+            {agendas.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                アジェンダはまだありません
+              </p>
+            )}
+            <div className="flex gap-2 pt-2">
+              <Input
+                value={newTopic}
+                onChange={(e) => setNewTopic(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="アジェンダを追加..."
+                className="flex-1"
+                disabled={isAddingAgenda}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleAddAgenda()}
+                disabled={isAddingAgenda || !newTopic.trim()}
+              >
+                追加
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/preparation/components/AgendaList.tsx
+++ b/frontend/src/features/preparation/components/AgendaList.tsx
@@ -16,11 +16,14 @@ interface AgendaListProps {
   agendas: AgendaItem[];
   isLoading: boolean;
   error: string | null;
-  onAddAgenda: (topic: string) => Promise<void>;
+  onAddAgenda: (topic: string) => Promise<boolean>;
   onDeleteAgenda: (agendaId: string) => Promise<void>;
-  onAddComment: (agendaId: string, body: string) => Promise<void>;
+  onAddComment: (agendaId: string, body: string) => Promise<boolean>;
   isAddingAgenda: boolean;
   isAddingComment: boolean;
+  addAgendaError?: string | null;
+  deleteAgendaError?: string | null;
+  addCommentError?: string | null;
 }
 
 export function AgendaList({
@@ -32,6 +35,9 @@ export function AgendaList({
   onAddComment,
   isAddingAgenda,
   isAddingComment,
+  addAgendaError,
+  deleteAgendaError,
+  addCommentError,
 }: AgendaListProps) {
   const [newTopic, setNewTopic] = useState("");
   const [expandedAgendaIds, setExpandedAgendaIds] = useState<Set<string>>(
@@ -41,8 +47,10 @@ export function AgendaList({
   const handleAddAgenda = async () => {
     const trimmed = newTopic.trim();
     if (!trimmed) return;
-    await onAddAgenda(trimmed);
-    setNewTopic("");
+    const success = await onAddAgenda(trimmed);
+    if (success) {
+      setNewTopic("");
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -122,6 +130,7 @@ export function AgendaList({
                       onAddComment(agenda.agenda_id, body)
                     }
                     isSubmitting={isAddingComment}
+                    error={addCommentError}
                   />
                 )}
               </div>
@@ -129,6 +138,16 @@ export function AgendaList({
             {agendas.length === 0 && (
               <p className="text-sm text-muted-foreground">
                 アジェンダはまだありません
+              </p>
+            )}
+            {deleteAgendaError && (
+              <p className="text-sm text-destructive" role="alert">
+                {deleteAgendaError}
+              </p>
+            )}
+            {addAgendaError && (
+              <p className="text-sm text-destructive" role="alert">
+                {addAgendaError}
               </p>
             )}
             <div className="flex gap-2 pt-2">

--- a/frontend/src/features/preparation/components/PendingActionItemList.tsx
+++ b/frontend/src/features/preparation/components/PendingActionItemList.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PendingActionItem } from "../types";
+import { formatDateShort } from "../utils";
+
+interface PendingActionItemListProps {
+  items: PendingActionItem[];
+  isLoading: boolean;
+  error: string | null;
+  onAddToAgenda: (content: string) => void;
+}
+
+export function PendingActionItemList({
+  items,
+  isLoading,
+  error,
+  onAddToAgenda,
+}: PendingActionItemListProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>未完了アクションアイテム</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1].map((i) => (
+              <div key={i} className="animate-pulse flex items-center gap-3">
+                <div className="flex-1 space-y-1">
+                  <div className="h-4 w-48 rounded bg-muted" />
+                  <div className="h-3 w-32 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!isLoading && !error && items.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            未完了のアクションアイテムはありません
+          </p>
+        )}
+        {!isLoading && !error && items.length > 0 && (
+          <div className="space-y-2">
+            {items.map((item) => (
+              <div
+                key={item.action_item_id}
+                className="flex items-center gap-3 rounded-md border p-3"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium">{item.content}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatDateShort(item.conducted_at)}の1on1から
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onAddToAgenda(item.content)}
+                >
+                  アジェンダに追加
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/preparation/components/ScheduleInfoCard.tsx
+++ b/frontend/src/features/preparation/components/ScheduleInfoCard.tsx
@@ -1,0 +1,87 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ScheduleDetail } from "../types";
+import { formatScheduleDateTime } from "../utils";
+
+interface ScheduleInfoCardProps {
+  schedule: ScheduleDetail | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function ScheduleInfoCard({
+  schedule,
+  isLoading,
+  error,
+}: ScheduleInfoCardProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>基本情報</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="animate-pulse">
+                <div className="h-3 w-20 rounded bg-muted mb-1" />
+                <div className="h-4 w-40 rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>基本情報</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">{error}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!schedule) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>基本情報</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <div>
+            <div className="text-xs text-muted-foreground">日時</div>
+            <div className="text-sm font-medium">
+              {formatScheduleDateTime(schedule.scheduled_at)}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">ステータス</div>
+            <div className="text-sm font-medium">{schedule.status}</div>
+          </div>
+        </div>
+        <div className="mt-4 border-t pt-4">
+          <div className="text-xs text-muted-foreground mb-2">参加者</div>
+          <div className="flex gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs">
+              {schedule.organizer_id.slice(0, 8)}
+              <span className="text-muted-foreground">オーガナイザー</span>
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs">
+              {schedule.counterpart_id.slice(0, 8)}
+              <span className="text-muted-foreground">カウンターパート</span>
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/preparation/components/ScheduleInfoCard.tsx
+++ b/frontend/src/features/preparation/components/ScheduleInfoCard.tsx
@@ -56,11 +56,25 @@ export function ScheduleInfoCard({
         <CardTitle>基本情報</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           <div>
             <div className="text-xs text-muted-foreground">日時</div>
             <div className="text-sm font-medium">
               {formatScheduleDateTime(schedule.scheduled_at)}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">所要時間</div>
+            <div className="text-sm font-medium">
+              {schedule.duration_minutes != null
+                ? `${schedule.duration_minutes}分`
+                : "-"}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">繰り返し</div>
+            <div className="text-sm font-medium">
+              {schedule.recurrence ?? "-"}
             </div>
           </div>
           <div>

--- a/frontend/src/features/preparation/hooks/useAddAgenda.ts
+++ b/frontend/src/features/preparation/hooks/useAddAgenda.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { AddAgendaResponse } from "../types";
+
+interface UseAddAgendaResult {
+  addAgenda: (topic: string) => Promise<AddAgendaResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useAddAgenda(scheduleId: string): UseAddAgendaResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addAgenda = useCallback(
+    async (topic: string): Promise<AddAgendaResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.post<AddAgendaResponse>(
+          `/schedules/${scheduleId}/agendas`,
+          userId,
+          { topic },
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`アジェンダの追加に失敗しました (${e.status})`);
+        } else {
+          setError("アジェンダの追加に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [scheduleId, userId],
+  );
+
+  return { addAgenda, isSubmitting, error };
+}

--- a/frontend/src/features/preparation/hooks/useAddAgendaComment.ts
+++ b/frontend/src/features/preparation/hooks/useAddAgendaComment.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { AddAgendaCommentResponse } from "../types";
+
+interface UseAddAgendaCommentResult {
+  addComment: (
+    agendaId: string,
+    body: string,
+  ) => Promise<AddAgendaCommentResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useAddAgendaComment(): UseAddAgendaCommentResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addComment = useCallback(
+    async (
+      agendaId: string,
+      body: string,
+    ): Promise<AddAgendaCommentResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.post<AddAgendaCommentResponse>(
+          `/agendas/${agendaId}/comments`,
+          userId,
+          { body },
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`コメントの追加に失敗しました (${e.status})`);
+        } else {
+          setError("コメントの追加に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [userId],
+  );
+
+  return { addComment, isSubmitting, error };
+}

--- a/frontend/src/features/preparation/hooks/useDeleteAgenda.ts
+++ b/frontend/src/features/preparation/hooks/useDeleteAgenda.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+
+interface UseDeleteAgendaResult {
+  deleteAgenda: (agendaId: string) => Promise<boolean>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useDeleteAgenda(scheduleId: string): UseDeleteAgendaResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteAgenda = useCallback(
+    async (agendaId: string): Promise<boolean> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        await apiClient.delete<void>(
+          `/schedules/${scheduleId}/agendas/${agendaId}`,
+          userId,
+        );
+        return true;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`アジェンダの削除に失敗しました (${e.status})`);
+        } else {
+          setError("アジェンダの削除に失敗しました");
+        }
+        return false;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [scheduleId, userId],
+  );
+
+  return { deleteAgenda, isSubmitting, error };
+}

--- a/frontend/src/features/preparation/hooks/usePendingActionItems.ts
+++ b/frontend/src/features/preparation/hooks/usePendingActionItems.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { PendingActionItem, PendingActionItemsResponse } from "../types";
+
+interface UsePendingActionItemsResult {
+  items: PendingActionItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function usePendingActionItems(
+  counterpartId: string | null,
+): UsePendingActionItemsResult {
+  const { userId } = useCurrentUser();
+  const [items, setItems] = useState<PendingActionItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchItems = useCallback(async () => {
+    if (!counterpartId) {
+      setItems([]);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<PendingActionItemsResponse>(
+        `/action-items/pending/${counterpartId}`,
+        userId,
+      );
+      setItems(data.items);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`アクションアイテムの取得に失敗しました (${e.status})`);
+      } else {
+        setError("アクションアイテムの取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [counterpartId, userId]);
+
+  useEffect(() => {
+    void fetchItems();
+  }, [fetchItems]);
+
+  return { items, isLoading, error, refetch: fetchItems };
+}

--- a/frontend/src/features/preparation/hooks/useScheduleAgendas.ts
+++ b/frontend/src/features/preparation/hooks/useScheduleAgendas.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { AgendaItem, AgendasResponse } from "../types";
+
+interface UseScheduleAgendasResult {
+  agendas: AgendaItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useScheduleAgendas(
+  scheduleId: string,
+): UseScheduleAgendasResult {
+  const { userId } = useCurrentUser();
+  const [agendas, setAgendas] = useState<AgendaItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAgendas = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<AgendasResponse>(
+        `/schedules/${scheduleId}/agendas`,
+        userId,
+      );
+      setAgendas(data.agendas);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`アジェンダの取得に失敗しました (${e.status})`);
+      } else {
+        setError("アジェンダの取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [scheduleId, userId]);
+
+  useEffect(() => {
+    void fetchAgendas();
+  }, [fetchAgendas]);
+
+  return { agendas, isLoading, error, refetch: fetchAgendas };
+}

--- a/frontend/src/features/preparation/hooks/useScheduleDetail.ts
+++ b/frontend/src/features/preparation/hooks/useScheduleDetail.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { ScheduleDetail } from "../types";
+
+interface UseScheduleDetailResult {
+  schedule: ScheduleDetail | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useScheduleDetail(scheduleId: string): UseScheduleDetailResult {
+  const { userId } = useCurrentUser();
+  const [schedule, setSchedule] = useState<ScheduleDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSchedule = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<ScheduleDetail>(
+        `/schedules/${scheduleId}`,
+        userId,
+      );
+      setSchedule(data);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`スケジュールの取得に失敗しました (${e.status})`);
+      } else {
+        setError("スケジュールの取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [scheduleId, userId]);
+
+  useEffect(() => {
+    void fetchSchedule();
+  }, [fetchSchedule]);
+
+  return { schedule, isLoading, error, refetch: fetchSchedule };
+}

--- a/frontend/src/features/preparation/hooks/useStartSession.ts
+++ b/frontend/src/features/preparation/hooks/useStartSession.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { StartSessionResponse } from "../types";
+
+interface UseStartSessionResult {
+  startSession: (
+    scheduleId: string,
+    conductedAt: string,
+  ) => Promise<StartSessionResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useStartSession(): UseStartSessionResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startSession = useCallback(
+    async (
+      scheduleId: string,
+      conductedAt: string,
+    ): Promise<StartSessionResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.post<StartSessionResponse>(
+          `/records/from-schedule`,
+          userId,
+          { schedule_id: scheduleId, conducted_at: conductedAt },
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`1on1の開始に失敗しました (${e.status})`);
+        } else {
+          setError("1on1の開始に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [userId],
+  );
+
+  return { startSession, isSubmitting, error };
+}

--- a/frontend/src/features/preparation/pages/PreparationPage.tsx
+++ b/frontend/src/features/preparation/pages/PreparationPage.tsx
@@ -1,12 +1,147 @@
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
+import { Button } from "@/components/ui/button";
+import { useScheduleDetail } from "../hooks/useScheduleDetail";
+import { useScheduleAgendas } from "../hooks/useScheduleAgendas";
+import { useAddAgenda } from "../hooks/useAddAgenda";
+import { useDeleteAgenda } from "../hooks/useDeleteAgenda";
+import { useAddAgendaComment } from "../hooks/useAddAgendaComment";
+import { usePendingActionItems } from "../hooks/usePendingActionItems";
+import { useStartSession } from "../hooks/useStartSession";
+import { ScheduleInfoCard } from "../components/ScheduleInfoCard";
+import { AgendaList } from "../components/AgendaList";
+import { PendingActionItemList } from "../components/PendingActionItemList";
+import { getRelativeLabel } from "../utils";
 
 export function PreparationPage() {
   const { scheduleId } = useParams<{ scheduleId: string }>();
+  const navigate = useNavigate();
+
+  const {
+    schedule,
+    isLoading: scheduleLoading,
+    error: scheduleError,
+  } = useScheduleDetail(scheduleId!);
+
+  const {
+    agendas,
+    isLoading: agendasLoading,
+    error: agendasError,
+    refetch: refetchAgendas,
+  } = useScheduleAgendas(scheduleId!);
+
+  const { addAgenda, isSubmitting: isAddingAgenda } = useAddAgenda(scheduleId!);
+
+  const { deleteAgenda } = useDeleteAgenda(scheduleId!);
+
+  const { addComment, isSubmitting: isAddingComment } = useAddAgendaComment();
+
+  const {
+    startSession,
+    isSubmitting: isStarting,
+    error: startError,
+  } = useStartSession();
+
+  // Determine counterpart_id from schedule for pending action items
+  const counterpartId = schedule?.counterpart_id ?? null;
+
+  const {
+    items: pendingItems,
+    isLoading: pendingLoading,
+    error: pendingError,
+  } = usePendingActionItems(counterpartId);
+
+  const handleAddAgenda = async (topic: string) => {
+    const result = await addAgenda(topic);
+    if (result) {
+      refetchAgendas();
+    }
+  };
+
+  const handleDeleteAgenda = async (agendaId: string) => {
+    const success = await deleteAgenda(agendaId);
+    if (success) {
+      refetchAgendas();
+    }
+  };
+
+  const handleAddComment = async (agendaId: string, body: string) => {
+    const result = await addComment(agendaId, body);
+    if (result) {
+      refetchAgendas();
+    }
+  };
+
+  const handleAddToAgenda = (content: string) => {
+    void handleAddAgenda(content);
+  };
+
+  const handleStartSession = async () => {
+    if (!scheduleId || !schedule) return;
+    const conductedAt = new Date().toISOString();
+    const result = await startSession(scheduleId, conductedAt);
+    if (result) {
+      void navigate(`/records/${result.record_id}/recording`);
+    }
+  };
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Preparation</h1>
-      <p className="mt-2 text-muted-foreground">Schedule ID: {scheduleId}</p>
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">
+            {schedule?.title ?? "準備画面"}
+          </h1>
+          {schedule && (
+            <p className="mt-1 text-muted-foreground">
+              {getRelativeLabel(schedule.scheduled_at)}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Schedule info */}
+      <ScheduleInfoCard
+        schedule={schedule}
+        isLoading={scheduleLoading}
+        error={scheduleError}
+      />
+
+      {/* Agenda list */}
+      <AgendaList
+        agendas={agendas}
+        isLoading={agendasLoading}
+        error={agendasError}
+        onAddAgenda={handleAddAgenda}
+        onDeleteAgenda={handleDeleteAgenda}
+        onAddComment={handleAddComment}
+        isAddingAgenda={isAddingAgenda}
+        isAddingComment={isAddingComment}
+      />
+
+      {/* Pending action items */}
+      <PendingActionItemList
+        items={pendingItems}
+        isLoading={pendingLoading}
+        error={pendingError}
+        onAddToAgenda={handleAddToAgenda}
+      />
+
+      {/* Start session */}
+      <div className="flex justify-end">
+        {startError && (
+          <p className="mr-4 self-center text-sm text-destructive">
+            {startError}
+          </p>
+        )}
+        <Button
+          size="lg"
+          onClick={() => void handleStartSession()}
+          disabled={isStarting || scheduleLoading}
+        >
+          {isStarting ? "開始中..." : "1on1 を開始する"}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/preparation/pages/PreparationPage.tsx
+++ b/frontend/src/features/preparation/pages/PreparationPage.tsx
@@ -29,11 +29,21 @@ export function PreparationPage() {
     refetch: refetchAgendas,
   } = useScheduleAgendas(scheduleId!);
 
-  const { addAgenda, isSubmitting: isAddingAgenda } = useAddAgenda(scheduleId!);
+  const {
+    addAgenda,
+    isSubmitting: isAddingAgenda,
+    error: addAgendaError,
+  } = useAddAgenda(scheduleId!);
 
-  const { deleteAgenda } = useDeleteAgenda(scheduleId!);
+  const { deleteAgenda, error: deleteAgendaError } = useDeleteAgenda(
+    scheduleId!,
+  );
 
-  const { addComment, isSubmitting: isAddingComment } = useAddAgendaComment();
+  const {
+    addComment,
+    isSubmitting: isAddingComment,
+    error: addCommentError,
+  } = useAddAgendaComment();
 
   const {
     startSession,
@@ -50,11 +60,13 @@ export function PreparationPage() {
     error: pendingError,
   } = usePendingActionItems(counterpartId);
 
-  const handleAddAgenda = async (topic: string) => {
+  const handleAddAgenda = async (topic: string): Promise<boolean> => {
     const result = await addAgenda(topic);
     if (result) {
       refetchAgendas();
+      return true;
     }
+    return false;
   };
 
   const handleDeleteAgenda = async (agendaId: string) => {
@@ -64,11 +76,16 @@ export function PreparationPage() {
     }
   };
 
-  const handleAddComment = async (agendaId: string, body: string) => {
+  const handleAddComment = async (
+    agendaId: string,
+    body: string,
+  ): Promise<boolean> => {
     const result = await addComment(agendaId, body);
     if (result) {
       refetchAgendas();
+      return true;
     }
+    return false;
   };
 
   const handleAddToAgenda = (content: string) => {
@@ -117,6 +134,9 @@ export function PreparationPage() {
         onAddComment={handleAddComment}
         isAddingAgenda={isAddingAgenda}
         isAddingComment={isAddingComment}
+        addAgendaError={addAgendaError}
+        deleteAgendaError={deleteAgendaError}
+        addCommentError={addCommentError}
       />
 
       {/* Pending action items */}
@@ -137,7 +157,9 @@ export function PreparationPage() {
         <Button
           size="lg"
           onClick={() => void handleStartSession()}
-          disabled={isStarting || scheduleLoading}
+          disabled={
+            isStarting || scheduleLoading || !schedule || !!scheduleError
+          }
         >
           {isStarting ? "開始中..." : "1on1 を開始する"}
         </Button>

--- a/frontend/src/features/preparation/types.ts
+++ b/frontend/src/features/preparation/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared type definitions for the preparation feature.
+ *
+ * These types mirror the backend API response schemas and are shared
+ * across hooks and components.
+ */
+
+export interface ScheduleDetail {
+  schedule_id: string;
+  organizer_id: string;
+  counterpart_id: string;
+  title: string;
+  scheduled_at: string;
+  status: string;
+  schedule_group_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgendaComment {
+  comment_id: string;
+  author_id: string;
+  body: string;
+  created_at: string;
+}
+
+export interface AgendaItem {
+  agenda_id: string;
+  topic: string;
+  added_by: string;
+  added_by_tag: string;
+  comments: AgendaComment[];
+  created_at: string;
+}
+
+export interface AgendasResponse {
+  agendas: AgendaItem[];
+}
+
+export interface AddAgendaResponse {
+  agenda_id: string;
+}
+
+export interface AddAgendaCommentResponse {
+  comment_id: string;
+}
+
+export interface PendingActionItem {
+  action_item_id: string;
+  content: string;
+  created_at: string;
+  record_id: string;
+  organizer_id: string;
+  conducted_at: string;
+}
+
+export interface PendingActionItemsResponse {
+  items: PendingActionItem[];
+}
+
+export interface StartSessionResponse {
+  record_id: string;
+}

--- a/frontend/src/features/preparation/types.ts
+++ b/frontend/src/features/preparation/types.ts
@@ -5,6 +5,12 @@
  * across hooks and components.
  */
 
+// Re-export shared action item types for use within this feature
+export type {
+  PendingActionItem,
+  PendingActionItemsResponse,
+} from "@/types/action-item";
+
 export interface ScheduleDetail {
   schedule_id: string;
   organizer_id: string;
@@ -15,6 +21,11 @@ export interface ScheduleDetail {
   schedule_group_id: string | null;
   created_at: string;
   updated_at: string;
+  // TODO: Backend GET /schedules/{id} (GetScheduleDetailResponse) does not yet
+  // include duration_minutes or recurrence. Add these fields to the backend
+  // schema when the domain model supports them.
+  duration_minutes?: number;
+  recurrence?: string;
 }
 
 export interface AgendaComment {
@@ -43,19 +54,6 @@ export interface AddAgendaResponse {
 
 export interface AddAgendaCommentResponse {
   comment_id: string;
-}
-
-export interface PendingActionItem {
-  action_item_id: string;
-  content: string;
-  created_at: string;
-  record_id: string;
-  organizer_id: string;
-  conducted_at: string;
-}
-
-export interface PendingActionItemsResponse {
-  items: PendingActionItem[];
 }
 
 export interface StartSessionResponse {

--- a/frontend/src/features/preparation/utils.ts
+++ b/frontend/src/features/preparation/utils.ts
@@ -1,64 +1,16 @@
 /**
  * Utility functions for the preparation feature.
  * Separated from components to avoid react-refresh warnings.
+ *
+ * Date formatting utilities are re-exported from the shared utils/date module.
  */
 
-/**
- * Format an ISO datetime string to a localized Japanese date string.
- * e.g. "2026/04/03（金）10:00"
- */
-export function formatScheduleDateTime(isoString: string): string {
-  const date = new Date(isoString);
-  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const weekday = weekdays[date.getDay()];
-  const hours = date.getHours();
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${year}/${month}/${day}（${weekday}）${hours}:${minutes}`;
-}
-
-/**
- * Format an ISO datetime string to a short date string.
- * e.g. "2026/03/20"
- */
-export function formatDateShort(isoString: string): string {
-  const date = new Date(isoString);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}/${month}/${day}`;
-}
-
-/**
- * Format an ISO datetime string to a Japanese comment date.
- * e.g. "3月31日"
- */
-export function formatCommentDate(isoString: string): string {
-  const date = new Date(isoString);
-  return `${date.getMonth() + 1}月${date.getDate()}日`;
-}
-
-/**
- * Return a relative label like "あと3日", "今日", "1日前".
- */
-export function getRelativeLabel(isoString: string): string {
-  const now = new Date();
-  const target = new Date(isoString);
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const targetStart = new Date(
-    target.getFullYear(),
-    target.getMonth(),
-    target.getDate(),
-  );
-  const diffMs = targetStart.getTime() - todayStart.getTime();
-  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) return "今日";
-  if (diffDays > 0) return `あと${diffDays}日`;
-  return `${Math.abs(diffDays)}日前`;
-}
+export {
+  getRelativeLabel,
+  formatScheduleDateTime,
+  formatDateShort,
+  formatCommentDate,
+} from "@/utils/date";
 
 /**
  * Get the added_by_tag display label.

--- a/frontend/src/features/preparation/utils.ts
+++ b/frontend/src/features/preparation/utils.ts
@@ -1,0 +1,77 @@
+/**
+ * Utility functions for the preparation feature.
+ * Separated from components to avoid react-refresh warnings.
+ */
+
+/**
+ * Format an ISO datetime string to a localized Japanese date string.
+ * e.g. "2026/04/03（金）10:00"
+ */
+export function formatScheduleDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const weekday = weekdays[date.getDay()];
+  const hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}/${month}/${day}（${weekday}）${hours}:${minutes}`;
+}
+
+/**
+ * Format an ISO datetime string to a short date string.
+ * e.g. "2026/03/20"
+ */
+export function formatDateShort(isoString: string): string {
+  const date = new Date(isoString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}/${month}/${day}`;
+}
+
+/**
+ * Format an ISO datetime string to a Japanese comment date.
+ * e.g. "3月31日"
+ */
+export function formatCommentDate(isoString: string): string {
+  const date = new Date(isoString);
+  return `${date.getMonth() + 1}月${date.getDate()}日`;
+}
+
+/**
+ * Return a relative label like "あと3日", "今日", "1日前".
+ */
+export function getRelativeLabel(isoString: string): string {
+  const now = new Date();
+  const target = new Date(isoString);
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const targetStart = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate(),
+  );
+  const diffMs = targetStart.getTime() - todayStart.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "今日";
+  if (diffDays > 0) return `あと${diffDays}日`;
+  return `${Math.abs(diffDays)}日前`;
+}
+
+/**
+ * Get the added_by_tag display label.
+ */
+export function getAddedByTagLabel(tag: string): string {
+  switch (tag) {
+    case "organizer":
+      return "オーガナイザーが追加";
+    case "counterpart":
+      return "カウンターパートが追加";
+    case "template":
+      return "テンプレート";
+    default:
+      return tag;
+  }
+}

--- a/frontend/src/features/scheduling/components/CounterpartScheduleBlock.tsx
+++ b/frontend/src/features/scheduling/components/CounterpartScheduleBlock.tsx
@@ -21,7 +21,6 @@ const DURATION_OPTIONS = [
   { value: 90, label: "90分" },
 ];
 
-
 export function CounterpartScheduleBlock({
   data,
   onChange,

--- a/frontend/src/types/action-item.ts
+++ b/frontend/src/types/action-item.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared type definitions for action items.
+ *
+ * These types mirror the backend API response schemas:
+ * - PendingActionItemSchema (per-counterpart endpoint: GET /action-items/pending/{counterpart_id})
+ * - AllPendingActionItemSchema (all-counterpart endpoint: GET /action-items/pending)
+ */
+
+/**
+ * A pending action item for a specific counterpart.
+ * Matches backend PendingActionItemSchema which includes organizer_id.
+ * Used in the preparation page (per-counterpart context).
+ */
+export interface PendingActionItem {
+  action_item_id: string;
+  content: string;
+  created_at: string;
+  record_id: string;
+  organizer_id: string;
+  conducted_at: string;
+}
+
+/**
+ * A pending action item across all counterparts.
+ * Matches backend AllPendingActionItemSchema which includes counterpart_id.
+ * Used in the dashboard page (all-counterpart overview).
+ */
+export interface AllPendingActionItem {
+  action_item_id: string;
+  content: string;
+  created_at: string;
+  record_id: string;
+  counterpart_id: string;
+  conducted_at: string;
+}
+
+/**
+ * Response for GET /action-items/pending/{counterpart_id}.
+ */
+export interface PendingActionItemsResponse {
+  items: PendingActionItem[];
+}
+
+/**
+ * Response for GET /action-items/pending.
+ */
+export interface AllPendingActionItemsResponse {
+  items: AllPendingActionItem[];
+}

--- a/frontend/src/utils/__tests__/date.test.ts
+++ b/frontend/src/utils/__tests__/date.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  getRelativeLabel,
+  formatDateJa,
+  formatTime,
+  formatScheduleDateTime,
+  formatDateShort,
+  formatCommentDate,
+} from "../date";
+
+describe("getRelativeLabel", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "今日" for today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 26, 10, 0, 0)); // 2026-03-26 10:00
+    expect(getRelativeLabel("2026-03-26T15:00:00")).toBe("今日");
+  });
+
+  it('returns "明日" for tomorrow', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 26, 10, 0, 0));
+    expect(getRelativeLabel("2026-03-27T09:00:00")).toBe("明日");
+  });
+
+  it('returns "昨日" for yesterday', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 26, 10, 0, 0));
+    expect(getRelativeLabel("2026-03-25T23:00:00")).toBe("昨日");
+  });
+
+  it('returns "N日後" for N days in the future', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 26, 10, 0, 0));
+    expect(getRelativeLabel("2026-03-29T10:00:00")).toBe("3日後");
+  });
+
+  it('returns "N日前" for N days in the past', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 26, 10, 0, 0));
+    expect(getRelativeLabel("2026-03-22T10:00:00")).toBe("4日前");
+  });
+});
+
+describe("formatDateJa", () => {
+  it("formats an ISO string to Japanese date with weekday", () => {
+    // 2026-04-03 is a Friday
+    expect(formatDateJa("2026-04-03T10:00:00")).toBe("2026年4月3日（金）");
+  });
+
+  it("formats a Sunday correctly", () => {
+    // 2026-03-29 is a Sunday
+    expect(formatDateJa("2026-03-29T10:00:00")).toBe("2026年3月29日（日）");
+  });
+});
+
+describe("formatTime", () => {
+  it("formats time as H:MM", () => {
+    expect(formatTime("2026-04-03T10:05:00")).toBe("10:05");
+  });
+
+  it("pads minutes with leading zero", () => {
+    expect(formatTime("2026-04-03T09:00:00")).toBe("9:00");
+  });
+
+  it("handles midnight", () => {
+    expect(formatTime("2026-04-03T00:00:00")).toBe("0:00");
+  });
+});
+
+describe("formatScheduleDateTime", () => {
+  it("formats a full date-time string", () => {
+    // 2026-04-03 is a Friday
+    expect(formatScheduleDateTime("2026-04-03T10:00:00")).toBe(
+      "2026/04/03（金）10:00",
+    );
+  });
+
+  it("pads month and day with leading zeros", () => {
+    // 2026-01-05 is a Monday
+    expect(formatScheduleDateTime("2026-01-05T09:30:00")).toBe(
+      "2026/01/05（月）9:30",
+    );
+  });
+});
+
+describe("formatDateShort", () => {
+  it("formats an ISO string to YYYY/MM/DD", () => {
+    expect(formatDateShort("2026-03-20T10:00:00")).toBe("2026/03/20");
+  });
+
+  it("pads single-digit month and day", () => {
+    expect(formatDateShort("2026-01-05T00:00:00")).toBe("2026/01/05");
+  });
+});
+
+describe("formatCommentDate", () => {
+  it("formats as M月D日", () => {
+    expect(formatCommentDate("2026-03-31T10:00:00")).toBe("3月31日");
+  });
+
+  it("handles single-digit month and day", () => {
+    expect(formatCommentDate("2026-01-05T00:00:00")).toBe("1月5日");
+  });
+});

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared date formatting utilities.
+ * Separated from feature-specific files to avoid duplication and
+ * ensure consistent behavior across the application.
+ */
+
+/**
+ * Return a relative label like "今日", "明日", "2日後", "昨日", "3日前".
+ */
+export function getRelativeLabel(isoString: string): string {
+  const now = new Date();
+  const target = new Date(isoString);
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const targetStart = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate(),
+  );
+  const diffMs = targetStart.getTime() - todayStart.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "今日";
+  if (diffDays === 1) return "明日";
+  if (diffDays > 1) return `${diffDays}日後`;
+  if (diffDays === -1) return "昨日";
+  return `${Math.abs(diffDays)}日前`;
+}
+
+/**
+ * Format an ISO datetime string to a localized Japanese date string.
+ * e.g. "2026年4月3日（金）"
+ */
+export function formatDateJa(isoString: string): string {
+  const date = new Date(isoString);
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const weekday = weekdays[date.getDay()];
+  return `${year}年${month}月${day}日（${weekday}）`;
+}
+
+/**
+ * Format an ISO datetime string to time "HH:MM".
+ */
+export function formatTime(isoString: string): string {
+  const date = new Date(isoString);
+  return `${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+/**
+ * Format an ISO datetime string to a full date-time string.
+ * e.g. "2026/04/03（金）10:00"
+ */
+export function formatScheduleDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const weekday = weekdays[date.getDay()];
+  const hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}/${month}/${day}（${weekday}）${hours}:${minutes}`;
+}
+
+/**
+ * Format an ISO datetime string to a short date string.
+ * e.g. "2026/03/20"
+ */
+export function formatDateShort(isoString: string): string {
+  const date = new Date(isoString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}/${month}/${day}`;
+}
+
+/**
+ * Format an ISO datetime string to a Japanese comment date.
+ * e.g. "3月31日"
+ */
+export function formatCommentDate(isoString: string): string {
+  const date = new Date(isoString);
+  return `${date.getMonth() + 1}月${date.getDate()}日`;
+}


### PR DESCRIPTION
## 概要
1on1の事前準備画面を実装。アジェンダ管理・コメント、未完了アクションアイテム表示、1on1開始機能を含む。

## 実装内容
- hooks: useScheduleDetail, useScheduleAgendas, useAddAgenda, useDeleteAgenda, useAddAgendaComment, usePendingActionItems, useStartSession
- components: ScheduleInfoCard, AgendaList, AgendaCommentThread, PendingActionItemList
- pages: PreparationPage
- テスト: 12ケース

## テスト計画
- pnpm lint 通過
- pnpm test 通過（54テスト全パス）

Closes #144