### PR TITLE
Record: コメント追加時の latest_activity_at 更新 + 投稿者自動既読

### DIFF
--- a/backend/contexts/record/application/add_comment.py
+++ b/backend/contexts/record/application/add_comment.py
@@ -107,19 +107,13 @@ class AddCommentUseCase:
             # Update latest_activity_at on the record
             record.notify_comment_added(now)
 
-            # Auto-mark the commenter as having read the record
-            read_status = await self._read_status_repository.find_by_record_and_user(
-                record.id, input_dto.actor_id
+            # Auto-mark commenter as read (upsert for concurrency safety)
+            read_status = ReadStatus.create(
+                record_id=record.id,
+                user_id=input_dto.actor_id,
+                now=now,
             )
-            if read_status is None:
-                read_status = ReadStatus.create(
-                    record_id=record.id,
-                    user_id=input_dto.actor_id,
-                    now=now,
-                )
-            else:
-                read_status.mark_viewed(now)
-            await self._read_status_repository.save(read_status)
+            await self._read_status_repository.upsert(read_status)
 
             await self._comment_repository.save(comment)
             await self._record_repository.save(record)

--- a/backend/contexts/record/application/add_comment.py
+++ b/backend/contexts/record/application/add_comment.py
@@ -18,6 +18,8 @@ from contexts.record.domain.exceptions import (
     RecordNotPublishedError,
     UnauthorizedOperationError,
 )
+from contexts.record.domain.read_status import ReadStatus
+from contexts.record.domain.read_status_repository import ReadStatusRepository
 from contexts.record.domain.record_repository import RecordRepository
 from contexts.record.domain.value_objects import CommentId, RecordId, RecordStatus
 from foundation.application.unit_of_work import UnitOfWork
@@ -67,11 +69,13 @@ class AddCommentUseCase:
         *,
         record_repository: RecordRepository,
         comment_repository: CommentRepository,
+        read_status_repository: ReadStatusRepository,
         unit_of_work: UnitOfWork,
         event_dispatcher: EventDispatcher,
     ) -> None:
         self._record_repository = record_repository
         self._comment_repository = comment_repository
+        self._read_status_repository = read_status_repository
         self._unit_of_work = unit_of_work
         self._event_dispatcher = event_dispatcher
 
@@ -100,7 +104,25 @@ class AddCommentUseCase:
                 now=now,
             )
 
+            # Update latest_activity_at on the record
+            record.notify_comment_added(now)
+
+            # Auto-mark the commenter as having read the record
+            read_status = await self._read_status_repository.find_by_record_and_user(
+                record.id, input_dto.actor_id
+            )
+            if read_status is None:
+                read_status = ReadStatus.create(
+                    record_id=record.id,
+                    user_id=input_dto.actor_id,
+                    now=now,
+                )
+            else:
+                read_status.mark_viewed(now)
+            await self._read_status_repository.save(read_status)
+
             await self._comment_repository.save(comment)
+            await self._record_repository.save(record)
             await self._unit_of_work.commit()
 
         # Dispatch events after successful commit

--- a/backend/contexts/record/presentation/dependencies.py
+++ b/backend/contexts/record/presentation/dependencies.py
@@ -265,6 +265,9 @@ def get_get_viewers_use_case(
 def get_add_comment_use_case(
     record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
     comment_repo: Annotated[CommentRepository, Depends(get_comment_repository)],
+    read_status_repo: Annotated[
+        ReadStatusRepository, Depends(get_read_status_repository)
+    ],
     uow: Annotated[UnitOfWork, Depends(get_unit_of_work)],
     event_dispatcher: Annotated[EventDispatcher, Depends(get_event_dispatcher)],
 ) -> AddCommentUseCase:
@@ -272,6 +275,7 @@ def get_add_comment_use_case(
     return AddCommentUseCase(
         record_repository=record_repo,
         comment_repository=comment_repo,
+        read_status_repository=read_status_repo,
         unit_of_work=uow,
         event_dispatcher=event_dispatcher,
     )

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -37,12 +37,14 @@ class InMemoryRecordRepository(RecordRepository):
 
     def __init__(self) -> None:
         self._records: dict[RecordId, Record] = {}
+        self.save_count: int = 0
 
     async def get_by_id(self, entity_id: RecordId) -> Record | None:
         return self._records.get(entity_id)
 
     async def save(self, entity: Record) -> None:
         self._records[entity.id] = entity
+        self.save_count += 1
 
     async def exists_by_participant(
         self, user_id: UserId, counterpart_id: UserId

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -225,6 +225,14 @@ class InMemoryReadStatusRepository(ReadStatusRepository):
                 return rs
         return None
 
+    async def upsert(self, entity: ReadStatus) -> None:
+        # Mimic ON DUPLICATE KEY UPDATE: match by (record_id, user_id)
+        for _rs_id, rs in self._statuses.items():
+            if rs.record_id == entity.record_id and rs.user_id == entity.user_id:
+                rs.mark_viewed(entity.last_viewed_at)
+                return
+        self._statuses[entity.id] = entity
+
     async def delete_by_record_and_user(
         self, record_id: RecordId, user_id: UserId
     ) -> None:

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -16,11 +16,14 @@ from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.action_item_repository import ActionItemRepository
 from contexts.record.domain.comment import Comment
 from contexts.record.domain.comment_repository import CommentRepository
+from contexts.record.domain.read_status import ReadStatus
+from contexts.record.domain.read_status_repository import ReadStatusRepository
 from contexts.record.domain.record import Record
 from contexts.record.domain.record_repository import RecordRepository
 from contexts.record.domain.value_objects import (
     ActionItemId,
     CommentId,
+    ReadStatusId,
     RecordId,
 )
 from foundation.application.unit_of_work import UnitOfWork
@@ -200,6 +203,42 @@ class InMemoryCommentRepository(CommentRepository):
     @property
     def saved_comments(self) -> list[Comment]:
         return list(self._comments.values())
+
+
+class InMemoryReadStatusRepository(ReadStatusRepository):
+    """In-memory stub for ReadStatusRepository."""
+
+    def __init__(self) -> None:
+        self._statuses: dict[ReadStatusId, ReadStatus] = {}
+
+    async def get_by_id(self, entity_id: ReadStatusId) -> ReadStatus | None:
+        return self._statuses.get(entity_id)
+
+    async def save(self, entity: ReadStatus) -> None:
+        self._statuses[entity.id] = entity
+
+    async def find_by_record_and_user(
+        self, record_id: RecordId, user_id: UserId
+    ) -> ReadStatus | None:
+        for rs in self._statuses.values():
+            if rs.record_id == record_id and rs.user_id == user_id:
+                return rs
+        return None
+
+    async def delete_by_record_and_user(
+        self, record_id: RecordId, user_id: UserId
+    ) -> None:
+        to_delete = [
+            rs_id
+            for rs_id, rs in self._statuses.items()
+            if rs.record_id == record_id and rs.user_id == user_id
+        ]
+        for rs_id in to_delete:
+            del self._statuses[rs_id]
+
+    @property
+    def saved_statuses(self) -> list[ReadStatus]:
+        return list(self._statuses.values())
 
 
 class InMemoryScheduleRepository(ScheduleRepository):

--- a/backend/tests/contexts/record/application/test_add_comment.py
+++ b/backend/tests/contexts/record/application/test_add_comment.py
@@ -18,12 +18,14 @@ from contexts.record.domain.exceptions import (
     RecordNotPublishedError,
     UnauthorizedOperationError,
 )
+from contexts.record.domain.read_status import ReadStatus
 from contexts.record.domain.record import Record
 from contexts.record.domain.value_objects import RecordId
 from shared.domain.value_objects import UserId
 from tests.contexts.record.application.conftest import (
     FakeUnitOfWork,
     InMemoryCommentRepository,
+    InMemoryReadStatusRepository,
     InMemoryRecordRepository,
     SpyEventDispatcher,
 )
@@ -69,26 +71,30 @@ def _build_use_case(
     *,
     record_repo: InMemoryRecordRepository | None = None,
     comment_repo: InMemoryCommentRepository | None = None,
+    read_status_repo: InMemoryReadStatusRepository | None = None,
     uow: FakeUnitOfWork | None = None,
     event_dispatcher: SpyEventDispatcher | None = None,
 ) -> tuple[
     AddCommentUseCase,
     InMemoryRecordRepository,
     InMemoryCommentRepository,
+    InMemoryReadStatusRepository,
     FakeUnitOfWork,
     SpyEventDispatcher,
 ]:
     rr = record_repo or InMemoryRecordRepository()
     cr = comment_repo or InMemoryCommentRepository()
+    rs = read_status_repo or InMemoryReadStatusRepository()
     u = uow or FakeUnitOfWork()
     ed = event_dispatcher or SpyEventDispatcher()
     uc = AddCommentUseCase(
         record_repository=rr,
         comment_repository=cr,
+        read_status_repository=rs,
         unit_of_work=u,
         event_dispatcher=ed,
     )
-    return uc, rr, cr, u, ed
+    return uc, rr, cr, rs, u, ed
 
 
 class TestAddComment:
@@ -97,7 +103,7 @@ class TestAddComment:
     async def test_organizer_can_add_comment(self) -> None:
         organizer = UserId.generate()
         record = _make_published_record(organizer=organizer)
-        uc, rr, cr, _uow, _ed = _build_use_case()
+        uc, rr, cr, _rs, _uow, _ed = _build_use_case()
         await rr.save(record)
 
         output = await uc.execute(
@@ -120,7 +126,7 @@ class TestAddComment:
         organizer = UserId.generate()
         counterpart = UserId.generate()
         record = _make_published_record(organizer=organizer, counterpart=counterpart)
-        uc, rr, cr, _uow, _ed = _build_use_case()
+        uc, rr, cr, _rs, _uow, _ed = _build_use_case()
         await rr.save(record)
 
         output = await uc.execute(
@@ -138,7 +144,7 @@ class TestAddComment:
         organizer = UserId.generate()
         viewer = UserId.generate()
         record = _make_published_record(organizer=organizer, viewer_ids=[viewer])
-        uc, rr, cr, _uow, _ed = _build_use_case()
+        uc, rr, cr, _rs, _uow, _ed = _build_use_case()
         await rr.save(record)
 
         output = await uc.execute(
@@ -155,7 +161,7 @@ class TestAddComment:
     async def test_commits_transaction(self) -> None:
         organizer = UserId.generate()
         record = _make_published_record(organizer=organizer)
-        uc, rr, _cr, uow, _ed = _build_use_case()
+        uc, rr, _cr, _rs, uow, _ed = _build_use_case()
         await rr.save(record)
 
         await uc.execute(
@@ -171,7 +177,7 @@ class TestAddComment:
     async def test_dispatches_record_comment_added_event(self) -> None:
         organizer = UserId.generate()
         record = _make_published_record(organizer=organizer)
-        uc, rr, _cr, _uow, ed = _build_use_case()
+        uc, rr, _cr, _rs, _uow, ed = _build_use_case()
         await rr.save(record)
 
         output = await uc.execute(
@@ -196,7 +202,7 @@ class TestAddCommentErrors:
     """Tests for error conditions."""
 
     async def test_raises_when_record_not_found(self) -> None:
-        uc, _rr, _cr, _uow, _ed = _build_use_case()
+        uc, _rr, _cr, _rs, _uow, _ed = _build_use_case()
 
         with pytest.raises(RecordNotFoundError):
             await uc.execute(
@@ -210,7 +216,7 @@ class TestAddCommentErrors:
     async def test_raises_when_record_is_draft(self) -> None:
         organizer = UserId.generate()
         record = _make_draft_record(organizer=organizer)
-        uc, rr, _cr, _uow, _ed = _build_use_case()
+        uc, rr, _cr, _rs, _uow, _ed = _build_use_case()
         await rr.save(record)
 
         with pytest.raises(RecordNotPublishedError):
@@ -225,7 +231,7 @@ class TestAddCommentErrors:
     async def test_raises_when_user_has_no_access(self) -> None:
         record = _make_published_record()
         outsider = UserId.generate()
-        uc, rr, _cr, _uow, _ed = _build_use_case()
+        uc, rr, _cr, _rs, _uow, _ed = _build_use_case()
         await rr.save(record)
 
         with pytest.raises(UnauthorizedOperationError):
@@ -238,7 +244,7 @@ class TestAddCommentErrors:
             )
 
     async def test_does_not_commit_on_error(self) -> None:
-        uc, _rr, _cr, uow, _ed = _build_use_case()
+        uc, _rr, _cr, _rs, uow, _ed = _build_use_case()
 
         with pytest.raises(RecordNotFoundError):
             await uc.execute(
@@ -252,7 +258,7 @@ class TestAddCommentErrors:
         assert uow.committed is False
 
     async def test_does_not_dispatch_events_on_error(self) -> None:
-        uc, _rr, _cr, _uow, ed = _build_use_case()
+        uc, _rr, _cr, _rs, _uow, ed = _build_use_case()
 
         with pytest.raises(RecordNotFoundError):
             await uc.execute(
@@ -264,3 +270,96 @@ class TestAddCommentErrors:
             )
 
         assert ed.dispatched_events == []
+
+
+class TestAddCommentLatestActivityAndAutoRead:
+    """Tests for latest_activity_at update and author auto-read on comment."""
+
+    async def test_updates_latest_activity_at_on_record(self) -> None:
+        """Adding a comment should update Record.latest_activity_at."""
+        organizer = UserId.generate()
+        record = _make_published_record(organizer=organizer)
+        original_activity_at = record.latest_activity_at
+        uc, rr, _cr, _rs, _uow, _ed = _build_use_case()
+        await rr.save(record)
+
+        await uc.execute(
+            AddCommentInput(
+                record_id=record.id,
+                actor_id=organizer,
+                body=CommentBody("New comment"),
+            )
+        )
+
+        saved_record = await rr.get_by_id(record.id)
+        assert saved_record is not None
+        assert saved_record.latest_activity_at is not None
+        assert saved_record.latest_activity_at != original_activity_at
+
+    async def test_auto_reads_commenter_when_no_prior_read_status(self) -> None:
+        """Commenter should get a new ReadStatus with last_viewed_at = now."""
+        organizer = UserId.generate()
+        record = _make_published_record(organizer=organizer)
+        uc, rr, _cr, rs, _uow, _ed = _build_use_case()
+        await rr.save(record)
+
+        await uc.execute(
+            AddCommentInput(
+                record_id=record.id,
+                actor_id=organizer,
+                body=CommentBody("Comment"),
+            )
+        )
+
+        read_status = await rs.find_by_record_and_user(record.id, organizer)
+        assert read_status is not None
+        # last_viewed_at should equal latest_activity_at (same `now`)
+        assert read_status.last_viewed_at == record.latest_activity_at
+
+    async def test_auto_reads_commenter_when_prior_read_status_exists(self) -> None:
+        """Existing ReadStatus should be updated, not duplicated."""
+        organizer = UserId.generate()
+        record = _make_published_record(organizer=organizer)
+        uc, rr, _cr, rs, _uow, _ed = _build_use_case()
+        await rr.save(record)
+
+        # Pre-existing ReadStatus with an old timestamp
+        old_read = ReadStatus.create(
+            record_id=record.id,
+            user_id=organizer,
+            now=datetime(2026, 1, 1, 0, 0),
+        )
+        await rs.save(old_read)
+
+        await uc.execute(
+            AddCommentInput(
+                record_id=record.id,
+                actor_id=organizer,
+                body=CommentBody("Another comment"),
+            )
+        )
+
+        read_status = await rs.find_by_record_and_user(record.id, organizer)
+        assert read_status is not None
+        assert read_status.id == old_read.id  # same entity, not new
+        assert read_status.last_viewed_at == record.latest_activity_at
+
+    async def test_record_is_re_saved_in_same_transaction(self) -> None:
+        """Record should be saved after notify_comment_added to persist latest_activity_at."""
+        organizer = UserId.generate()
+        record = _make_published_record(organizer=organizer)
+        uc, rr, _cr, _rs, uow, _ed = _build_use_case()
+        await rr.save(record)
+
+        await uc.execute(
+            AddCommentInput(
+                record_id=record.id,
+                actor_id=organizer,
+                body=CommentBody("Trigger save"),
+            )
+        )
+
+        assert uow.committed is True
+        saved_record = await rr.get_by_id(record.id)
+        assert saved_record is not None
+        assert saved_record.latest_activity_at is not None

--- a/backend/tests/contexts/record/application/test_add_comment.py
+++ b/backend/tests/contexts/record/application/test_add_comment.py
@@ -345,11 +345,12 @@ class TestAddCommentLatestActivityAndAutoRead:
         assert read_status.last_viewed_at == record.latest_activity_at
 
     async def test_record_is_re_saved_in_same_transaction(self) -> None:
-        """Record should be saved after notify_comment_added to persist latest_activity_at."""
+        """Record.save() must be called after notify_comment_added."""
         organizer = UserId.generate()
         record = _make_published_record(organizer=organizer)
         uc, rr, _cr, _rs, uow, _ed = _build_use_case()
         await rr.save(record)
+        save_count_before = rr.save_count
 
         await uc.execute(
             AddCommentInput(
@@ -360,6 +361,5 @@ class TestAddCommentLatestActivityAndAutoRead:
         )
 
         assert uow.committed is True
-        saved_record = await rr.get_by_id(record.id)
-        assert saved_record is not None
-        assert saved_record.latest_activity_at is not None
+        # Verify save was called again (not just relying on object reference)
+        assert rr.save_count == save_count_before + 1


### PR DESCRIPTION
## 概要
コメント追加時に Record の latest_activity_at を更新し、投稿者本人を自動既読にする。

## 変更内容
- AddCommentUseCase に ReadStatusRepository の依存を追加
- コメント追加時に Record.notify_comment_added(now) で latest_activity_at を更新
- 投稿者本人の ReadStatus を自動的に作成/更新（自動既読）
- Record の再保存を同一トランザクション内で実行
- DI コンテナ（dependencies.py）を更新

## テスト
- latest_activity_at がコメント追加時に更新されること
- 既存の ReadStatus がない場合に新規作成されること
- 既存の ReadStatus がある場合に更新されること
- Record が同一トランザクション内で再保存されること

## 設計根拠
docs/design/unread_management.md セクション 5, 9 に基づく。

Closes #161