### PR TITLE
フロントエンド: 実施・記録画面の実装

### DIFF
--- a/frontend/src/features/preparation/hooks/useAddAgenda.ts
+++ b/frontend/src/features/preparation/hooks/useAddAgenda.ts
@@ -16,6 +16,10 @@ export function useAddAgenda(scheduleId: string): UseAddAgendaResult {
 
   const addAgenda = useCallback(
     async (topic: string): Promise<AddAgendaResponse | null> => {
+      if (!scheduleId) {
+        setError("スケジュールが指定されていません");
+        return null;
+      }
       setIsSubmitting(true);
       setError(null);
       try {

--- a/frontend/src/features/preparation/hooks/useScheduleAgendas.ts
+++ b/frontend/src/features/preparation/hooks/useScheduleAgendas.ts
@@ -39,8 +39,12 @@ export function useScheduleAgendas(
   }, [scheduleId, userId]);
 
   useEffect(() => {
+    if (!scheduleId) {
+      setIsLoading(false);
+      return;
+    }
     void fetchAgendas();
-  }, [fetchAgendas]);
+  }, [fetchAgendas, scheduleId]);
 
   return { agendas, isLoading, error, refetch: fetchAgendas };
 }

--- a/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
+++ b/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
@@ -360,10 +360,11 @@ describe("RecordingPage", () => {
 
     const input = screen.getByPlaceholderText("アクションアイテムを追加...");
     await user.type(input, "新しいアクション");
-    // Get the add button in the action item section (second "追加" button)
+    // Get the add button in the action item section (last "追加" button)
     const addButtons = screen.getAllByRole("button", { name: "追加" });
     await user.click(addButtons[addButtons.length - 1]);
 
+    // handleAddActionItem receives (title, dueDate?) but forwards only title to hook
     expect(mockAddActionItem).toHaveBeenCalledWith("新しいアクション");
   });
 
@@ -403,6 +404,24 @@ describe("RecordingPage", () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith("/records/r1/publish");
     });
+  });
+
+  it("does not call saveDraft when updateMemo fails", async () => {
+    mockUpdateMemo.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const completeButtons = screen.getAllByRole("button", {
+      name: "完了として保存",
+    });
+    await user.click(completeButtons[0]);
+
+    await waitFor(() => {
+      expect(mockUpdateMemo).toHaveBeenCalled();
+    });
+
+    expect(mockSaveDraft).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   // -- Input preserved on error ---------------------------------------------

--- a/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
+++ b/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
@@ -1,0 +1,529 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { RecordingPage } from "../pages/RecordingPage";
+import type { RecordDetail, RecordActionItem } from "../types";
+import type { AgendaItem } from "@/features/preparation/types";
+
+// -- Mock data ----------------------------------------------------------------
+
+const mockActionItems: RecordActionItem[] = [
+  {
+    action_item_id: "ai1",
+    title: "進捗共有メールを送る",
+    is_completed: false,
+    counterpart_id: "cp1",
+    created_at: "2026-03-20T10:00:00Z",
+  },
+];
+
+const mockRecord: RecordDetail = {
+  record_id: "r1",
+  organizer_id: "org1",
+  counterpart_id: "cp1",
+  schedule_id: "s1",
+  memo: "テストメモ",
+  status: "draft",
+  confirmed_agenda_ids: ["a1"],
+  action_items: mockActionItems,
+  conducted_at: "2026-04-01T10:00:00Z",
+  created_at: "2026-03-20T10:00:00Z",
+  updated_at: "2026-03-20T10:00:00Z",
+};
+
+const mockAgendas: AgendaItem[] = [
+  {
+    agenda_id: "a1",
+    topic: "前回のアクションアイテム確認",
+    added_by: "org1",
+    added_by_tag: "template",
+    comments: [],
+    created_at: "2026-03-20T10:00:00Z",
+  },
+  {
+    agenda_id: "a2",
+    topic: "業務状況の共有",
+    added_by: "org1",
+    added_by_tag: "template",
+    comments: [],
+    created_at: "2026-03-20T10:00:00Z",
+  },
+];
+
+// -- Mock hooks ---------------------------------------------------------------
+
+let recordDetailReturn = {
+  record: mockRecord as RecordDetail | null,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+let scheduleAgendasReturn = {
+  agendas: mockAgendas,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+const mockAddAgenda = vi.fn().mockResolvedValue({ agenda_id: "a3" });
+let addAgendaReturn = {
+  addAgenda: mockAddAgenda,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockConfirmAgenda = vi
+  .fn()
+  .mockResolvedValue({ record_id: "r1", agenda_id: "a2" });
+let confirmAgendaReturn = {
+  confirmAgenda: mockConfirmAgenda,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockAddActionItem = vi
+  .fn()
+  .mockResolvedValue({ action_item_id: "ai-new" });
+let addActionItemReturn = {
+  addActionItem: mockAddActionItem,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockDeleteActionItem = vi.fn().mockResolvedValue(true);
+let deleteActionItemReturn = {
+  deleteActionItem: mockDeleteActionItem,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockUpdateMemo = vi.fn().mockResolvedValue({ record_id: "r1" });
+let updateMemoReturn = {
+  updateMemo: mockUpdateMemo,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockSaveDraft = vi.fn().mockResolvedValue({ record_id: "r1" });
+let saveDraftReturn = {
+  saveDraft: mockSaveDraft,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+vi.mock("../hooks/useRecordDetail", () => ({
+  useRecordDetail: () => recordDetailReturn,
+}));
+
+vi.mock("@/features/preparation/hooks/useScheduleAgendas", () => ({
+  useScheduleAgendas: () => scheduleAgendasReturn,
+}));
+
+vi.mock("@/features/preparation/hooks/useAddAgenda", () => ({
+  useAddAgenda: () => addAgendaReturn,
+}));
+
+vi.mock("../hooks/useConfirmAgenda", () => ({
+  useConfirmAgenda: () => confirmAgendaReturn,
+}));
+
+vi.mock("../hooks/useAddActionItem", () => ({
+  useAddActionItem: () => addActionItemReturn,
+}));
+
+vi.mock("../hooks/useDeleteActionItem", () => ({
+  useDeleteActionItem: () => deleteActionItemReturn,
+}));
+
+vi.mock("@/hooks/useUpdateMemo", () => ({
+  useUpdateMemo: () => updateMemoReturn,
+}));
+
+vi.mock("@/hooks/useSaveDraft", () => ({
+  useSaveDraft: () => saveDraftReturn,
+}));
+
+// -- Helpers ------------------------------------------------------------------
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/records/r1/recording"]}>
+      <Routes>
+        <Route path="records/:recordId/recording" element={<RecordingPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("RecordingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recordDetailReturn = {
+      record: mockRecord,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    scheduleAgendasReturn = {
+      agendas: mockAgendas,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    addAgendaReturn = {
+      addAgenda: mockAddAgenda,
+      isSubmitting: false,
+      error: null,
+    };
+    confirmAgendaReturn = {
+      confirmAgenda: mockConfirmAgenda,
+      isSubmitting: false,
+      error: null,
+    };
+    addActionItemReturn = {
+      addActionItem: mockAddActionItem,
+      isSubmitting: false,
+      error: null,
+    };
+    deleteActionItemReturn = {
+      deleteActionItem: mockDeleteActionItem,
+      isSubmitting: false,
+      error: null,
+    };
+    updateMemoReturn = {
+      updateMemo: mockUpdateMemo,
+      isSubmitting: false,
+      error: null,
+    };
+    saveDraftReturn = {
+      saveDraft: mockSaveDraft,
+      isSubmitting: false,
+      error: null,
+    };
+  });
+
+  // -- Normal data display --------------------------------------------------
+
+  it("renders the page title", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /1on1 記録/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the status bar", () => {
+    renderPage();
+    expect(screen.getByText("実施中")).toBeInTheDocument();
+  });
+
+  it("renders agenda items with checkboxes", () => {
+    renderPage();
+    expect(screen.getByText("アジェンダ")).toBeInTheDocument();
+    expect(
+      screen.getByText("前回のアクションアイテム確認"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("業務状況の共有")).toBeInTheDocument();
+  });
+
+  it("renders confirmed agenda with check mark", () => {
+    renderPage();
+    // a1 is confirmed
+    const checkbox = screen.getByRole("checkbox", {
+      name: "前回のアクションアイテム確認を確認",
+    });
+    expect(checkbox).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders unconfirmed agenda without check mark", () => {
+    renderPage();
+    const checkbox = screen.getByRole("checkbox", {
+      name: "業務状況の共有を確認",
+    });
+    expect(checkbox).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders memo editor with initial memo", () => {
+    renderPage();
+    expect(screen.getByText("メモ")).toBeInTheDocument();
+    const textarea = screen.getByRole("textbox", { name: "メモ" });
+    expect(textarea).toHaveValue("テストメモ");
+  });
+
+  it("renders action items", () => {
+    renderPage();
+    expect(screen.getByText("アクションアイテム")).toBeInTheDocument();
+    expect(screen.getByText("進捗共有メールを送る")).toBeInTheDocument();
+  });
+
+  it("renders the complete button", () => {
+    renderPage();
+    const buttons = screen.getAllByRole("button", {
+      name: "完了として保存",
+    });
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  // -- Loading state --------------------------------------------------------
+
+  it("shows loading skeleton when record is loading", () => {
+    recordDetailReturn = {
+      ...recordDetailReturn,
+      record: null,
+      isLoading: true,
+    };
+
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  // -- Error state ----------------------------------------------------------
+
+  it("shows error message when record fetch fails", () => {
+    recordDetailReturn = {
+      ...recordDetailReturn,
+      record: null,
+      error: "記録の取得に失敗しました",
+    };
+
+    renderPage();
+    expect(screen.getByText("記録の取得に失敗しました")).toBeInTheDocument();
+  });
+
+  // -- Confirm agenda -------------------------------------------------------
+
+  it("calls confirmAgenda when clicking unconfirmed agenda checkbox", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "業務状況の共有を確認",
+    });
+    await user.click(checkbox);
+
+    expect(mockConfirmAgenda).toHaveBeenCalledWith("a2");
+  });
+
+  // -- Add agenda -----------------------------------------------------------
+
+  it("calls addAgenda when submitting a new agenda", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const input = screen.getByPlaceholderText("話題が増えたら追加...");
+    await user.type(input, "新しいアジェンダ");
+    const addButton = screen.getAllByRole("button", { name: "追加" })[0];
+    await user.click(addButton);
+
+    expect(mockAddAgenda).toHaveBeenCalledWith("新しいアジェンダ");
+  });
+
+  // -- Memo update ----------------------------------------------------------
+
+  it("updates memo text on input change", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const textarea = screen.getByRole("textbox", { name: "メモ" });
+    await user.clear(textarea);
+    await user.type(textarea, "新しいメモ");
+
+    expect(textarea).toHaveValue("新しいメモ");
+  });
+
+  // -- Add action item ------------------------------------------------------
+
+  it("calls addActionItem when submitting a new action item", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const input = screen.getByPlaceholderText("アクションアイテムを追加...");
+    await user.type(input, "新しいアクション");
+    // Get the add button in the action item section (second "追加" button)
+    const addButtons = screen.getAllByRole("button", { name: "追加" });
+    await user.click(addButtons[addButtons.length - 1]);
+
+    expect(mockAddActionItem).toHaveBeenCalledWith("新しいアクション");
+  });
+
+  // -- Delete action item ---------------------------------------------------
+
+  it("calls deleteActionItem when clicking delete button", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const deleteButton = screen.getByRole("button", {
+      name: "進捗共有メールを送るを削除",
+    });
+    await user.click(deleteButton);
+
+    expect(mockDeleteActionItem).toHaveBeenCalledWith("ai1");
+  });
+
+  // -- Save and complete ----------------------------------------------------
+
+  it("navigates to publish page when clicking complete button", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const completeButtons = screen.getAllByRole("button", {
+      name: "完了として保存",
+    });
+    await user.click(completeButtons[0]);
+
+    await waitFor(() => {
+      expect(mockUpdateMemo).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockSaveDraft).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/records/r1/publish");
+    });
+  });
+
+  // -- Input preserved on error ---------------------------------------------
+
+  it("does not clear agenda input when addAgenda fails", async () => {
+    mockAddAgenda.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const input = screen.getByPlaceholderText("話題が増えたら追加...");
+    await user.type(input, "失敗するアジェンダ");
+    const addButton = screen.getAllByRole("button", { name: "追加" })[0];
+    await user.click(addButton);
+
+    await waitFor(() => {
+      expect(mockAddAgenda).toHaveBeenCalledWith("失敗するアジェンダ");
+    });
+
+    expect(input).toHaveValue("失敗するアジェンダ");
+  });
+
+  it("does not clear action item input when addActionItem fails", async () => {
+    mockAddActionItem.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const input = screen.getByPlaceholderText("アクションアイテムを追加...");
+    await user.type(input, "失敗するアクション");
+    const addButtons = screen.getAllByRole("button", { name: "追加" });
+    await user.click(addButtons[addButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockAddActionItem).toHaveBeenCalledWith("失敗するアクション");
+    });
+
+    expect(input).toHaveValue("失敗するアクション");
+  });
+
+  // -- Mutation error display -----------------------------------------------
+
+  it("shows confirmAgenda error message", () => {
+    confirmAgendaReturn = {
+      ...confirmAgendaReturn,
+      error: "アジェンダの確認に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("アジェンダの確認に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows addActionItem error message", () => {
+    addActionItemReturn = {
+      ...addActionItemReturn,
+      error: "アクションアイテムの追加に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("アクションアイテムの追加に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows deleteActionItem error message", () => {
+    deleteActionItemReturn = {
+      ...deleteActionItemReturn,
+      error: "アクションアイテムの削除に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("アクションアイテムの削除に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows memo save error message", () => {
+    updateMemoReturn = {
+      ...updateMemoReturn,
+      error: "メモの保存に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("メモの保存に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows saveDraft error message", () => {
+    saveDraftReturn = {
+      ...saveDraftReturn,
+      error: "下書き保存に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("下書き保存に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Empty state ----------------------------------------------------------
+
+  it("shows empty message when no action items", () => {
+    recordDetailReturn = {
+      ...recordDetailReturn,
+      record: { ...mockRecord, action_items: [] },
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("アクションアイテムはまだありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty message when no agendas", () => {
+    scheduleAgendasReturn = {
+      ...scheduleAgendasReturn,
+      agendas: [],
+    };
+
+    renderPage();
+    expect(screen.getByText("アジェンダはまだありません")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
+++ b/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
@@ -406,6 +406,35 @@ describe("RecordingPage", () => {
     });
   });
 
+  it("does not double-fire updateMemo when blur and complete button overlap", async () => {
+    // Simulate updateMemo taking time so blur and click overlap
+    mockUpdateMemo.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ record_id: "r1" }), 50),
+        ),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    const textarea = screen.getByRole("textbox", { name: "メモ" });
+    await user.type(textarea, "追記");
+
+    // Click the complete button while textarea has focus (triggers blur + click)
+    const completeButtons = screen.getAllByRole("button", {
+      name: "完了として保存",
+    });
+    await user.click(completeButtons[0]);
+
+    await waitFor(() => {
+      expect(mockSaveDraft).toHaveBeenCalled();
+    });
+
+    // updateMemo should be called exactly once (from handleSaveAndComplete),
+    // not twice (blur should be suppressed)
+    expect(mockUpdateMemo).toHaveBeenCalledTimes(1);
+  });
+
   it("does not call saveDraft when updateMemo fails", async () => {
     mockUpdateMemo.mockResolvedValueOnce(null);
     const user = userEvent.setup();

--- a/frontend/src/features/recording/__tests__/hooks.test.ts
+++ b/frontend/src/features/recording/__tests__/hooks.test.ts
@@ -1,0 +1,259 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApiError } from "@/api/client";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPut = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("@/api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    apiClient: {
+      get: (...args: unknown[]) => mockGet(...args),
+      post: (...args: unknown[]) => mockPost(...args),
+      put: (...args: unknown[]) => mockPut(...args),
+      delete: (...args: unknown[]) => mockDelete(...args),
+    },
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// -- useRecordDetail ----------------------------------------------------------
+
+describe("useRecordDetail", () => {
+  it("fetches record detail on mount and returns data", async () => {
+    const mockRecord = {
+      record_id: "r1",
+      organizer_id: "org1",
+      counterpart_id: "cp1",
+      schedule_id: "s1",
+      memo: "test memo",
+      status: "draft",
+      confirmed_agenda_ids: ["a1"],
+      action_items: [],
+      conducted_at: "2026-04-01T10:00:00Z",
+      created_at: "2026-03-20T10:00:00Z",
+      updated_at: "2026-03-20T10:00:00Z",
+    };
+    mockGet.mockResolvedValueOnce(mockRecord);
+
+    const { useRecordDetail } = await import("../hooks/useRecordDetail");
+    const { result } = renderHook(() => useRecordDetail("r1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith("/records/r1", TEST_USER_ID);
+    expect(result.current.record).toEqual(mockRecord);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when API call fails with ApiError", async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(404, "Not Found", {}));
+
+    const { useRecordDetail } = await import("../hooks/useRecordDetail");
+    const { result } = renderHook(() => useRecordDetail("r1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.record).toBeNull();
+    expect(result.current.error).toBe("記録の取得に失敗しました (404)");
+  });
+
+  it("sets generic error when a non-ApiError is thrown", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network failure"));
+
+    const { useRecordDetail } = await import("../hooks/useRecordDetail");
+    const { result } = renderHook(() => useRecordDetail("r1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("記録の取得に失敗しました");
+  });
+});
+
+// -- useConfirmAgenda ---------------------------------------------------------
+
+describe("useConfirmAgenda", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { record_id: "r1", agenda_id: "a1" };
+    mockPost.mockResolvedValueOnce(mockResponse);
+
+    const { useConfirmAgenda } = await import("../hooks/useConfirmAgenda");
+    const { result } = renderHook(() => useConfirmAgenda("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.confirmAgenda("a1");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/records/r1/agendas/a1/confirm",
+      TEST_USER_ID,
+    );
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useConfirmAgenda } = await import("../hooks/useConfirmAgenda");
+    const { result } = renderHook(() => useConfirmAgenda("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.confirmAgenda("a1");
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("アジェンダの確認に失敗しました (400)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new Error("network"));
+
+    const { useConfirmAgenda } = await import("../hooks/useConfirmAgenda");
+    const { result } = renderHook(() => useConfirmAgenda("r1"));
+
+    await act(async () => {
+      await result.current.confirmAgenda("a1");
+    });
+
+    expect(result.current.error).toBe("アジェンダの確認に失敗しました");
+  });
+});
+
+// -- useAddActionItem ---------------------------------------------------------
+
+describe("useAddActionItem", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { action_item_id: "ai-new" };
+    mockPost.mockResolvedValueOnce(mockResponse);
+
+    const { useAddActionItem } = await import("../hooks/useAddActionItem");
+    const { result } = renderHook(() => useAddActionItem("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.addActionItem("New action");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/records/r1/action-items",
+      TEST_USER_ID,
+      { title: "New action" },
+    );
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useAddActionItem } = await import("../hooks/useAddActionItem");
+    const { result } = renderHook(() => useAddActionItem("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.addActionItem("Bad action");
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe(
+      "アクションアイテムの追加に失敗しました (400)",
+    );
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new Error("network"));
+
+    const { useAddActionItem } = await import("../hooks/useAddActionItem");
+    const { result } = renderHook(() => useAddActionItem("r1"));
+
+    await act(async () => {
+      await result.current.addActionItem("action");
+    });
+
+    expect(result.current.error).toBe("アクションアイテムの追加に失敗しました");
+  });
+});
+
+// -- useDeleteActionItem ------------------------------------------------------
+
+describe("useDeleteActionItem", () => {
+  it("calls API and returns true on success", async () => {
+    mockDelete.mockResolvedValueOnce(undefined);
+
+    const { useDeleteActionItem } =
+      await import("../hooks/useDeleteActionItem");
+    const { result } = renderHook(() => useDeleteActionItem("r1"));
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.deleteActionItem("ai1");
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/records/r1/action-items/ai1",
+      TEST_USER_ID,
+    );
+    expect(success).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns false on ApiError", async () => {
+    mockDelete.mockRejectedValueOnce(new ApiError(403, "Forbidden", {}));
+
+    const { useDeleteActionItem } =
+      await import("../hooks/useDeleteActionItem");
+    const { result } = renderHook(() => useDeleteActionItem("r1"));
+
+    let success: boolean | undefined;
+    await act(async () => {
+      success = await result.current.deleteActionItem("ai1");
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe(
+      "アクションアイテムの削除に失敗しました (403)",
+    );
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockDelete.mockRejectedValueOnce(new Error("network"));
+
+    const { useDeleteActionItem } =
+      await import("../hooks/useDeleteActionItem");
+    const { result } = renderHook(() => useDeleteActionItem("r1"));
+
+    await act(async () => {
+      await result.current.deleteActionItem("ai1");
+    });
+
+    expect(result.current.error).toBe("アクションアイテムの削除に失敗しました");
+  });
+});

--- a/frontend/src/features/recording/components/ActionItemForm.tsx
+++ b/frontend/src/features/recording/components/ActionItemForm.tsx
@@ -6,7 +6,7 @@ import type { RecordActionItem } from "../types";
 
 interface ActionItemFormProps {
   actionItems: RecordActionItem[];
-  onAddActionItem: (title: string) => Promise<boolean>;
+  onAddActionItem: (title: string, dueDate?: string) => Promise<boolean>;
   onDeleteActionItem: (actionItemId: string) => Promise<void>;
   isAdding: boolean;
   addError: string | null;
@@ -22,13 +22,15 @@ export function ActionItemForm({
   deleteError,
 }: ActionItemFormProps) {
   const [newTitle, setNewTitle] = useState("");
+  const [newDueDate, setNewDueDate] = useState("");
 
   const handleAdd = async () => {
     const trimmed = newTitle.trim();
     if (!trimmed) return;
-    const success = await onAddActionItem(trimmed);
+    const success = await onAddActionItem(trimmed, newDueDate || undefined);
     if (success) {
       setNewTitle("");
+      setNewDueDate("");
     }
   };
 
@@ -53,6 +55,11 @@ export function ActionItemForm({
             >
               <div className="flex-1 min-w-0">
                 <span className="text-sm font-medium">{item.title}</span>
+                {item.due_date && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    期限: {item.due_date}
+                  </span>
+                )}
               </div>
               <Button
                 variant="ghost"
@@ -87,6 +94,15 @@ export function ActionItemForm({
               placeholder="アクションアイテムを追加..."
               className="flex-1"
               disabled={isAdding}
+            />
+            {/* TODO: API未対応。バックエンドにdue_dateが追加されたら送信値として連携する */}
+            <Input
+              type="date"
+              value={newDueDate}
+              onChange={(e) => setNewDueDate(e.target.value)}
+              className="w-40"
+              disabled={isAdding}
+              aria-label="期限"
             />
             <Button
               variant="outline"

--- a/frontend/src/features/recording/components/ActionItemForm.tsx
+++ b/frontend/src/features/recording/components/ActionItemForm.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { RecordActionItem } from "../types";
+
+interface ActionItemFormProps {
+  actionItems: RecordActionItem[];
+  onAddActionItem: (title: string) => Promise<boolean>;
+  onDeleteActionItem: (actionItemId: string) => Promise<void>;
+  isAdding: boolean;
+  addError: string | null;
+  deleteError: string | null;
+}
+
+export function ActionItemForm({
+  actionItems,
+  onAddActionItem,
+  onDeleteActionItem,
+  isAdding,
+  addError,
+  deleteError,
+}: ActionItemFormProps) {
+  const [newTitle, setNewTitle] = useState("");
+
+  const handleAdd = async () => {
+    const trimmed = newTitle.trim();
+    if (!trimmed) return;
+    const success = await onAddActionItem(trimmed);
+    if (success) {
+      setNewTitle("");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleAdd();
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>アクションアイテム</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {actionItems.map((item) => (
+            <div
+              key={item.action_item_id}
+              className="flex items-center gap-2 rounded-md border p-3"
+            >
+              <div className="flex-1 min-w-0">
+                <span className="text-sm font-medium">{item.title}</span>
+              </div>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => void onDeleteActionItem(item.action_item_id)}
+                aria-label={`${item.title}を削除`}
+              >
+                x
+              </Button>
+            </div>
+          ))}
+          {actionItems.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              アクションアイテムはまだありません
+            </p>
+          )}
+          {deleteError && (
+            <p className="text-sm text-destructive" role="alert">
+              {deleteError}
+            </p>
+          )}
+          {addError && (
+            <p className="text-sm text-destructive" role="alert">
+              {addError}
+            </p>
+          )}
+          <div className="flex gap-2 pt-2">
+            <Input
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="アクションアイテムを追加..."
+              className="flex-1"
+              disabled={isAdding}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleAdd()}
+              disabled={isAdding || !newTitle.trim()}
+            >
+              追加
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/recording/components/AgendaChecklist.tsx
+++ b/frontend/src/features/recording/components/AgendaChecklist.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { AgendaItem } from "@/features/preparation/types";
+import { getAddedByTagLabel } from "../utils";
+
+interface AgendaChecklistProps {
+  agendas: AgendaItem[];
+  confirmedAgendaIds: string[];
+  isLoading: boolean;
+  error: string | null;
+  onConfirmAgenda: (agendaId: string) => Promise<void>;
+  onAddAgenda: (topic: string) => Promise<boolean>;
+  isAddingAgenda: boolean;
+  confirmError: string | null;
+  addAgendaError: string | null;
+}
+
+export function AgendaChecklist({
+  agendas,
+  confirmedAgendaIds,
+  isLoading,
+  error,
+  onConfirmAgenda,
+  onAddAgenda,
+  isAddingAgenda,
+  confirmError,
+  addAgendaError,
+}: AgendaChecklistProps) {
+  const [newTopic, setNewTopic] = useState("");
+
+  const handleAddAgenda = async () => {
+    const trimmed = newTopic.trim();
+    if (!trimmed) return;
+    const success = await onAddAgenda(trimmed);
+    if (success) {
+      setNewTopic("");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleAddAgenda();
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>アジェンダ</CardTitle>
+        <CardDescription>話し終えたらチェック</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="animate-pulse flex items-center gap-3">
+                <div className="h-4 w-4 rounded bg-muted" />
+                <div className="flex-1 space-y-1">
+                  <div className="h-4 w-48 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!isLoading && !error && (
+          <div className="space-y-2">
+            {agendas.map((agenda) => {
+              const isConfirmed = confirmedAgendaIds.includes(agenda.agenda_id);
+              return (
+                <div
+                  key={agenda.agenda_id}
+                  className="flex items-center gap-3 rounded-md border p-3"
+                >
+                  <button
+                    type="button"
+                    role="checkbox"
+                    aria-checked={isConfirmed}
+                    aria-label={`${agenda.topic}を確認`}
+                    className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border text-xs ${
+                      isConfirmed
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-input"
+                    }`}
+                    onClick={() => void onConfirmAgenda(agenda.agenda_id)}
+                    disabled={isConfirmed}
+                  >
+                    {isConfirmed && "✓"}
+                  </button>
+                  <div className="flex-1 min-w-0">
+                    <span
+                      className={`text-sm font-medium ${isConfirmed ? "line-through text-muted-foreground" : ""}`}
+                    >
+                      {agenda.topic}
+                    </span>
+                    <span className="ml-2 inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                      {getAddedByTagLabel(agenda.added_by_tag)}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+            {agendas.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                アジェンダはまだありません
+              </p>
+            )}
+            {confirmError && (
+              <p className="text-sm text-destructive" role="alert">
+                {confirmError}
+              </p>
+            )}
+            {addAgendaError && (
+              <p className="text-sm text-destructive" role="alert">
+                {addAgendaError}
+              </p>
+            )}
+            <div className="flex gap-2 pt-2">
+              <Input
+                value={newTopic}
+                onChange={(e) => setNewTopic(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="話題が増えたら追加..."
+                className="flex-1"
+                disabled={isAddingAgenda}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleAddAgenda()}
+                disabled={isAddingAgenda || !newTopic.trim()}
+              >
+                追加
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/recording/components/MemoEditor.tsx
+++ b/frontend/src/features/recording/components/MemoEditor.tsx
@@ -1,0 +1,48 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface MemoEditorProps {
+  memo: string;
+  onMemoChange: (memo: string) => void;
+  onSaveMemo: () => void;
+  isSaving: boolean;
+  error: string | null;
+}
+
+export function MemoEditor({
+  memo,
+  onMemoChange,
+  onSaveMemo,
+  isSaving,
+  error,
+}: MemoEditorProps) {
+  const handleBlur = () => {
+    onSaveMemo();
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>メモ</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <textarea
+          value={memo}
+          onChange={(e) => onMemoChange(e.target.value)}
+          onBlur={handleBlur}
+          placeholder="1on1中に話した内容をメモしてください。"
+          aria-label="メモ"
+          className="w-full min-h-[160px] rounded-lg border border-input bg-muted/30 px-3 py-2.5 text-sm leading-relaxed transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 resize-y"
+          disabled={isSaving}
+        />
+        {isSaving && (
+          <p className="mt-1 text-xs text-muted-foreground">保存中...</p>
+        )}
+        {error && (
+          <p className="mt-1 text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/recording/hooks/useAddActionItem.ts
+++ b/frontend/src/features/recording/hooks/useAddActionItem.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { AddActionItemResponse } from "../types";
+
+interface UseAddActionItemResult {
+  addActionItem: (title: string) => Promise<AddActionItemResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useAddActionItem(recordId: string): UseAddActionItemResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addActionItem = useCallback(
+    async (title: string): Promise<AddActionItemResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.post<AddActionItemResponse>(
+          `/records/${recordId}/action-items`,
+          userId,
+          { title },
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`アクションアイテムの追加に失敗しました (${e.status})`);
+        } else {
+          setError("アクションアイテムの追加に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [recordId, userId],
+  );
+
+  return { addActionItem, isSubmitting, error };
+}

--- a/frontend/src/features/recording/hooks/useConfirmAgenda.ts
+++ b/frontend/src/features/recording/hooks/useConfirmAgenda.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { ConfirmAgendaResponse } from "../types";
+
+interface UseConfirmAgendaResult {
+  confirmAgenda: (agendaId: string) => Promise<ConfirmAgendaResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useConfirmAgenda(recordId: string): UseConfirmAgendaResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const confirmAgenda = useCallback(
+    async (agendaId: string): Promise<ConfirmAgendaResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.post<ConfirmAgendaResponse>(
+          `/records/${recordId}/agendas/${agendaId}/confirm`,
+          userId,
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`アジェンダの確認に失敗しました (${e.status})`);
+        } else {
+          setError("アジェンダの確認に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [recordId, userId],
+  );
+
+  return { confirmAgenda, isSubmitting, error };
+}

--- a/frontend/src/features/recording/hooks/useDeleteActionItem.ts
+++ b/frontend/src/features/recording/hooks/useDeleteActionItem.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+
+interface UseDeleteActionItemResult {
+  deleteActionItem: (actionItemId: string) => Promise<boolean>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useDeleteActionItem(
+  recordId: string,
+): UseDeleteActionItemResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteActionItem = useCallback(
+    async (actionItemId: string): Promise<boolean> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        await apiClient.delete<void>(
+          `/records/${recordId}/action-items/${actionItemId}`,
+          userId,
+        );
+        return true;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`アクションアイテムの削除に失敗しました (${e.status})`);
+        } else {
+          setError("アクションアイテムの削除に失敗しました");
+        }
+        return false;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [recordId, userId],
+  );
+
+  return { deleteActionItem, isSubmitting, error };
+}

--- a/frontend/src/features/recording/hooks/useRecordDetail.ts
+++ b/frontend/src/features/recording/hooks/useRecordDetail.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { RecordDetail } from "../types";
+
+interface UseRecordDetailResult {
+  record: RecordDetail | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useRecordDetail(recordId: string): UseRecordDetailResult {
+  const { userId } = useCurrentUser();
+  const [record, setRecord] = useState<RecordDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRecord = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<RecordDetail>(
+        `/records/${recordId}`,
+        userId,
+      );
+      setRecord(data);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`記録の取得に失敗しました (${e.status})`);
+      } else {
+        setError("記録の取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [recordId, userId]);
+
+  useEffect(() => {
+    void fetchRecord();
+  }, [fetchRecord]);
+
+  return { record, isLoading, error, refetch: fetchRecord };
+}

--- a/frontend/src/features/recording/pages/RecordingPage.tsx
+++ b/frontend/src/features/recording/pages/RecordingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { useScheduleAgendas } from "@/features/preparation/hooks/useScheduleAgendas";
@@ -66,6 +66,7 @@ export function RecordingPage() {
   } = useSaveDraft(recordId!);
 
   const [memo, setMemo] = useState<string | null>(null);
+  const isSavingRef = useRef(false);
 
   // Initialize memo from record once loaded
   const currentMemo = memo ?? record?.memo ?? "";
@@ -75,6 +76,7 @@ export function RecordingPage() {
   };
 
   const handleSaveMemo = async () => {
+    if (isSavingRef.current) return;
     await updateMemo(currentMemo);
   };
 
@@ -115,13 +117,21 @@ export function RecordingPage() {
     }
   };
 
+  const handleCompleteMouseDown = () => {
+    isSavingRef.current = true;
+  };
+
   const handleSaveAndComplete = async () => {
-    // Save memo first, then save draft, then navigate to publish
-    const memoResult = await updateMemo(currentMemo);
-    if (!memoResult) return;
-    const result = await saveDraft();
-    if (result) {
-      void navigate(`/records/${recordId}/publish`);
+    try {
+      // Save memo first, then save draft, then navigate to publish
+      const memoResult = await updateMemo(currentMemo);
+      if (!memoResult) return;
+      const result = await saveDraft();
+      if (result) {
+        void navigate(`/records/${recordId}/publish`);
+      }
+    } finally {
+      isSavingRef.current = false;
     }
   };
 
@@ -162,6 +172,7 @@ export function RecordingPage() {
         </div>
         <Button
           size="lg"
+          onMouseDown={handleCompleteMouseDown}
           onClick={() => void handleSaveAndComplete()}
           disabled={isSavingDraft || isSavingMemo}
         >
@@ -218,6 +229,7 @@ export function RecordingPage() {
         )}
         <Button
           size="lg"
+          onMouseDown={handleCompleteMouseDown}
           onClick={() => void handleSaveAndComplete()}
           disabled={isSavingDraft || isSavingMemo}
         >

--- a/frontend/src/features/recording/pages/RecordingPage.tsx
+++ b/frontend/src/features/recording/pages/RecordingPage.tsx
@@ -1,12 +1,223 @@
-import { useParams } from "react-router";
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import { Button } from "@/components/ui/button";
+import { useScheduleAgendas } from "@/features/preparation/hooks/useScheduleAgendas";
+import { useAddAgenda } from "@/features/preparation/hooks/useAddAgenda";
+import { useRecordDetail } from "../hooks/useRecordDetail";
+import { useConfirmAgenda } from "../hooks/useConfirmAgenda";
+import { useAddActionItem } from "../hooks/useAddActionItem";
+import { useDeleteActionItem } from "../hooks/useDeleteActionItem";
+import { useUpdateMemo } from "@/hooks/useUpdateMemo";
+import { useSaveDraft } from "@/hooks/useSaveDraft";
+import { AgendaChecklist } from "../components/AgendaChecklist";
+import { MemoEditor } from "../components/MemoEditor";
+import { ActionItemForm } from "../components/ActionItemForm";
+import { formatScheduleDateTime } from "../utils";
 
 export function RecordingPage() {
   const { recordId } = useParams<{ recordId: string }>();
+  const navigate = useNavigate();
+
+  const {
+    record,
+    isLoading: recordLoading,
+    error: recordError,
+    refetch: refetchRecord,
+  } = useRecordDetail(recordId!);
+
+  // Load agendas from the linked schedule
+  const scheduleId = record?.schedule_id ?? null;
+  const {
+    agendas,
+    isLoading: agendasLoading,
+    error: agendasError,
+    refetch: refetchAgendas,
+  } = useScheduleAgendas(scheduleId ?? "");
+
+  const {
+    addAgenda,
+    isSubmitting: isAddingAgenda,
+    error: addAgendaError,
+  } = useAddAgenda(scheduleId ?? "");
+
+  const { confirmAgenda, error: confirmAgendaError } = useConfirmAgenda(
+    recordId!,
+  );
+
+  const {
+    addActionItem,
+    isSubmitting: isAddingActionItem,
+    error: addActionItemError,
+  } = useAddActionItem(recordId!);
+
+  const { deleteActionItem, error: deleteActionItemError } =
+    useDeleteActionItem(recordId!);
+
+  const {
+    updateMemo,
+    isSubmitting: isSavingMemo,
+    error: memoError,
+  } = useUpdateMemo(recordId!);
+
+  const {
+    saveDraft,
+    isSubmitting: isSavingDraft,
+    error: saveDraftError,
+  } = useSaveDraft(recordId!);
+
+  const [memo, setMemo] = useState<string | null>(null);
+
+  // Initialize memo from record once loaded
+  const currentMemo = memo ?? record?.memo ?? "";
+
+  const handleMemoChange = (value: string) => {
+    setMemo(value);
+  };
+
+  const handleSaveMemo = async () => {
+    await updateMemo(currentMemo);
+  };
+
+  const handleConfirmAgenda = async (agendaId: string) => {
+    const result = await confirmAgenda(agendaId);
+    if (result) {
+      refetchRecord();
+    }
+  };
+
+  const handleAddAgenda = async (topic: string): Promise<boolean> => {
+    const result = await addAgenda(topic);
+    if (result) {
+      refetchAgendas();
+      return true;
+    }
+    return false;
+  };
+
+  const handleAddActionItem = async (title: string): Promise<boolean> => {
+    const result = await addActionItem(title);
+    if (result) {
+      refetchRecord();
+      return true;
+    }
+    return false;
+  };
+
+  const handleDeleteActionItem = async (actionItemId: string) => {
+    const success = await deleteActionItem(actionItemId);
+    if (success) {
+      refetchRecord();
+    }
+  };
+
+  const handleSaveAndComplete = async () => {
+    // Save memo first, then save draft, then navigate to publish
+    await updateMemo(currentMemo);
+    const result = await saveDraft();
+    if (result) {
+      void navigate(`/records/${recordId}/publish`);
+    }
+  };
+
+  // Show loading state
+  if (recordLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 w-64 rounded bg-muted" />
+          <div className="h-4 w-40 rounded bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  // Show error state
+  if (recordError) {
+    return (
+      <div className="space-y-6">
+        <p className="text-sm text-destructive" role="alert">
+          {recordError}
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Recording</h1>
-      <p className="mt-2 text-muted-foreground">Record ID: {recordId}</p>
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">1on1 記録</h1>
+          {record && (
+            <p className="mt-1 text-muted-foreground">
+              {formatScheduleDateTime(record.conducted_at)}
+            </p>
+          )}
+        </div>
+        <Button
+          size="lg"
+          onClick={() => void handleSaveAndComplete()}
+          disabled={isSavingDraft || isSavingMemo}
+        >
+          {isSavingDraft ? "保存中..." : "完了として保存"}
+        </Button>
+      </div>
+
+      {/* Status bar */}
+      <div className="flex items-center gap-2 rounded-lg bg-green-50 px-4 py-2 text-sm text-green-800 dark:bg-green-950 dark:text-green-200">
+        <div className="h-2 w-2 rounded-full bg-green-500" />
+        実施中
+      </div>
+
+      {/* Agenda checklist */}
+      {scheduleId && (
+        <AgendaChecklist
+          agendas={agendas}
+          confirmedAgendaIds={record?.confirmed_agenda_ids ?? []}
+          isLoading={agendasLoading}
+          error={agendasError}
+          onConfirmAgenda={handleConfirmAgenda}
+          onAddAgenda={handleAddAgenda}
+          isAddingAgenda={isAddingAgenda}
+          confirmError={confirmAgendaError}
+          addAgendaError={addAgendaError}
+        />
+      )}
+
+      {/* Memo editor */}
+      <MemoEditor
+        memo={currentMemo}
+        onMemoChange={handleMemoChange}
+        onSaveMemo={() => void handleSaveMemo()}
+        isSaving={isSavingMemo}
+        error={memoError}
+      />
+
+      {/* Action items */}
+      <ActionItemForm
+        actionItems={record?.action_items ?? []}
+        onAddActionItem={handleAddActionItem}
+        onDeleteActionItem={handleDeleteActionItem}
+        isAdding={isAddingActionItem}
+        addError={addActionItemError}
+        deleteError={deleteActionItemError}
+      />
+
+      {/* Footer save button */}
+      <div className="flex justify-end gap-3">
+        {saveDraftError && (
+          <p className="self-center text-sm text-destructive">
+            {saveDraftError}
+          </p>
+        )}
+        <Button
+          size="lg"
+          onClick={() => void handleSaveAndComplete()}
+          disabled={isSavingDraft || isSavingMemo}
+        >
+          {isSavingDraft ? "保存中..." : "完了として保存"}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/recording/pages/RecordingPage.tsx
+++ b/frontend/src/features/recording/pages/RecordingPage.tsx
@@ -94,7 +94,12 @@ export function RecordingPage() {
     return false;
   };
 
-  const handleAddActionItem = async (title: string): Promise<boolean> => {
+  // TODO: API未対応。バックエンドにdue_dateフィールドが追加されたらdueDateを送信する
+  const handleAddActionItem = async (
+    title: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _dueDate?: string,
+  ): Promise<boolean> => {
     const result = await addActionItem(title);
     if (result) {
       refetchRecord();
@@ -112,7 +117,8 @@ export function RecordingPage() {
 
   const handleSaveAndComplete = async () => {
     // Save memo first, then save draft, then navigate to publish
-    await updateMemo(currentMemo);
+    const memoResult = await updateMemo(currentMemo);
+    if (!memoResult) return;
     const result = await saveDraft();
     if (result) {
       void navigate(`/records/${recordId}/publish`);

--- a/frontend/src/features/recording/types.ts
+++ b/frontend/src/features/recording/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared type definitions for the recording feature.
+ *
+ * These types mirror the backend API response schemas for the Record context.
+ */
+
+export interface RecordActionItem {
+  action_item_id: string;
+  title: string;
+  is_completed: boolean;
+  counterpart_id: string;
+  created_at: string;
+}
+
+export interface RecordDetail {
+  record_id: string;
+  organizer_id: string;
+  counterpart_id: string;
+  schedule_id: string | null;
+  memo: string;
+  status: string;
+  confirmed_agenda_ids: string[];
+  action_items: RecordActionItem[];
+  conducted_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ConfirmAgendaResponse {
+  record_id: string;
+  agenda_id: string;
+}
+
+export interface AddActionItemResponse {
+  action_item_id: string;
+}
+
+export interface DeleteActionItemResponse {
+  action_item_id: string;
+}

--- a/frontend/src/features/recording/types.ts
+++ b/frontend/src/features/recording/types.ts
@@ -10,6 +10,8 @@ export interface RecordActionItem {
   is_completed: boolean;
   counterpart_id: string;
   created_at: string;
+  /** TODO: API未対応。バックエンドにdue_dateフィールドが追加されたら連携する */
+  due_date?: string;
 }
 
 export interface RecordDetail {
@@ -32,9 +34,5 @@ export interface ConfirmAgendaResponse {
 }
 
 export interface AddActionItemResponse {
-  action_item_id: string;
-}
-
-export interface DeleteActionItemResponse {
   action_item_id: string;
 }

--- a/frontend/src/features/recording/utils.ts
+++ b/frontend/src/features/recording/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Utility functions for the recording feature.
+ * Separated from components to avoid react-refresh warnings.
+ */
+
+export { getRelativeLabel, formatScheduleDateTime } from "@/utils/date";
+
+/**
+ * Get the added_by_tag display label for agenda items.
+ */
+export function getAddedByTagLabel(tag: string): string {
+  switch (tag) {
+    case "organizer":
+      return "オーガナイザーが追加";
+    case "counterpart":
+      return "カウンターパートが追加";
+    case "template":
+      return "テンプレート";
+    default:
+      return tag;
+  }
+}

--- a/frontend/src/hooks/__tests__/useSaveDraft.test.ts
+++ b/frontend/src/hooks/__tests__/useSaveDraft.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApiError } from "@/api/client";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockPost = vi.fn();
+
+vi.mock("@/api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    apiClient: {
+      get: vi.fn(),
+      post: (...args: unknown[]) => mockPost(...args),
+      put: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// -- useSaveDraft -------------------------------------------------------------
+
+describe("useSaveDraft", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { record_id: "r1" };
+    mockPost.mockResolvedValueOnce(mockResponse);
+
+    const { useSaveDraft } = await import("../useSaveDraft");
+    const { result } = renderHook(() => useSaveDraft("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.saveDraft();
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/records/r1/save-draft",
+      TEST_USER_ID,
+    );
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useSaveDraft } = await import("../useSaveDraft");
+    const { result } = renderHook(() => useSaveDraft("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.saveDraft();
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("下書き保存に失敗しました (400)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new Error("network"));
+
+    const { useSaveDraft } = await import("../useSaveDraft");
+    const { result } = renderHook(() => useSaveDraft("r1"));
+
+    await act(async () => {
+      await result.current.saveDraft();
+    });
+
+    expect(result.current.error).toBe("下書き保存に失敗しました");
+  });
+});

--- a/frontend/src/hooks/__tests__/useUpdateMemo.test.ts
+++ b/frontend/src/hooks/__tests__/useUpdateMemo.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApiError } from "@/api/client";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockPut = vi.fn();
+
+vi.mock("@/api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    apiClient: {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: (...args: unknown[]) => mockPut(...args),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// -- useUpdateMemo ------------------------------------------------------------
+
+describe("useUpdateMemo", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { record_id: "r1" };
+    mockPut.mockResolvedValueOnce(mockResponse);
+
+    const { useUpdateMemo } = await import("../useUpdateMemo");
+    const { result } = renderHook(() => useUpdateMemo("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.updateMemo("Updated memo");
+    });
+
+    expect(mockPut).toHaveBeenCalledWith("/records/r1/memo", TEST_USER_ID, {
+      memo: "Updated memo",
+    });
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPut.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useUpdateMemo } = await import("../useUpdateMemo");
+    const { result } = renderHook(() => useUpdateMemo("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.updateMemo("Bad memo");
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("メモの保存に失敗しました (400)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPut.mockRejectedValueOnce(new Error("network"));
+
+    const { useUpdateMemo } = await import("../useUpdateMemo");
+    const { result } = renderHook(() => useUpdateMemo("r1"));
+
+    await act(async () => {
+      await result.current.updateMemo("memo");
+    });
+
+    expect(result.current.error).toBe("メモの保存に失敗しました");
+  });
+});

--- a/frontend/src/hooks/useSaveDraft.ts
+++ b/frontend/src/hooks/useSaveDraft.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+
+interface SaveDraftResponse {
+  record_id: string;
+}
+
+interface UseSaveDraftResult {
+  saveDraft: () => Promise<SaveDraftResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useSaveDraft(recordId: string): UseSaveDraftResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const saveDraft = useCallback(async (): Promise<SaveDraftResponse | null> => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const data = await apiClient.post<SaveDraftResponse>(
+        `/records/${recordId}/save-draft`,
+        userId,
+      );
+      return data;
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`下書き保存に失敗しました (${e.status})`);
+      } else {
+        setError("下書き保存に失敗しました");
+      }
+      return null;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [recordId, userId]);
+
+  return { saveDraft, isSubmitting, error };
+}

--- a/frontend/src/hooks/useUpdateMemo.ts
+++ b/frontend/src/hooks/useUpdateMemo.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+
+interface UpdateMemoResponse {
+  record_id: string;
+}
+
+interface UseUpdateMemoResult {
+  updateMemo: (memo: string) => Promise<UpdateMemoResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useUpdateMemo(recordId: string): UseUpdateMemoResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateMemo = useCallback(
+    async (memo: string): Promise<UpdateMemoResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.put<UpdateMemoResponse>(
+          `/records/${recordId}/memo`,
+          userId,
+          { memo },
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`メモの保存に失敗しました (${e.status})`);
+        } else {
+          setError("メモの保存に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [recordId, userId],
+  );
+
+  return { updateMemo, isSubmitting, error };
+}


### PR DESCRIPTION
## Summary
- 1on1 実施中の記録画面（RecordingPage）を実装
- アジェンダのチェック・追加、メモ入力・保存、アクションアイテムの追加・削除が動作
- 「完了として保存」ボタンで公開フロー画面に遷移
- 共通 hooks（useUpdateMemo, useSaveDraft）を src/hooks/ に配置し #146 と共有可能に

## 実装内容

### hooks
- useRecordDetail, useConfirmAgenda, useAddActionItem, useDeleteActionItem
- useUpdateMemo, useSaveDraft（共通hook）

### components
- AgendaChecklist, MemoEditor, ActionItemForm

### pages
- RecordingPage

## 受け入れ条件
- [x] アジェンダのチェック・追加が動作する
- [x] メモの入力・保存が動作する
- [x] アクションアイテムの追加・削除が動作する
- [x] 完了として保存で公開フロー画面に遷移する
- [x] Vitest + RTL テスト

Closes #145

## Test plan
- [ ] pnpm lint / pnpm test が通ること
- [ ] 各操作が正しく動作すること
- [ ] APIエラー時に入力が消えないこと
