### PR TITLE
フロントエンド: 通知設定画面の実装

### DIFF
--- a/frontend/src/features/notification-settings/__tests__/NotificationSettingPage.test.tsx
+++ b/frontend/src/features/notification-settings/__tests__/NotificationSettingPage.test.tsx
@@ -1,0 +1,344 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NotificationSettingPage } from "../pages/NotificationSettingPage";
+import type { NotificationSetting } from "../types";
+
+// -- Mock data ----------------------------------------------------------------
+
+const mockSetting: NotificationSetting = {
+  user_id: "00000000-0000-0000-0000-000000000001",
+  reminder_minutes_before: 30,
+  is_enabled: true,
+};
+
+// -- Mock hooks ---------------------------------------------------------------
+
+let notificationSettingReturn = {
+  setting: mockSetting as NotificationSetting | null,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+const mockUpdateSetting = vi
+  .fn()
+  .mockResolvedValue({ ...mockSetting, reminder_minutes_before: 15 });
+let updateNotificationSettingReturn = {
+  updateSetting: mockUpdateSetting,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+vi.mock("../hooks/useNotificationSetting", () => ({
+  useNotificationSetting: () => notificationSettingReturn,
+}));
+
+vi.mock("../hooks/useUpdateNotificationSetting", () => ({
+  useUpdateNotificationSetting: () => updateNotificationSettingReturn,
+}));
+
+// -- Helpers ------------------------------------------------------------------
+
+function renderPage() {
+  return render(<NotificationSettingPage />);
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("NotificationSettingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationSettingReturn = {
+      setting: mockSetting,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    updateNotificationSettingReturn = {
+      updateSetting: mockUpdateSetting,
+      isSubmitting: false,
+      error: null,
+    };
+  });
+
+  // -- Normal data display --------------------------------------------------
+
+  it("renders the page title", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "通知設定" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the notification setting form with current values", () => {
+    renderPage();
+    expect(screen.getByText("リマインド通知")).toBeInTheDocument();
+    const minutesInput = screen.getByLabelText("リマインド時間（分前）");
+    expect(minutesInput).toHaveValue(30);
+  });
+
+  it("renders the toggle in enabled state", () => {
+    renderPage();
+    const toggle = screen.getByRole("switch", { name: "リマインド通知" });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders the toggle in disabled state when is_enabled is false", () => {
+    notificationSettingReturn = {
+      ...notificationSettingReturn,
+      setting: { ...mockSetting, is_enabled: false },
+    };
+    renderPage();
+    const toggle = screen.getByRole("switch", { name: "リマインド通知" });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  // -- Loading state --------------------------------------------------------
+
+  it("shows loading skeleton when data is loading", () => {
+    notificationSettingReturn = {
+      ...notificationSettingReturn,
+      setting: null,
+      isLoading: true,
+    };
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("does not render form when loading", () => {
+    notificationSettingReturn = {
+      ...notificationSettingReturn,
+      setting: null,
+      isLoading: true,
+    };
+    renderPage();
+    expect(
+      screen.queryByLabelText("リマインド時間（分前）"),
+    ).not.toBeInTheDocument();
+  });
+
+  // -- Error state ----------------------------------------------------------
+
+  it("shows error message when fetch fails", () => {
+    notificationSettingReturn = {
+      ...notificationSettingReturn,
+      setting: null,
+      error: "通知設定の取得に失敗しました (500)",
+    };
+    renderPage();
+    expect(
+      screen.getByText("通知設定の取得に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render form when fetch fails", () => {
+    notificationSettingReturn = {
+      ...notificationSettingReturn,
+      setting: null,
+      error: "通知設定の取得に失敗しました",
+    };
+    renderPage();
+    expect(
+      screen.queryByLabelText("リマインド時間（分前）"),
+    ).not.toBeInTheDocument();
+  });
+
+  // -- Save operation -------------------------------------------------------
+
+  it("calls updateSetting with form values when saving", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith({
+      is_enabled: true,
+      reminder_minutes_before: 30,
+    });
+  });
+
+  it("calls refetch after successful save", async () => {
+    mockUpdateSetting.mockResolvedValueOnce({
+      ...mockSetting,
+      reminder_minutes_before: 15,
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(notificationSettingReturn.refetch).toHaveBeenCalled();
+    });
+  });
+
+  it("does not call refetch when save fails", async () => {
+    mockUpdateSetting.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateSetting).toHaveBeenCalled();
+    });
+
+    expect(notificationSettingReturn.refetch).not.toHaveBeenCalled();
+  });
+
+  // -- Toggle interaction ---------------------------------------------------
+
+  it("toggles the switch and sends updated value on save", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const toggle = screen.getByRole("switch", { name: "リマインド通知" });
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith({
+      is_enabled: false,
+      reminder_minutes_before: 30,
+    });
+  });
+
+  // -- Minutes input interaction --------------------------------------------
+
+  it("updates minutes and sends updated value on save", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const minutesInput = screen.getByLabelText("リマインド時間（分前）");
+    await user.clear(minutesInput);
+    await user.type(minutesInput, "15");
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith({
+      is_enabled: true,
+      reminder_minutes_before: 15,
+    });
+  });
+
+  // -- Validation -----------------------------------------------------------
+
+  it("shows validation error for out-of-range minutes", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const minutesInput = screen.getByLabelText("リマインド時間（分前）");
+    await user.clear(minutesInput);
+    await user.type(minutesInput, "2");
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    expect(
+      screen.getByText("リマインド時間は5分から1440分の間で設定してください"),
+    ).toBeInTheDocument();
+    expect(mockUpdateSetting).not.toHaveBeenCalled();
+  });
+
+  it("clears validation error when user changes input", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const minutesInput = screen.getByLabelText("リマインド時間（分前）");
+    await user.clear(minutesInput);
+    await user.type(minutesInput, "2");
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    expect(
+      screen.getByText("リマインド時間は5分から1440分の間で設定してください"),
+    ).toBeInTheDocument();
+
+    await user.clear(minutesInput);
+    await user.type(minutesInput, "30");
+
+    expect(
+      screen.queryByText("リマインド時間は5分から1440分の間で設定してください"),
+    ).not.toBeInTheDocument();
+  });
+
+  // -- Update error display ------------------------------------------------
+
+  it("shows update error message", () => {
+    updateNotificationSettingReturn = {
+      ...updateNotificationSettingReturn,
+      error: "通知設定の更新に失敗しました (500)",
+    };
+    renderPage();
+    expect(
+      screen.getByText("通知設定の更新に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Input preserved on error ---------------------------------------------
+
+  it("preserves form values when update fails", async () => {
+    mockUpdateSetting.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const minutesInput = screen.getByLabelText("リマインド時間（分前）");
+    await user.clear(minutesInput);
+    await user.type(minutesInput, "60");
+
+    const toggle = screen.getByRole("switch", { name: "リマインド通知" });
+    await user.click(toggle);
+
+    const saveButton = screen.getByRole("button", { name: "保存" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateSetting).toHaveBeenCalled();
+    });
+
+    // Values should be preserved after failed save
+    expect(minutesInput).toHaveValue(60);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  // -- Submitting state -----------------------------------------------------
+
+  it("shows submitting state on save button", () => {
+    updateNotificationSettingReturn = {
+      ...updateNotificationSettingReturn,
+      isSubmitting: true,
+    };
+    renderPage();
+    const saveButton = screen.getByRole("button", { name: "保存中..." });
+    expect(saveButton).toBeDisabled();
+  });
+
+  // -- Minutes input disabled when toggle is off ----------------------------
+
+  it("disables minutes input when toggle is off", async () => {
+    notificationSettingReturn = {
+      ...notificationSettingReturn,
+      setting: { ...mockSetting, is_enabled: false },
+    };
+    renderPage();
+
+    const minutesInput = screen.getByLabelText("リマインド時間（分前）");
+    expect(minutesInput).toBeDisabled();
+  });
+});

--- a/frontend/src/features/notification-settings/__tests__/hooks.test.ts
+++ b/frontend/src/features/notification-settings/__tests__/hooks.test.ts
@@ -1,0 +1,188 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApiError } from "@/api/client";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockPut = vi.fn();
+
+vi.mock("@/api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    apiClient: {
+      get: (...args: unknown[]) => mockGet(...args),
+      put: (...args: unknown[]) => mockPut(...args),
+    },
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// -- useNotificationSetting ---------------------------------------------------
+
+describe("useNotificationSetting", () => {
+  it("fetches notification setting on mount and returns data", async () => {
+    const mockSetting = {
+      user_id: TEST_USER_ID,
+      reminder_minutes_before: 30,
+      is_enabled: true,
+    };
+    mockGet.mockResolvedValueOnce(mockSetting);
+
+    const { useNotificationSetting } =
+      await import("../hooks/useNotificationSetting");
+    const { result } = renderHook(() => useNotificationSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/notification-settings",
+      TEST_USER_ID,
+    );
+    expect(result.current.setting).toEqual(mockSetting);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when API call fails with ApiError", async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(500, "Server Error", {}));
+
+    const { useNotificationSetting } =
+      await import("../hooks/useNotificationSetting");
+    const { result } = renderHook(() => useNotificationSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.setting).toBeNull();
+    expect(result.current.error).toBe("通知設定の取得に失敗しました (500)");
+  });
+
+  it("sets generic error when a non-ApiError is thrown", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network failure"));
+
+    const { useNotificationSetting } =
+      await import("../hooks/useNotificationSetting");
+    const { result } = renderHook(() => useNotificationSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("通知設定の取得に失敗しました");
+  });
+
+  it("refetch reloads the data", async () => {
+    const mockSetting = {
+      user_id: TEST_USER_ID,
+      reminder_minutes_before: 30,
+      is_enabled: true,
+    };
+    mockGet.mockResolvedValue(mockSetting);
+
+    const { useNotificationSetting } =
+      await import("../hooks/useNotificationSetting");
+    const { result } = renderHook(() => useNotificationSetting());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+// -- useUpdateNotificationSetting ---------------------------------------------
+
+describe("useUpdateNotificationSetting", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = {
+      user_id: TEST_USER_ID,
+      reminder_minutes_before: 15,
+      is_enabled: false,
+    };
+    mockPut.mockResolvedValueOnce(mockResponse);
+
+    const { useUpdateNotificationSetting } =
+      await import("../hooks/useUpdateNotificationSetting");
+    const { result } = renderHook(() => useUpdateNotificationSetting());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.updateSetting({
+        reminder_minutes_before: 15,
+        is_enabled: false,
+      });
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "/notification-settings",
+      TEST_USER_ID,
+      { reminder_minutes_before: 15, is_enabled: false },
+    );
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPut.mockRejectedValueOnce(
+      new ApiError(422, "Unprocessable Entity", {}),
+    );
+
+    const { useUpdateNotificationSetting } =
+      await import("../hooks/useUpdateNotificationSetting");
+    const { result } = renderHook(() => useUpdateNotificationSetting());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.updateSetting({
+        reminder_minutes_before: 3,
+        is_enabled: true,
+      });
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("通知設定の更新に失敗しました (422)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPut.mockRejectedValueOnce(new Error("network"));
+
+    const { useUpdateNotificationSetting } =
+      await import("../hooks/useUpdateNotificationSetting");
+    const { result } = renderHook(() => useUpdateNotificationSetting());
+
+    await act(async () => {
+      await result.current.updateSetting({
+        reminder_minutes_before: 30,
+        is_enabled: true,
+      });
+    });
+
+    expect(result.current.error).toBe("通知設定の更新に失敗しました");
+  });
+});

--- a/frontend/src/features/notification-settings/components/NotificationSettingForm.tsx
+++ b/frontend/src/features/notification-settings/components/NotificationSettingForm.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  MIN_REMINDER_MINUTES,
+  MAX_REMINDER_MINUTES,
+  validateReminderMinutes,
+} from "../utils";
+
+interface NotificationSettingFormProps {
+  isEnabled: boolean;
+  reminderMinutesBefore: number;
+  onSave: (isEnabled: boolean, reminderMinutesBefore: number) => void;
+  isSubmitting: boolean;
+  submitError: string | null;
+}
+
+export function NotificationSettingForm({
+  isEnabled,
+  reminderMinutesBefore,
+  onSave,
+  isSubmitting,
+  submitError,
+}: NotificationSettingFormProps) {
+  const [enabled, setEnabled] = useState(isEnabled);
+  const [minutes, setMinutes] = useState(String(reminderMinutesBefore));
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSave = () => {
+    const minutesNum = Number(minutes);
+    const error = validateReminderMinutes(minutesNum);
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+    setValidationError(null);
+    onSave(enabled, minutesNum);
+  };
+
+  const handleMinutesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMinutes(e.target.value);
+    if (validationError) {
+      setValidationError(null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>通知設定</CardTitle>
+        <CardDescription>
+          リマインド通知の有効/無効と通知タイミングを設定します
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium">リマインド通知</p>
+            <p className="text-sm text-muted-foreground">
+              1on1の開始前にSlackで通知を受け取ります
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label="リマインド通知"
+            onClick={() => setEnabled(!enabled)}
+            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+              enabled ? "bg-primary" : "bg-muted"
+            }`}
+          >
+            <span
+              className={`pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                enabled ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+
+        {/* Reminder minutes */}
+        <div className="space-y-2">
+          <label htmlFor="reminder-minutes" className="text-sm font-medium">
+            リマインド時間（分前）
+          </label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="reminder-minutes"
+              type="number"
+              min={MIN_REMINDER_MINUTES}
+              max={MAX_REMINDER_MINUTES}
+              value={minutes}
+              onChange={handleMinutesChange}
+              className="w-24"
+              disabled={!enabled}
+            />
+            <span className="text-sm text-muted-foreground">
+              分前に通知（{MIN_REMINDER_MINUTES}〜{MAX_REMINDER_MINUTES}）
+            </span>
+          </div>
+          {validationError && (
+            <p className="text-sm text-destructive">{validationError}</p>
+          )}
+        </div>
+
+        {/* Error and save button */}
+        <div className="flex items-center justify-end gap-4">
+          {submitError && (
+            <p className="text-sm text-destructive">{submitError}</p>
+          )}
+          <Button onClick={handleSave} disabled={isSubmitting}>
+            {isSubmitting ? "保存中..." : "保存"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/notification-settings/hooks/useNotificationSetting.ts
+++ b/frontend/src/features/notification-settings/hooks/useNotificationSetting.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { NotificationSetting } from "../types";
+
+interface UseNotificationSettingResult {
+  setting: NotificationSetting | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useNotificationSetting(): UseNotificationSettingResult {
+  const { userId } = useCurrentUser();
+  const [setting, setSetting] = useState<NotificationSetting | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSetting = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<NotificationSetting>(
+        "/notification-settings",
+        userId,
+      );
+      setSetting(data);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`通知設定の取得に失敗しました (${e.status})`);
+      } else {
+        setError("通知設定の取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void fetchSetting();
+  }, [fetchSetting]);
+
+  return { setting, isLoading, error, refetch: fetchSetting };
+}

--- a/frontend/src/features/notification-settings/hooks/useUpdateNotificationSetting.ts
+++ b/frontend/src/features/notification-settings/hooks/useUpdateNotificationSetting.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type {
+  NotificationSetting,
+  UpdateNotificationSettingPayload,
+} from "../types";
+
+interface UseUpdateNotificationSettingResult {
+  updateSetting: (
+    payload: UpdateNotificationSettingPayload,
+  ) => Promise<NotificationSetting | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useUpdateNotificationSetting(): UseUpdateNotificationSettingResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateSetting = useCallback(
+    async (
+      payload: UpdateNotificationSettingPayload,
+    ): Promise<NotificationSetting | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.put<NotificationSetting>(
+          "/notification-settings",
+          userId,
+          payload,
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`通知設定の更新に失敗しました (${e.status})`);
+        } else {
+          setError("通知設定の更新に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [userId],
+  );
+
+  return { updateSetting, isSubmitting, error };
+}

--- a/frontend/src/features/notification-settings/pages/NotificationSettingPage.tsx
+++ b/frontend/src/features/notification-settings/pages/NotificationSettingPage.tsx
@@ -1,7 +1,64 @@
+import { useNotificationSetting } from "../hooks/useNotificationSetting";
+import { useUpdateNotificationSetting } from "../hooks/useUpdateNotificationSetting";
+import { NotificationSettingForm } from "../components/NotificationSettingForm";
+
 export function NotificationSettingPage() {
+  const {
+    setting,
+    isLoading,
+    error: fetchError,
+    refetch,
+  } = useNotificationSetting();
+
+  const {
+    updateSetting,
+    isSubmitting,
+    error: updateError,
+  } = useUpdateNotificationSetting();
+
+  const handleSave = async (
+    isEnabled: boolean,
+    reminderMinutesBefore: number,
+  ) => {
+    const result = await updateSetting({
+      is_enabled: isEnabled,
+      reminder_minutes_before: reminderMinutesBefore,
+    });
+    if (result) {
+      refetch();
+    }
+  };
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Notification Settings</h1>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">通知設定</h1>
+        <p className="mt-1 text-muted-foreground">
+          リマインド通知の設定を管理します
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-4">
+          <div className="h-48 animate-pulse rounded-xl bg-muted" />
+        </div>
+      )}
+
+      {fetchError && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{fetchError}</p>
+        </div>
+      )}
+
+      {!isLoading && !fetchError && setting && (
+        <NotificationSettingForm
+          isEnabled={setting.is_enabled}
+          reminderMinutesBefore={setting.reminder_minutes_before}
+          onSave={(enabled, minutes) => void handleSave(enabled, minutes)}
+          isSubmitting={isSubmitting}
+          submitError={updateError}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/features/notification-settings/types.ts
+++ b/frontend/src/features/notification-settings/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared type definitions for the notification-settings feature.
+ *
+ * These types mirror the backend API response schemas (NotificationSettingResponse)
+ * and request schemas (UpdateNotificationSettingRequest).
+ */
+
+export interface NotificationSetting {
+  user_id: string;
+  reminder_minutes_before: number;
+  is_enabled: boolean;
+}
+
+export interface UpdateNotificationSettingPayload {
+  reminder_minutes_before: number;
+  is_enabled: boolean;
+}

--- a/frontend/src/features/notification-settings/utils.ts
+++ b/frontend/src/features/notification-settings/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Utility constants and functions for the notification-settings feature.
+ * Separated from components to avoid react-refresh warnings.
+ */
+
+export const MIN_REMINDER_MINUTES = 5;
+export const MAX_REMINDER_MINUTES = 1440;
+
+/**
+ * Validate that the reminder minutes value is within the allowed range.
+ * Returns an error message if invalid, or null if valid.
+ */
+export function validateReminderMinutes(value: number): string | null {
+  if (!Number.isInteger(value)) {
+    return "リマインド時間は整数で入力してください";
+  }
+  if (value < MIN_REMINDER_MINUTES || value > MAX_REMINDER_MINUTES) {
+    return `リマインド時間は${MIN_REMINDER_MINUTES}分から${MAX_REMINDER_MINUTES}分の間で設定してください`;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- 通知設定の取得・更新画面を実装（#141）
- GET /notification-settings と PUT /notification-settings APIに対応するhooksを追加
- トグル（有効/無効）+ 数値入力（リマインド時間）+ 保存ボタンのフォームコンポーネントを実装
- クライアントサイドバリデーション（5〜1440分の範囲チェック）を実装
- hooks個別テスト・ページレベルテスト（Vitest + RTL）を追加

## Test plan
- [x] pnpm lint が通ること
- [x] pnpm test で全122テストが通ること
- [ ] 画面で通知設定の表示・変更・保存が動作すること
- [ ] 範囲外の値を入力した場合にバリデーションエラーが表示されること
- [ ] API エラー時にエラーメッセージが表示され、入力値が保持されること

Closes #141