### PR TITLE
フロントエンド: 公開フロー画面の実装

### DIFF
--- a/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
+++ b/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
@@ -1,0 +1,545 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PublishingPage } from "../pages/PublishingPage";
+import type {
+  RecordDetail,
+  RecordActionItem,
+} from "@/features/recording/types";
+
+// -- Mock data ----------------------------------------------------------------
+
+const mockActionItems: RecordActionItem[] = [
+  {
+    action_item_id: "ai1",
+    title: "資格取得の勉強計画を作成する",
+    is_completed: false,
+    counterpart_id: "cp1",
+    created_at: "2026-03-20T10:00:00Z",
+    due_date: "2026-04-10T00:00:00Z",
+  },
+  {
+    action_item_id: "ai2",
+    title: "進捗共有メールを送る",
+    is_completed: false,
+    counterpart_id: "cp1",
+    created_at: "2026-03-20T10:00:00Z",
+  },
+];
+
+const mockRecord: RecordDetail = {
+  record_id: "r1",
+  organizer_id: "org1",
+  counterpart_id: "cp1",
+  schedule_id: "s1",
+  memo: "テストメモの内容",
+  status: "draft",
+  confirmed_agenda_ids: ["a1"],
+  action_items: mockActionItems,
+  conducted_at: "2026-04-03T10:00:00Z",
+  created_at: "2026-03-20T10:00:00Z",
+  updated_at: "2026-03-20T10:00:00Z",
+};
+
+const mockSuggestedViewerIds = ["cp1", "viewer1"];
+
+// -- Mock hooks ---------------------------------------------------------------
+
+let recordDetailReturn = {
+  record: mockRecord as RecordDetail | null,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+let suggestedViewersReturn = {
+  suggestedViewerIds: mockSuggestedViewerIds,
+  isLoading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+const mockUpdateMemo = vi.fn().mockResolvedValue({ record_id: "r1" });
+let updateMemoReturn = {
+  updateMemo: mockUpdateMemo,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockSaveDraft = vi.fn().mockResolvedValue({ record_id: "r1" });
+let saveDraftReturn = {
+  saveDraft: mockSaveDraft,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockSetViewers = vi.fn().mockResolvedValue({ record_id: "r1" });
+let setViewersReturn = {
+  setViewers: mockSetViewers,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockPublishRecord = vi.fn().mockResolvedValue({ record_id: "r1" });
+let publishRecordReturn = {
+  publishRecord: mockPublishRecord,
+  isSubmitting: false,
+  error: null as string | null,
+};
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+vi.mock("@/features/recording/hooks/useRecordDetail", () => ({
+  useRecordDetail: () => recordDetailReturn,
+}));
+
+vi.mock("../hooks/useSuggestedViewers", () => ({
+  useSuggestedViewers: () => suggestedViewersReturn,
+}));
+
+vi.mock("@/hooks/useUpdateMemo", () => ({
+  useUpdateMemo: () => updateMemoReturn,
+}));
+
+vi.mock("@/hooks/useSaveDraft", () => ({
+  useSaveDraft: () => saveDraftReturn,
+}));
+
+vi.mock("../hooks/useSetViewers", () => ({
+  useSetViewers: () => setViewersReturn,
+}));
+
+vi.mock("../hooks/usePublishRecord", () => ({
+  usePublishRecord: () => publishRecordReturn,
+}));
+
+// -- Helpers ------------------------------------------------------------------
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/records/r1/publish"]}>
+      <Routes>
+        <Route path="records/:recordId/publish" element={<PublishingPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("PublishingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recordDetailReturn = {
+      record: mockRecord,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    suggestedViewersReturn = {
+      suggestedViewerIds: mockSuggestedViewerIds,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    updateMemoReturn = {
+      updateMemo: mockUpdateMemo,
+      isSubmitting: false,
+      error: null,
+    };
+    saveDraftReturn = {
+      saveDraft: mockSaveDraft,
+      isSubmitting: false,
+      error: null,
+    };
+    setViewersReturn = {
+      setViewers: mockSetViewers,
+      isSubmitting: false,
+      error: null,
+    };
+    publishRecordReturn = {
+      publishRecord: mockPublishRecord,
+      isSubmitting: false,
+      error: null,
+    };
+  });
+
+  // -- Normal data display --------------------------------------------------
+
+  it("renders the page title", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /公開フロー/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders status badge", () => {
+    renderPage();
+    expect(screen.getByText("下書き")).toBeInTheDocument();
+  });
+
+  it("renders the status bar", () => {
+    renderPage();
+    expect(screen.getByText("1on1 完了・記録を編集中")).toBeInTheDocument();
+  });
+
+  it("renders memo editor with initial memo", () => {
+    renderPage();
+    expect(screen.getByText("記録（メモ）")).toBeInTheDocument();
+    const textarea = screen.getByRole("textbox", { name: "メモ" });
+    expect(textarea).toHaveValue("テストメモの内容");
+  });
+
+  it("renders action items in read-only summary", () => {
+    renderPage();
+    expect(screen.getByText("アクションアイテム")).toBeInTheDocument();
+    expect(
+      screen.getByText("資格取得の勉強計画を作成する"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("進捗共有メールを送る")).toBeInTheDocument();
+  });
+
+  it("renders action item due date when present", () => {
+    renderPage();
+    expect(screen.getByText("期限：2026/04/10")).toBeInTheDocument();
+  });
+
+  it("renders the save draft button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: "下書き保存" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the publish settings button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: "公開設定へ" }),
+    ).toBeInTheDocument();
+  });
+
+  // -- Loading state --------------------------------------------------------
+
+  it("shows loading skeleton when record is loading", () => {
+    recordDetailReturn = {
+      ...recordDetailReturn,
+      record: null,
+      isLoading: true,
+    };
+
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows loading skeleton when suggested viewers are loading", () => {
+    suggestedViewersReturn = {
+      ...suggestedViewersReturn,
+      isLoading: true,
+    };
+
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  // -- Error state ----------------------------------------------------------
+
+  it("shows error message when record fetch fails", () => {
+    recordDetailReturn = {
+      ...recordDetailReturn,
+      record: null,
+      error: "記録の取得に失敗しました",
+    };
+
+    renderPage();
+    expect(screen.getByText("記録の取得に失敗しました")).toBeInTheDocument();
+  });
+
+  it("shows error message when suggested viewers fetch fails", () => {
+    suggestedViewersReturn = {
+      ...suggestedViewersReturn,
+      error: "公開先サジェストの取得に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("公開先サジェストの取得に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Memo update ----------------------------------------------------------
+
+  it("updates memo text on input change", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const textarea = screen.getByRole("textbox", { name: "メモ" });
+    await user.clear(textarea);
+    await user.type(textarea, "新しいメモ");
+
+    expect(textarea).toHaveValue("新しいメモ");
+  });
+
+  // -- Save draft -----------------------------------------------------------
+
+  it("calls updateMemo and saveDraft when clicking save draft button", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const saveButton = screen.getByRole("button", { name: "下書き保存" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateMemo).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockSaveDraft).toHaveBeenCalled();
+    });
+  });
+
+  it("does not call saveDraft when updateMemo fails during save draft", async () => {
+    mockUpdateMemo.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const saveButton = screen.getByRole("button", { name: "下書き保存" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateMemo).toHaveBeenCalled();
+    });
+
+    expect(mockSaveDraft).not.toHaveBeenCalled();
+  });
+
+  // -- Open modal -----------------------------------------------------------
+
+  it("opens the viewer select modal when clicking publish settings button", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const publishButton = screen.getByRole("button", { name: "公開設定へ" });
+    await user.click(publishButton);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("公開設定")).toBeInTheDocument();
+  });
+
+  // -- Publish flow ---------------------------------------------------------
+
+  it("calls updateMemo, setViewers, and publishRecord when publishing", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Open modal
+    const publishButton = screen.getByRole("button", { name: "公開設定へ" });
+    await user.click(publishButton);
+
+    // Click publish (default timing is "now")
+    const confirmButton = screen.getByRole("button", { name: "公開する" });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockUpdateMemo).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockSetViewers).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockPublishRecord).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/records/r1");
+    });
+  });
+
+  it("does not call setViewers when updateMemo fails during publish", async () => {
+    mockUpdateMemo.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const publishButton = screen.getByRole("button", { name: "公開設定へ" });
+    await user.click(publishButton);
+
+    const confirmButton = screen.getByRole("button", { name: "公開する" });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockUpdateMemo).toHaveBeenCalled();
+    });
+
+    expect(mockSetViewers).not.toHaveBeenCalled();
+    expect(mockPublishRecord).not.toHaveBeenCalled();
+  });
+
+  it("does not call publishRecord when setViewers fails", async () => {
+    mockSetViewers.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    renderPage();
+
+    const publishButton = screen.getByRole("button", { name: "公開設定へ" });
+    await user.click(publishButton);
+
+    const confirmButton = screen.getByRole("button", { name: "公開する" });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockSetViewers).toHaveBeenCalled();
+    });
+
+    expect(mockPublishRecord).not.toHaveBeenCalled();
+  });
+
+  // -- Draft from modal -----------------------------------------------------
+
+  it("saves draft from modal when selecting draft timing", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const publishButton = screen.getByRole("button", { name: "公開設定へ" });
+    await user.click(publishButton);
+
+    // Select draft timing
+    const draftRadio = screen.getByRole("radio", {
+      name: /下書きとして保存/,
+    });
+    await user.click(draftRadio);
+
+    // There are two "下書き保存" buttons (footer + modal), take the modal one (last)
+    const draftButtons = screen.getAllByRole("button", { name: "下書き保存" });
+    await user.click(draftButtons[draftButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockUpdateMemo).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockSetViewers).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockSaveDraft).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/records/drafts");
+    });
+  });
+
+  // -- Close modal ----------------------------------------------------------
+
+  it("closes modal when clicking cancel", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const publishButton = screen.getByRole("button", { name: "公開設定へ" });
+    await user.click(publishButton);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    const cancelButton = screen.getByRole("button", { name: "キャンセル" });
+    await user.click(cancelButton);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // -- Mutation error display -----------------------------------------------
+
+  it("shows memo save error message", () => {
+    updateMemoReturn = {
+      ...updateMemoReturn,
+      error: "メモの保存に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("メモの保存に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows saveDraft error message", () => {
+    saveDraftReturn = {
+      ...saveDraftReturn,
+      error: "下書き保存に失敗しました (500)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("下書き保存に失敗しました (500)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows setViewers error message", () => {
+    setViewersReturn = {
+      ...setViewersReturn,
+      error: "公開先の設定に失敗しました (400)",
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("公開先の設定に失敗しました (400)"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Empty action items ---------------------------------------------------
+
+  it("shows empty message when no action items", () => {
+    recordDetailReturn = {
+      ...recordDetailReturn,
+      record: { ...mockRecord, action_items: [] },
+    };
+
+    renderPage();
+    expect(
+      screen.getByText("アクションアイテムはありません"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Double-submit prevention on save draft --------------------------------
+
+  it("does not double-fire updateMemo when blur and save draft overlap", async () => {
+    mockUpdateMemo.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ record_id: "r1" }), 50),
+        ),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    const textarea = screen.getByRole("textbox", { name: "メモ" });
+    await user.type(textarea, "追記");
+
+    const saveButton = screen.getByRole("button", { name: "下書き保存" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveDraft).toHaveBeenCalled();
+    });
+
+    // updateMemo should be called exactly once (from handleSaveDraft),
+    // not twice (blur should be suppressed by isSavingRef)
+    expect(mockUpdateMemo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
+++ b/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
@@ -539,7 +539,7 @@ describe("PublishingPage", () => {
     });
 
     // updateMemo should be called exactly once (from handleSaveDraft),
-    // not twice (blur should be suppressed by isSavingRef)
+    // blur is skipped because dirty check sees memo was already marked as saved
     expect(mockUpdateMemo).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
+++ b/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
@@ -539,7 +539,7 @@ describe("PublishingPage", () => {
     });
 
     // updateMemo should be called exactly once (from handleSaveDraft),
-    // blur is skipped because dirty check sees memo was already marked as saved
+    // blur save is deferred via setTimeout and skipped because savingInProgressRef is set
     expect(mockUpdateMemo).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/publishing/__tests__/hooks.test.ts
+++ b/frontend/src/features/publishing/__tests__/hooks.test.ts
@@ -155,12 +155,14 @@ describe("usePublishRecord", () => {
 
     let response: unknown;
     await act(async () => {
-      response = await result.current.publishRecord(["v1", "v2"]);
+      response = await result.current.publishRecord();
     });
 
-    expect(mockPost).toHaveBeenCalledWith("/records/r1/publish", TEST_USER_ID, {
-      viewer_ids: ["v1", "v2"],
-    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/records/r1/publish",
+      TEST_USER_ID,
+      {},
+    );
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });
@@ -173,7 +175,7 @@ describe("usePublishRecord", () => {
 
     let response: unknown;
     await act(async () => {
-      response = await result.current.publishRecord(["v1"]);
+      response = await result.current.publishRecord();
     });
 
     expect(response).toBeNull();
@@ -187,7 +189,7 @@ describe("usePublishRecord", () => {
     const { result } = renderHook(() => usePublishRecord("r1"));
 
     await act(async () => {
-      await result.current.publishRecord(["v1"]);
+      await result.current.publishRecord();
     });
 
     expect(result.current.error).toBe("記録の公開に失敗しました");

--- a/frontend/src/features/publishing/__tests__/hooks.test.ts
+++ b/frontend/src/features/publishing/__tests__/hooks.test.ts
@@ -1,0 +1,195 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApiError } from "@/api/client";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPut = vi.fn();
+
+vi.mock("@/api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    apiClient: {
+      get: (...args: unknown[]) => mockGet(...args),
+      post: (...args: unknown[]) => mockPost(...args),
+      put: (...args: unknown[]) => mockPut(...args),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+  }),
+}));
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// -- useSuggestedViewers ------------------------------------------------------
+
+describe("useSuggestedViewers", () => {
+  it("fetches suggested viewers on mount and returns data", async () => {
+    const mockResponse = {
+      suggested_viewer_ids: ["viewer1", "viewer2"],
+    };
+    mockGet.mockResolvedValueOnce(mockResponse);
+
+    const { useSuggestedViewers } =
+      await import("../hooks/useSuggestedViewers");
+    const { result } = renderHook(() => useSuggestedViewers("r1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/records/r1/suggested-viewers",
+      TEST_USER_ID,
+    );
+    expect(result.current.suggestedViewerIds).toEqual(["viewer1", "viewer2"]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when API call fails with ApiError", async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(404, "Not Found", {}));
+
+    const { useSuggestedViewers } =
+      await import("../hooks/useSuggestedViewers");
+    const { result } = renderHook(() => useSuggestedViewers("r1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.suggestedViewerIds).toEqual([]);
+    expect(result.current.error).toBe(
+      "公開先サジェストの取得に失敗しました (404)",
+    );
+  });
+
+  it("sets generic error when a non-ApiError is thrown", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network failure"));
+
+    const { useSuggestedViewers } =
+      await import("../hooks/useSuggestedViewers");
+    const { result } = renderHook(() => useSuggestedViewers("r1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("公開先サジェストの取得に失敗しました");
+  });
+});
+
+// -- useSetViewers ------------------------------------------------------------
+
+describe("useSetViewers", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { record_id: "r1" };
+    mockPut.mockResolvedValueOnce(mockResponse);
+
+    const { useSetViewers } = await import("../hooks/useSetViewers");
+    const { result } = renderHook(() => useSetViewers("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.setViewers(["v1", "v2"]);
+    });
+
+    expect(mockPut).toHaveBeenCalledWith("/records/r1/viewers", TEST_USER_ID, {
+      viewer_ids: ["v1", "v2"],
+    });
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPut.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useSetViewers } = await import("../hooks/useSetViewers");
+    const { result } = renderHook(() => useSetViewers("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.setViewers(["v1"]);
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("公開先の設定に失敗しました (400)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPut.mockRejectedValueOnce(new Error("network"));
+
+    const { useSetViewers } = await import("../hooks/useSetViewers");
+    const { result } = renderHook(() => useSetViewers("r1"));
+
+    await act(async () => {
+      await result.current.setViewers(["v1"]);
+    });
+
+    expect(result.current.error).toBe("公開先の設定に失敗しました");
+  });
+});
+
+// -- usePublishRecord ---------------------------------------------------------
+
+describe("usePublishRecord", () => {
+  it("calls API and returns response on success", async () => {
+    const mockResponse = { record_id: "r1" };
+    mockPost.mockResolvedValueOnce(mockResponse);
+
+    const { usePublishRecord } = await import("../hooks/usePublishRecord");
+    const { result } = renderHook(() => usePublishRecord("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.publishRecord(["v1", "v2"]);
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("/records/r1/publish", TEST_USER_ID, {
+      viewer_ids: ["v1", "v2"],
+    });
+    expect(response).toEqual(mockResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { usePublishRecord } = await import("../hooks/usePublishRecord");
+    const { result } = renderHook(() => usePublishRecord("r1"));
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.publishRecord(["v1"]);
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBe("記録の公開に失敗しました (400)");
+  });
+
+  it("sets generic error on non-ApiError", async () => {
+    mockPost.mockRejectedValueOnce(new Error("network"));
+
+    const { usePublishRecord } = await import("../hooks/usePublishRecord");
+    const { result } = renderHook(() => usePublishRecord("r1"));
+
+    await act(async () => {
+      await result.current.publishRecord(["v1"]);
+    });
+
+    expect(result.current.error).toBe("記録の公開に失敗しました");
+  });
+});

--- a/frontend/src/features/publishing/components/ActionItemSummary.tsx
+++ b/frontend/src/features/publishing/components/ActionItemSummary.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { RecordActionItem } from "@/features/recording/types";
+import { formatDateShort } from "@/utils/date";
+
+interface ActionItemSummaryProps {
+  actionItems: RecordActionItem[];
+}
+
+export function ActionItemSummary({ actionItems }: ActionItemSummaryProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>アクションアイテム</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {actionItems.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            アクションアイテムはありません
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {actionItems.map((item) => (
+              <li
+                key={item.action_item_id}
+                className="flex items-center justify-between rounded-lg border px-4 py-3"
+              >
+                <span className="text-sm">{item.title}</span>
+                {item.due_date && (
+                  <span className="text-xs text-muted-foreground">
+                    期限：{formatDateShort(item.due_date)}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/publishing/components/MemoEditor.tsx
+++ b/frontend/src/features/publishing/components/MemoEditor.tsx
@@ -1,0 +1,48 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface MemoEditorProps {
+  memo: string;
+  onMemoChange: (memo: string) => void;
+  onSaveMemo: () => void;
+  isSaving: boolean;
+  error: string | null;
+}
+
+export function MemoEditor({
+  memo,
+  onMemoChange,
+  onSaveMemo,
+  isSaving,
+  error,
+}: MemoEditorProps) {
+  const handleBlur = () => {
+    onSaveMemo();
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>記録（メモ）</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <textarea
+          value={memo}
+          onChange={(e) => onMemoChange(e.target.value)}
+          onBlur={handleBlur}
+          placeholder="1on1の記録を編集してください。"
+          aria-label="メモ"
+          className="w-full min-h-[160px] rounded-lg border border-input bg-muted/30 px-3 py-2.5 text-sm leading-relaxed transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 resize-y"
+          disabled={isSaving}
+        />
+        {isSaving && (
+          <p className="mt-1 text-xs text-muted-foreground">保存中...</p>
+        )}
+        {error && (
+          <p className="mt-1 text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/publishing/components/ViewerSelectModal.tsx
+++ b/frontend/src/features/publishing/components/ViewerSelectModal.tsx
@@ -1,0 +1,199 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ViewerSelectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  suggestedViewerIds: string[];
+  counterpartId: string;
+  onPublish: (viewerIds: string[]) => void;
+  onSaveDraft: (viewerIds: string[]) => void;
+  isPublishing: boolean;
+  isSavingDraft: boolean;
+  publishError: string | null;
+  saveDraftError: string | null;
+}
+
+/**
+ * Inner modal content, remounted each time the modal opens via key prop.
+ * This ensures state is reset on each open without useEffect.
+ */
+function ViewerSelectModalContent({
+  onClose,
+  suggestedViewerIds,
+  counterpartId,
+  onPublish,
+  onSaveDraft,
+  isPublishing,
+  isSavingDraft,
+  publishError,
+  saveDraftError,
+}: Omit<ViewerSelectModalProps, "isOpen">) {
+  const [selectedViewerIds, setSelectedViewerIds] = useState<Set<string>>(
+    () => new Set(suggestedViewerIds),
+  );
+  const [timing, setTiming] = useState<"now" | "draft">("now");
+
+  const toggleViewer = (viewerId: string) => {
+    setSelectedViewerIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(viewerId)) {
+        next.delete(viewerId);
+      } else {
+        next.add(viewerId);
+      }
+      return next;
+    });
+  };
+
+  // Additional viewers are suggested viewers excluding the counterpart
+  const additionalViewerIds = suggestedViewerIds.filter(
+    (id) => id !== counterpartId,
+  );
+
+  const handleConfirm = () => {
+    // Counterpart is always included
+    const allViewerIds = [counterpartId, ...selectedViewerIds];
+    // Deduplicate
+    const uniqueViewerIds = [...new Set(allViewerIds)];
+
+    if (timing === "now") {
+      onPublish(uniqueViewerIds);
+    } else {
+      onSaveDraft(uniqueViewerIds);
+    }
+  };
+
+  const isBusy = isPublishing || isSavingDraft;
+  const error = publishError ?? saveDraftError;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-label="公開設定"
+    >
+      <div className="w-full max-w-md rounded-xl bg-background p-6 shadow-lg">
+        <h2 className="text-lg font-semibold">公開設定</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          この1on1の記録を共有する相手を選んでください。カウンターパートには常に公開されます。
+        </p>
+
+        {/* Additional viewers */}
+        {additionalViewerIds.length > 0 && (
+          <div className="mt-4">
+            <p className="mb-2 text-sm font-medium">追加で共有する相手</p>
+            <div className="space-y-2">
+              {additionalViewerIds.map((viewerId) => (
+                <label
+                  key={viewerId}
+                  className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors ${
+                    selectedViewerIds.has(viewerId)
+                      ? "border-primary bg-primary/5"
+                      : "border-border"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedViewerIds.has(viewerId)}
+                    onChange={() => toggleViewer(viewerId)}
+                    className="h-4 w-4"
+                    aria-label={`${viewerId}を選択`}
+                  />
+                  <span className="text-sm">{viewerId}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Timing selection */}
+        <div className="mt-4 border-t pt-4">
+          <p className="mb-2 text-sm font-medium">公開タイミング</p>
+          <div className="space-y-2">
+            <label
+              className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors ${
+                timing === "now"
+                  ? "border-primary bg-primary/5"
+                  : "border-border"
+              }`}
+            >
+              <input
+                type="radio"
+                name="publish-timing"
+                value="now"
+                checked={timing === "now"}
+                onChange={() => setTiming("now")}
+                className="h-4 w-4"
+              />
+              <div>
+                <p className="text-sm font-medium">今すぐ公開</p>
+                <p className="text-xs text-muted-foreground">
+                  保存と同時にSlackで通知されます
+                </p>
+              </div>
+            </label>
+            <label
+              className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 transition-colors ${
+                timing === "draft"
+                  ? "border-primary bg-primary/5"
+                  : "border-border"
+              }`}
+            >
+              <input
+                type="radio"
+                name="publish-timing"
+                value="draft"
+                checked={timing === "draft"}
+                onChange={() => setTiming("draft")}
+                className="h-4 w-4"
+              />
+              <div>
+                <p className="text-sm font-medium">
+                  下書きとして保存（後で公開）
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  記録は保存されますが通知は送られません
+                </p>
+              </div>
+            </label>
+          </div>
+        </div>
+
+        {/* Error display */}
+        {error && (
+          <p className="mt-3 text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        {/* Actions */}
+        <div className="mt-6 flex justify-end gap-3">
+          <Button variant="ghost" onClick={onClose} disabled={isBusy}>
+            キャンセル
+          </Button>
+          <Button onClick={handleConfirm} disabled={isBusy}>
+            {isBusy
+              ? "処理中..."
+              : timing === "now"
+                ? "公開する"
+                : "下書き保存"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Wrapper that conditionally renders the modal content.
+ * Uses key={openCount} to remount and reset state each time the modal opens.
+ */
+export function ViewerSelectModal(props: ViewerSelectModalProps) {
+  if (!props.isOpen) return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { isOpen: _, ...rest } = props;
+  return <ViewerSelectModalContent {...rest} />;
+}

--- a/frontend/src/features/publishing/hooks/usePublishRecord.ts
+++ b/frontend/src/features/publishing/hooks/usePublishRecord.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { PublishRecordResponse } from "../types";
+
+interface UsePublishRecordResult {
+  publishRecord: (viewerIds: string[]) => Promise<PublishRecordResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function usePublishRecord(recordId: string): UsePublishRecordResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const publishRecord = useCallback(
+    async (viewerIds: string[]): Promise<PublishRecordResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.post<PublishRecordResponse>(
+          `/records/${recordId}/publish`,
+          userId,
+          { viewer_ids: viewerIds },
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`記録の公開に失敗しました (${e.status})`);
+        } else {
+          setError("記録の公開に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [recordId, userId],
+  );
+
+  return { publishRecord, isSubmitting, error };
+}

--- a/frontend/src/features/publishing/hooks/usePublishRecord.ts
+++ b/frontend/src/features/publishing/hooks/usePublishRecord.ts
@@ -4,7 +4,7 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { PublishRecordResponse } from "../types";
 
 interface UsePublishRecordResult {
-  publishRecord: (viewerIds: string[]) => Promise<PublishRecordResponse | null>;
+  publishRecord: () => Promise<PublishRecordResponse | null>;
   isSubmitting: boolean;
   error: string | null;
 }
@@ -14,15 +14,15 @@ export function usePublishRecord(recordId: string): UsePublishRecordResult {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const publishRecord = useCallback(
-    async (viewerIds: string[]): Promise<PublishRecordResponse | null> => {
+  const publishRecord =
+    useCallback(async (): Promise<PublishRecordResponse | null> => {
       setIsSubmitting(true);
       setError(null);
       try {
         const data = await apiClient.post<PublishRecordResponse>(
           `/records/${recordId}/publish`,
           userId,
-          { viewer_ids: viewerIds },
+          {},
         );
         return data;
       } catch (e) {
@@ -35,9 +35,7 @@ export function usePublishRecord(recordId: string): UsePublishRecordResult {
       } finally {
         setIsSubmitting(false);
       }
-    },
-    [recordId, userId],
-  );
+    }, [recordId, userId]);
 
   return { publishRecord, isSubmitting, error };
 }

--- a/frontend/src/features/publishing/hooks/useSetViewers.ts
+++ b/frontend/src/features/publishing/hooks/useSetViewers.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { SetViewersResponse } from "../types";
+
+interface UseSetViewersResult {
+  setViewers: (viewerIds: string[]) => Promise<SetViewersResponse | null>;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function useSetViewers(recordId: string): UseSetViewersResult {
+  const { userId } = useCurrentUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setViewers = useCallback(
+    async (viewerIds: string[]): Promise<SetViewersResponse | null> => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const data = await apiClient.put<SetViewersResponse>(
+          `/records/${recordId}/viewers`,
+          userId,
+          { viewer_ids: viewerIds },
+        );
+        return data;
+      } catch (e) {
+        if (e instanceof ApiError) {
+          setError(`公開先の設定に失敗しました (${e.status})`);
+        } else {
+          setError("公開先の設定に失敗しました");
+        }
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [recordId, userId],
+  );
+
+  return { setViewers, isSubmitting, error };
+}

--- a/frontend/src/features/publishing/hooks/useSuggestedViewers.ts
+++ b/frontend/src/features/publishing/hooks/useSuggestedViewers.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { SuggestedViewersResponse } from "../types";
+
+interface UseSuggestedViewersResult {
+  suggestedViewerIds: string[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useSuggestedViewers(
+  recordId: string,
+): UseSuggestedViewersResult {
+  const { userId } = useCurrentUser();
+  const [suggestedViewerIds, setSuggestedViewerIds] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSuggestedViewers = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<SuggestedViewersResponse>(
+        `/records/${recordId}/suggested-viewers`,
+        userId,
+      );
+      setSuggestedViewerIds(data.suggested_viewer_ids);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`公開先サジェストの取得に失敗しました (${e.status})`);
+      } else {
+        setError("公開先サジェストの取得に失敗しました");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [recordId, userId]);
+
+  useEffect(() => {
+    void fetchSuggestedViewers();
+  }, [fetchSuggestedViewers]);
+
+  return {
+    suggestedViewerIds,
+    isLoading,
+    error,
+    refetch: fetchSuggestedViewers,
+  };
+}

--- a/frontend/src/features/publishing/pages/PublishingPage.tsx
+++ b/frontend/src/features/publishing/pages/PublishingPage.tsx
@@ -54,7 +54,7 @@ export function PublishingPage() {
 
   const [memo, setMemo] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const isSavingRef = useRef(false);
+  const savingInProgressRef = useRef(false);
 
   // Initialize memo from record once loaded
   const currentMemo = memo ?? record?.memo ?? "";
@@ -63,24 +63,22 @@ export function PublishingPage() {
     setMemo(value);
   };
 
-  const handleSaveMemo = async () => {
-    if (isSavingRef.current) return;
-    await updateMemo(currentMemo);
-  };
-
-  // Suppress blur save before button action (mousedown/keydown fires before blur)
-  const handleButtonInteraction = () => {
-    isSavingRef.current = true;
+  const handleSaveMemo = () => {
+    // Defer to next frame so button click handlers can set savingInProgressRef first
+    setTimeout(() => {
+      if (savingInProgressRef.current) return;
+      void updateMemo(currentMemo);
+    }, 0);
   };
 
   const handleSaveDraft = async () => {
-    isSavingRef.current = true;
+    savingInProgressRef.current = true;
     try {
       const memoResult = await updateMemo(currentMemo);
       if (!memoResult) return;
       await saveDraft();
     } finally {
-      isSavingRef.current = false;
+      savingInProgressRef.current = false;
     }
   };
 
@@ -93,36 +91,40 @@ export function PublishingPage() {
   };
 
   const handlePublish = async (viewerIds: string[]) => {
-    // Save memo first
-    const memoResult = await updateMemo(currentMemo);
-    if (!memoResult) return;
+    savingInProgressRef.current = true;
+    try {
+      const memoResult = await updateMemo(currentMemo);
+      if (!memoResult) return;
 
-    // Set viewers
-    const viewersResult = await setViewers(viewerIds);
-    if (!viewersResult) return;
+      const viewersResult = await setViewers(viewerIds);
+      if (!viewersResult) return;
 
-    // Publish
-    const result = await publishRecord();
-    if (result) {
-      setIsModalOpen(false);
-      void navigate(`/records/${recordId}`);
+      const result = await publishRecord();
+      if (result) {
+        setIsModalOpen(false);
+        void navigate(`/records/${recordId}`);
+      }
+    } finally {
+      savingInProgressRef.current = false;
     }
   };
 
   const handleModalSaveDraft = async (viewerIds: string[]) => {
-    // Save memo first
-    const memoResult = await updateMemo(currentMemo);
-    if (!memoResult) return;
+    savingInProgressRef.current = true;
+    try {
+      const memoResult = await updateMemo(currentMemo);
+      if (!memoResult) return;
 
-    // Set viewers
-    const viewersResult = await setViewers(viewerIds);
-    if (!viewersResult) return;
+      const viewersResult = await setViewers(viewerIds);
+      if (!viewersResult) return;
 
-    // Save draft
-    const result = await saveDraft();
-    if (result) {
-      setIsModalOpen(false);
-      void navigate(`/records/drafts`);
+      const result = await saveDraft();
+      if (result) {
+        setIsModalOpen(false);
+        void navigate(`/records/drafts`);
+      }
+    } finally {
+      savingInProgressRef.current = false;
     }
   };
 
@@ -210,8 +212,6 @@ export function PublishingPage() {
         )}
         <Button
           variant="ghost"
-          onMouseDown={handleButtonInteraction}
-          onKeyDown={handleButtonInteraction}
           onClick={() => void handleSaveDraft()}
           disabled={isSavingDraft || isSavingMemo}
         >

--- a/frontend/src/features/publishing/pages/PublishingPage.tsx
+++ b/frontend/src/features/publishing/pages/PublishingPage.tsx
@@ -1,12 +1,240 @@
-import { useParams } from "react-router";
+import { useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import { Button } from "@/components/ui/button";
+import { useRecordDetail } from "@/features/recording/hooks/useRecordDetail";
+import { useUpdateMemo } from "@/hooks/useUpdateMemo";
+import { useSaveDraft } from "@/hooks/useSaveDraft";
+import { useSuggestedViewers } from "../hooks/useSuggestedViewers";
+import { useSetViewers } from "../hooks/useSetViewers";
+import { usePublishRecord } from "../hooks/usePublishRecord";
+import { MemoEditor } from "../components/MemoEditor";
+import { ActionItemSummary } from "../components/ActionItemSummary";
+import { ViewerSelectModal } from "../components/ViewerSelectModal";
+import { formatScheduleDateTime, getStatusLabel } from "../utils";
 
 export function PublishingPage() {
   const { recordId } = useParams<{ recordId: string }>();
+  const navigate = useNavigate();
+
+  const {
+    record,
+    isLoading: recordLoading,
+    error: recordError,
+  } = useRecordDetail(recordId!);
+
+  const {
+    suggestedViewerIds,
+    isLoading: suggestedViewersLoading,
+    error: suggestedViewersError,
+  } = useSuggestedViewers(recordId!);
+
+  const {
+    updateMemo,
+    isSubmitting: isSavingMemo,
+    error: memoError,
+  } = useUpdateMemo(recordId!);
+
+  const {
+    saveDraft,
+    isSubmitting: isSavingDraft,
+    error: saveDraftError,
+  } = useSaveDraft(recordId!);
+
+  const {
+    setViewers,
+    isSubmitting: isSettingViewers,
+    error: setViewersError,
+  } = useSetViewers(recordId!);
+
+  const {
+    publishRecord,
+    isSubmitting: isPublishing,
+    error: publishError,
+  } = usePublishRecord(recordId!);
+
+  const [memo, setMemo] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const isSavingRef = useRef(false);
+
+  // Initialize memo from record once loaded
+  const currentMemo = memo ?? record?.memo ?? "";
+
+  const handleMemoChange = (value: string) => {
+    setMemo(value);
+  };
+
+  const handleSaveMemo = async () => {
+    if (isSavingRef.current) return;
+    await updateMemo(currentMemo);
+  };
+
+  const handleSaveDraftMouseDown = () => {
+    isSavingRef.current = true;
+  };
+
+  const handleSaveDraft = async () => {
+    try {
+      const memoResult = await updateMemo(currentMemo);
+      if (!memoResult) return;
+      await saveDraft();
+    } finally {
+      isSavingRef.current = false;
+    }
+  };
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handlePublish = async (viewerIds: string[]) => {
+    // Save memo first
+    const memoResult = await updateMemo(currentMemo);
+    if (!memoResult) return;
+
+    // Set viewers
+    const viewersResult = await setViewers(viewerIds);
+    if (!viewersResult) return;
+
+    // Publish
+    const result = await publishRecord(viewerIds);
+    if (result) {
+      setIsModalOpen(false);
+      void navigate(`/records/${recordId}`);
+    }
+  };
+
+  const handleModalSaveDraft = async (viewerIds: string[]) => {
+    // Save memo first
+    const memoResult = await updateMemo(currentMemo);
+    if (!memoResult) return;
+
+    // Set viewers
+    const viewersResult = await setViewers(viewerIds);
+    if (!viewersResult) return;
+
+    // Save draft
+    const result = await saveDraft();
+    if (result) {
+      setIsModalOpen(false);
+      void navigate(`/records/drafts`);
+    }
+  };
+
+  // Show loading state
+  if (recordLoading || suggestedViewersLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 w-64 rounded bg-muted" />
+          <div className="h-4 w-40 rounded bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  // Show error state
+  if (recordError) {
+    return (
+      <div className="space-y-6">
+        <p className="text-sm text-destructive" role="alert">
+          {recordError}
+        </p>
+      </div>
+    );
+  }
+
+  if (suggestedViewersError) {
+    return (
+      <div className="space-y-6">
+        <p className="text-sm text-destructive" role="alert">
+          {suggestedViewersError}
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Publishing</h1>
-      <p className="mt-2 text-muted-foreground">Record ID: {recordId}</p>
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold">公開フロー</h1>
+          {record && (
+            <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+              {getStatusLabel(record.status)}
+            </span>
+          )}
+        </div>
+        {record && (
+          <p className="mt-1 text-muted-foreground">
+            {formatScheduleDateTime(record.conducted_at)}
+          </p>
+        )}
+      </div>
+
+      {/* Status bar */}
+      <div className="flex items-center gap-2 rounded-lg bg-green-50 px-4 py-2 text-sm text-green-800 dark:bg-green-950 dark:text-green-200">
+        <div className="h-2 w-2 rounded-full bg-green-500" />
+        1on1 完了・記録を編集中
+      </div>
+
+      {/* Memo editor */}
+      <MemoEditor
+        memo={currentMemo}
+        onMemoChange={handleMemoChange}
+        onSaveMemo={() => void handleSaveMemo()}
+        isSaving={isSavingMemo}
+        error={memoError}
+      />
+
+      {/* Action items (read-only) */}
+      <ActionItemSummary actionItems={record?.action_items ?? []} />
+
+      {/* Footer */}
+      <div className="flex justify-end gap-3">
+        {saveDraftError && (
+          <p className="self-center text-sm text-destructive">
+            {saveDraftError}
+          </p>
+        )}
+        {setViewersError && (
+          <p className="self-center text-sm text-destructive">
+            {setViewersError}
+          </p>
+        )}
+        <Button
+          variant="ghost"
+          onMouseDown={handleSaveDraftMouseDown}
+          onClick={() => void handleSaveDraft()}
+          disabled={isSavingDraft || isSavingMemo}
+        >
+          {isSavingDraft ? "保存中..." : "下書き保存"}
+        </Button>
+        <Button
+          onClick={handleOpenModal}
+          disabled={isSavingDraft || isSavingMemo}
+        >
+          公開設定へ
+        </Button>
+      </div>
+
+      {/* Viewer select modal */}
+      <ViewerSelectModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        suggestedViewerIds={suggestedViewerIds}
+        counterpartId={record?.counterpart_id ?? ""}
+        onPublish={(viewerIds) => void handlePublish(viewerIds)}
+        onSaveDraft={(viewerIds) => void handleModalSaveDraft(viewerIds)}
+        isPublishing={isPublishing || isSettingViewers}
+        isSavingDraft={isSavingDraft || isSettingViewers}
+        publishError={publishError}
+        saveDraftError={saveDraftError}
+      />
     </div>
   );
 }

--- a/frontend/src/features/publishing/pages/PublishingPage.tsx
+++ b/frontend/src/features/publishing/pages/PublishingPage.tsx
@@ -68,11 +68,13 @@ export function PublishingPage() {
     await updateMemo(currentMemo);
   };
 
-  const handleSaveDraftMouseDown = () => {
+  // Suppress blur save before button action (mousedown/keydown fires before blur)
+  const handleButtonInteraction = () => {
     isSavingRef.current = true;
   };
 
   const handleSaveDraft = async () => {
+    isSavingRef.current = true;
     try {
       const memoResult = await updateMemo(currentMemo);
       if (!memoResult) return;
@@ -208,7 +210,8 @@ export function PublishingPage() {
         )}
         <Button
           variant="ghost"
-          onMouseDown={handleSaveDraftMouseDown}
+          onMouseDown={handleButtonInteraction}
+          onKeyDown={handleButtonInteraction}
           onClick={() => void handleSaveDraft()}
           disabled={isSavingDraft || isSavingMemo}
         >

--- a/frontend/src/features/publishing/pages/PublishingPage.tsx
+++ b/frontend/src/features/publishing/pages/PublishingPage.tsx
@@ -100,7 +100,7 @@ export function PublishingPage() {
     if (!viewersResult) return;
 
     // Publish
-    const result = await publishRecord(viewerIds);
+    const result = await publishRecord();
     if (result) {
       setIsModalOpen(false);
       void navigate(`/records/${recordId}`);

--- a/frontend/src/features/publishing/types.ts
+++ b/frontend/src/features/publishing/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared type definitions for the publishing feature.
+ *
+ * These types mirror the backend API response schemas for the publishing flow.
+ */
+
+export interface SuggestedViewersResponse {
+  suggested_viewer_ids: string[];
+}
+
+export interface SetViewersResponse {
+  record_id: string;
+}
+
+export interface PublishRecordResponse {
+  record_id: string;
+}

--- a/frontend/src/features/publishing/utils.ts
+++ b/frontend/src/features/publishing/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Utility functions for the publishing feature.
+ * Separated from components to avoid react-refresh warnings.
+ */
+
+export { formatScheduleDateTime } from "@/utils/date";
+
+/**
+ * Get a display label for the record status.
+ */
+export function getStatusLabel(status: string): string {
+  switch (status) {
+    case "draft":
+      return "下書き";
+    case "published":
+      return "公開済み";
+    default:
+      return status;
+  }
+}

--- a/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
+++ b/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
@@ -407,7 +407,7 @@ describe("RecordingPage", () => {
   });
 
   it("does not double-fire updateMemo when blur and complete button overlap", async () => {
-    // Simulate updateMemo taking time so blur and click overlap
+    // Dirty check: handleSaveAndComplete marks memo as saved, so blur skips
     mockUpdateMemo.mockImplementation(
       () =>
         new Promise((resolve) =>
@@ -431,7 +431,7 @@ describe("RecordingPage", () => {
     });
 
     // updateMemo should be called exactly once (from handleSaveAndComplete),
-    // not twice (blur should be suppressed)
+    // blur is skipped because dirty check sees memo was already marked as saved
     expect(mockUpdateMemo).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
+++ b/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
@@ -431,7 +431,7 @@ describe("RecordingPage", () => {
     });
 
     // updateMemo should be called exactly once (from handleSaveAndComplete),
-    // blur is skipped because dirty check sees memo was already marked as saved
+    // blur save is deferred via setTimeout and skipped because savingInProgressRef is set
     expect(mockUpdateMemo).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/features/recording/pages/RecordingPage.tsx
+++ b/frontend/src/features/recording/pages/RecordingPage.tsx
@@ -66,7 +66,7 @@ export function RecordingPage() {
   } = useSaveDraft(recordId!);
 
   const [memo, setMemo] = useState<string | null>(null);
-  const isSavingRef = useRef(false);
+  const savingInProgressRef = useRef(false);
 
   // Initialize memo from record once loaded
   const currentMemo = memo ?? record?.memo ?? "";
@@ -75,14 +75,12 @@ export function RecordingPage() {
     setMemo(value);
   };
 
-  const handleSaveMemo = async () => {
-    if (isSavingRef.current) return;
-    await updateMemo(currentMemo);
-  };
-
-  // Suppress blur save before button action (mousedown fires before blur)
-  const handleButtonInteraction = () => {
-    isSavingRef.current = true;
+  const handleSaveMemo = () => {
+    // Defer to next frame so button click handlers can set savingInProgressRef first
+    setTimeout(() => {
+      if (savingInProgressRef.current) return;
+      void updateMemo(currentMemo);
+    }, 0);
   };
 
   const handleConfirmAgenda = async (agendaId: string) => {
@@ -123,7 +121,7 @@ export function RecordingPage() {
   };
 
   const handleSaveAndComplete = async () => {
-    isSavingRef.current = true;
+    savingInProgressRef.current = true;
     try {
       const memoResult = await updateMemo(currentMemo);
       if (!memoResult) return;
@@ -132,7 +130,7 @@ export function RecordingPage() {
         void navigate(`/records/${recordId}/publish`);
       }
     } finally {
-      isSavingRef.current = false;
+      savingInProgressRef.current = false;
     }
   };
 
@@ -173,8 +171,6 @@ export function RecordingPage() {
         </div>
         <Button
           size="lg"
-          onMouseDown={handleButtonInteraction}
-          onKeyDown={handleButtonInteraction}
           onClick={() => void handleSaveAndComplete()}
           disabled={isSavingDraft || isSavingMemo}
         >
@@ -231,8 +227,6 @@ export function RecordingPage() {
         )}
         <Button
           size="lg"
-          onMouseDown={handleButtonInteraction}
-          onKeyDown={handleButtonInteraction}
           onClick={() => void handleSaveAndComplete()}
           disabled={isSavingDraft || isSavingMemo}
         >

--- a/frontend/src/features/recording/pages/RecordingPage.tsx
+++ b/frontend/src/features/recording/pages/RecordingPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState, useRef } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { useScheduleAgendas } from "@/features/preparation/hooks/useScheduleAgendas";
@@ -80,6 +80,11 @@ export function RecordingPage() {
     await updateMemo(currentMemo);
   };
 
+  // Suppress blur save before button action (mousedown fires before blur)
+  const handleButtonInteraction = () => {
+    isSavingRef.current = true;
+  };
+
   const handleConfirmAgenda = async (agendaId: string) => {
     const result = await confirmAgenda(agendaId);
     if (result) {
@@ -117,13 +122,9 @@ export function RecordingPage() {
     }
   };
 
-  const handleCompleteMouseDown = () => {
-    isSavingRef.current = true;
-  };
-
   const handleSaveAndComplete = async () => {
+    isSavingRef.current = true;
     try {
-      // Save memo first, then save draft, then navigate to publish
       const memoResult = await updateMemo(currentMemo);
       if (!memoResult) return;
       const result = await saveDraft();
@@ -172,7 +173,8 @@ export function RecordingPage() {
         </div>
         <Button
           size="lg"
-          onMouseDown={handleCompleteMouseDown}
+          onMouseDown={handleButtonInteraction}
+          onKeyDown={handleButtonInteraction}
           onClick={() => void handleSaveAndComplete()}
           disabled={isSavingDraft || isSavingMemo}
         >
@@ -229,7 +231,8 @@ export function RecordingPage() {
         )}
         <Button
           size="lg"
-          onMouseDown={handleCompleteMouseDown}
+          onMouseDown={handleButtonInteraction}
+          onKeyDown={handleButtonInteraction}
           onClick={() => void handleSaveAndComplete()}
           disabled={isSavingDraft || isSavingMemo}
         >


### PR DESCRIPTION
## Summary
- Issue #146 の公開フロー画面を実装
- メモ編集、公開先選択モーダル、下書き保存、公開実行

## 実装内容
- hooks: useSuggestedViewers, useSetViewers, usePublishRecord
- components: MemoEditor, ActionItemSummary, ViewerSelectModal
- pages: PublishingPage
- types.ts, utils.ts

## Test plan
- [x] pnpm lint 通過
- [x] pnpm test 全176テスト通過

Closes #146
