### PR TITLE
refactor: Record + Notification コンテキストの命名統一（PR-C）

### DIFF
--- a/backend/contexts/notification/application/send_reminder_use_case.py
+++ b/backend/contexts/notification/application/send_reminder_use_case.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 _MAX_REMINDER_MINUTES = 1440
 
 
-class SendReminderService:
+class SendReminderUseCase:
     """Send reminder notifications for upcoming confirmed schedules.
 
     Processing flow:

--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -88,13 +88,13 @@ if TYPE_CHECKING:
         RescheduleService,
     )
     from contexts.record.application.get_last_session_summary import (
-        GetLastSessionSummaryService,
+        GetLastSessionSummaryQueryService,
     )
     from contexts.record.application.list_all_pending_action_items import (
-        ListAllPendingActionItemsService,
+        ListAllPendingActionItemsQueryService,
     )
     from contexts.record.application.list_pending_action_items import (
-        ListPendingActionItemsService,
+        ListPendingActionItemsQueryService,
     )
     from contexts.record.domain.action_item_repository import ActionItemRepository
     from contexts.record.domain.record_repository import RecordRepository
@@ -454,13 +454,13 @@ def get_list_pending_action_items_service(
     action_item_repo: Annotated[
         ActionItemRepository, Depends(_get_action_item_repository)
     ],
-) -> ListPendingActionItemsService:
-    """Provide a ListPendingActionItemsService."""
+) -> ListPendingActionItemsQueryService:
+    """Provide a ListPendingActionItemsQueryService."""
     from contexts.record.application.list_pending_action_items import (
-        ListPendingActionItemsService,
+        ListPendingActionItemsQueryService,
     )
 
-    return ListPendingActionItemsService(
+    return ListPendingActionItemsQueryService(
         action_item_repository=action_item_repo,
         record_repository=record_repo,
     )
@@ -471,13 +471,13 @@ def get_list_all_pending_action_items_service(
     action_item_repo: Annotated[
         ActionItemRepository, Depends(_get_action_item_repository)
     ],
-) -> ListAllPendingActionItemsService:
-    """Provide a ListAllPendingActionItemsService."""
+) -> ListAllPendingActionItemsQueryService:
+    """Provide a ListAllPendingActionItemsQueryService."""
     from contexts.record.application.list_all_pending_action_items import (
-        ListAllPendingActionItemsService,
+        ListAllPendingActionItemsQueryService,
     )
 
-    return ListAllPendingActionItemsService(
+    return ListAllPendingActionItemsQueryService(
         action_item_repository=action_item_repo,
         record_repository=record_repo,
     )
@@ -488,13 +488,13 @@ def get_get_last_session_summary_service(
     action_item_repo: Annotated[
         ActionItemRepository, Depends(_get_action_item_repository)
     ],
-) -> GetLastSessionSummaryService:
-    """Provide a GetLastSessionSummaryService."""
+) -> GetLastSessionSummaryQueryService:
+    """Provide a GetLastSessionSummaryQueryService."""
     from contexts.record.application.get_last_session_summary import (
-        GetLastSessionSummaryService,
+        GetLastSessionSummaryQueryService,
     )
 
-    return GetLastSessionSummaryService(
+    return GetLastSessionSummaryQueryService(
         record_repository=record_repo,
         action_item_repository=action_item_repo,
     )

--- a/backend/contexts/preparation/presentation/router.py
+++ b/backend/contexts/preparation/presentation/router.py
@@ -153,15 +153,15 @@ from contexts.preparation.presentation.schemas import (
 )
 from contexts.record.application.get_last_session_summary import (
     GetLastSessionSummaryInput,
-    GetLastSessionSummaryService,
+    GetLastSessionSummaryQueryService,
 )
 from contexts.record.application.list_all_pending_action_items import (
     ListAllPendingActionItemsInput,
-    ListAllPendingActionItemsService,
+    ListAllPendingActionItemsQueryService,
 )
 from contexts.record.application.list_pending_action_items import (
     ListPendingActionItemsInput,
-    ListPendingActionItemsService,
+    ListPendingActionItemsQueryService,
 )
 from foundation.auth.dependencies import get_current_user_id
 from shared.domain.value_objects import UserId
@@ -573,7 +573,7 @@ async def add_agenda_comment(
 async def list_all_pending_action_items(
     current_user_id: Annotated[UserId, Depends(get_current_user_id)],
     service: Annotated[
-        ListAllPendingActionItemsService,
+        ListAllPendingActionItemsQueryService,
         Depends(get_list_all_pending_action_items_service),
     ],
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
@@ -607,7 +607,8 @@ async def list_pending_action_items(
     counterpart_id: UUID,
     current_user_id: Annotated[UserId, Depends(get_current_user_id)],
     service: Annotated[
-        ListPendingActionItemsService, Depends(get_list_pending_action_items_service)
+        ListPendingActionItemsQueryService,
+        Depends(get_list_pending_action_items_service),
     ],
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
 ) -> ListPendingActionItemsResponse:
@@ -644,7 +645,7 @@ async def get_last_session_summary(
     counterpart_id: Annotated[UUID, Query()],
     current_user_id: Annotated[UserId, Depends(get_current_user_id)],
     service: Annotated[
-        GetLastSessionSummaryService, Depends(get_get_last_session_summary_service)
+        GetLastSessionSummaryQueryService, Depends(get_get_last_session_summary_service)
     ],
 ) -> GetLastSessionSummaryResponse | None:
     output = await service.execute(

--- a/backend/contexts/record/application/get_last_session_summary.py
+++ b/backend/contexts/record/application/get_last_session_summary.py
@@ -31,7 +31,7 @@ class ActionItemSummaryDTO:
 
 @dataclass(frozen=True)
 class GetLastSessionSummaryInput:
-    """Input DTO for GetLastSessionSummaryService."""
+    """Input DTO for GetLastSessionSummaryQueryService."""
 
     actor_id: UserId
     organizer_id: UserId
@@ -40,7 +40,7 @@ class GetLastSessionSummaryInput:
 
 @dataclass(frozen=True)
 class GetLastSessionSummaryOutput:
-    """Output DTO for GetLastSessionSummaryService.
+    """Output DTO for GetLastSessionSummaryQueryService.
 
     None is returned by execute() when no matching Record exists.
     """
@@ -51,7 +51,7 @@ class GetLastSessionSummaryOutput:
     action_items: list[ActionItemSummaryDTO]
 
 
-class GetLastSessionSummaryService:
+class GetLastSessionSummaryQueryService:
     """Query the last session summary for a pair.
 
     Returns the most recent published Record visible to actor,

--- a/backend/contexts/record/application/list_all_pending_action_items.py
+++ b/backend/contexts/record/application/list_all_pending_action_items.py
@@ -32,7 +32,7 @@ class AllPendingActionItemDTO:
 
 @dataclass(frozen=True)
 class ListAllPendingActionItemsInput:
-    """Input DTO for ListAllPendingActionItemsService."""
+    """Input DTO for ListAllPendingActionItemsQueryService."""
 
     actor_id: UserId
     limit: int = 50
@@ -40,7 +40,7 @@ class ListAllPendingActionItemsInput:
 
 @dataclass(frozen=True)
 class ListAllPendingActionItemsOutput:
-    """Output DTO for ListAllPendingActionItemsService."""
+    """Output DTO for ListAllPendingActionItemsQueryService."""
 
     items: list[AllPendingActionItemDTO]
 
@@ -55,7 +55,7 @@ class InvalidLimitError(Exception):
         super().__init__(f"limit must be between 1 and {MAX_LIMIT}, got {limit}")
 
 
-class ListAllPendingActionItemsService:
+class ListAllPendingActionItemsQueryService:
     """Query all pending (not completed) action items for an organizer.
 
     Returns action items across all counterparts where the actor is the

--- a/backend/contexts/record/application/list_draft_records.py
+++ b/backend/contexts/record/application/list_draft_records.py
@@ -34,19 +34,19 @@ class DraftRecordItemDTO:
 
 @dataclass(frozen=True)
 class ListDraftRecordsInput:
-    """Input DTO for ListDraftRecordsService."""
+    """Input DTO for ListDraftRecordsQueryService."""
 
     actor_id: UserId
 
 
 @dataclass(frozen=True)
 class ListDraftRecordsOutput:
-    """Output DTO for ListDraftRecordsService."""
+    """Output DTO for ListDraftRecordsQueryService."""
 
     items: list[DraftRecordItemDTO]
 
 
-class ListDraftRecordsService:
+class ListDraftRecordsQueryService:
     """Query draft records owned by the actor.
 
     Authorization:

--- a/backend/contexts/record/application/list_oneonone_history.py
+++ b/backend/contexts/record/application/list_oneonone_history.py
@@ -35,7 +35,7 @@ class OneOnOneHistoryItemDTO:
 
 @dataclass(frozen=True)
 class ListOneOnOneHistoryInput:
-    """Input DTO for ListOneOnOneHistoryService."""
+    """Input DTO for ListOneOnOneHistoryQueryService."""
 
     actor_id: UserId
     organizer_id: UserId
@@ -46,7 +46,7 @@ class ListOneOnOneHistoryInput:
 
 @dataclass(frozen=True)
 class ListOneOnOneHistoryOutput:
-    """Output DTO for ListOneOnOneHistoryService."""
+    """Output DTO for ListOneOnOneHistoryQueryService."""
 
     items: list[OneOnOneHistoryItemDTO]
     total_count: int
@@ -56,7 +56,7 @@ class InvalidPaginationError(Exception):
     """offset or limit is out of valid range."""
 
 
-class ListOneOnOneHistoryService:
+class ListOneOnOneHistoryQueryService:
     """Query published 1-on-1 history for a pair, visible to actor.
 
     Authorization:

--- a/backend/contexts/record/application/list_pending_action_items.py
+++ b/backend/contexts/record/application/list_pending_action_items.py
@@ -33,7 +33,7 @@ class PendingActionItemDTO:
 
 @dataclass(frozen=True)
 class ListPendingActionItemsInput:
-    """Input DTO for ListPendingActionItemsService."""
+    """Input DTO for ListPendingActionItemsQueryService."""
 
     actor_id: UserId
     counterpart_id: UserId
@@ -42,7 +42,7 @@ class ListPendingActionItemsInput:
 
 @dataclass(frozen=True)
 class ListPendingActionItemsOutput:
-    """Output DTO for ListPendingActionItemsService."""
+    """Output DTO for ListPendingActionItemsQueryService."""
 
     items: list[PendingActionItemDTO]
 
@@ -57,7 +57,7 @@ class InvalidLimitError(Exception):
         super().__init__(f"limit must be between 1 and {MAX_LIMIT}, got {limit}")
 
 
-class ListPendingActionItemsService:
+class ListPendingActionItemsQueryService:
     """Query pending (not completed) action items for a counterpart.
 
     Authorization: the actor must have participated in at least one

--- a/backend/contexts/record/presentation/dependencies.py
+++ b/backend/contexts/record/presentation/dependencies.py
@@ -26,10 +26,10 @@ from contexts.record.application.delete_action_item import DeleteActionItemUseCa
 from contexts.record.application.get_record_detail import GetRecordDetailUseCase
 from contexts.record.application.get_viewers import GetViewersUseCase
 from contexts.record.application.list_draft_records import (
-    ListDraftRecordsService,
+    ListDraftRecordsQueryService,
 )
 from contexts.record.application.list_oneonone_history import (
-    ListOneOnOneHistoryService,
+    ListOneOnOneHistoryQueryService,
 )
 from contexts.record.application.list_record_comments import (
     ListRecordCommentsUseCase,
@@ -298,18 +298,18 @@ def get_complete_action_item_use_case(
 
 def get_list_draft_records_service(
     record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
-) -> ListDraftRecordsService:
-    """Provide a ListDraftRecordsService with all dependencies injected."""
-    return ListDraftRecordsService(
+) -> ListDraftRecordsQueryService:
+    """Provide a ListDraftRecordsQueryService with all dependencies injected."""
+    return ListDraftRecordsQueryService(
         record_repository=record_repo,
     )
 
 
 def get_list_oneonone_history_service(
     record_repo: Annotated[RecordRepository, Depends(get_record_repository)],
-) -> ListOneOnOneHistoryService:
-    """Provide a ListOneOnOneHistoryService with all dependencies injected."""
-    return ListOneOnOneHistoryService(
+) -> ListOneOnOneHistoryQueryService:
+    """Provide a ListOneOnOneHistoryQueryService with all dependencies injected."""
+    return ListOneOnOneHistoryQueryService(
         record_repository=record_repo,
     )
 

--- a/backend/contexts/record/presentation/router.py
+++ b/backend/contexts/record/presentation/router.py
@@ -46,11 +46,11 @@ from contexts.record.application.get_viewers import (
 )
 from contexts.record.application.list_draft_records import (
     ListDraftRecordsInput,
-    ListDraftRecordsService,
+    ListDraftRecordsQueryService,
 )
 from contexts.record.application.list_oneonone_history import (
     ListOneOnOneHistoryInput,
-    ListOneOnOneHistoryService,
+    ListOneOnOneHistoryQueryService,
 )
 from contexts.record.application.list_record_comments import (
     ListRecordCommentsInput,
@@ -337,7 +337,7 @@ async def save_draft(
 async def list_draft_records(
     current_user_id: Annotated[UserId, Depends(get_current_user_id)],
     service: Annotated[
-        ListDraftRecordsService, Depends(get_list_draft_records_service)
+        ListDraftRecordsQueryService, Depends(get_list_draft_records_service)
     ],
 ) -> ListDraftRecordsResponse:
     """List draft (unpublished) records for the current user."""
@@ -366,7 +366,7 @@ async def list_oneonone_history(
     counterpart_id: Annotated[UUID, Query()],
     current_user_id: Annotated[UserId, Depends(get_current_user_id)],
     service: Annotated[
-        ListOneOnOneHistoryService, Depends(get_list_oneonone_history_service)
+        ListOneOnOneHistoryQueryService, Depends(get_list_oneonone_history_service)
     ],
     offset: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=200)] = 20,

--- a/backend/foundation/scheduler/lifespan.py
+++ b/backend/foundation/scheduler/lifespan.py
@@ -32,15 +32,15 @@ class _SessionScopedReminderService:
 
     The scheduler runs outside of FastAPI's request lifecycle, so each
     execute() call creates its own session and wires up repositories
-    and the SendReminderService.
+    and the SendReminderUseCase.
     """
 
     async def execute(self, now: object) -> None:
-        """Create dependencies and delegate to SendReminderService."""
+        """Create dependencies and delegate to SendReminderUseCase."""
         from datetime import datetime as dt
 
-        from contexts.notification.application.send_reminder_service import (
-            SendReminderService,
+        from contexts.notification.application.send_reminder_use_case import (
+            SendReminderUseCase,
         )
         from contexts.notification.infrastructure.sqlalchemy_notification_setting_repository import (  # noqa: E501
             SqlAlchemyNotificationSettingRepository,
@@ -56,7 +56,7 @@ class _SessionScopedReminderService:
         assert isinstance(now, dt)
 
         async with async_session_factory() as session:
-            service = SendReminderService(
+            service = SendReminderUseCase(
                 schedule_repository=SqlAlchemyScheduleRepository(session),
                 notification_setting_repository=SqlAlchemyNotificationSettingRepository(
                     session

--- a/backend/tests/contexts/notification/application/test_send_reminder_use_case.py
+++ b/backend/tests/contexts/notification/application/test_send_reminder_use_case.py
@@ -1,11 +1,11 @@
-"""Tests for SendReminderService."""
+"""Tests for SendReminderUseCase."""
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from contexts.notification.application.send_reminder_service import (
-    SendReminderService,
+from contexts.notification.application.send_reminder_use_case import (
+    SendReminderUseCase,
 )
 from contexts.notification.domain.notification_setting import NotificationSetting
 from contexts.notification.domain.notification_setting_repository import (
@@ -81,7 +81,7 @@ def _build_service(
     reminder_log_repo: InMemoryReminderLogRepository | None = None,
     sender: SpyNotificationSender | None = None,
 ) -> tuple[
-    SendReminderService,
+    SendReminderUseCase,
     InMemoryScheduleRepository,
     InMemoryReminderLogRepository,
     SpyNotificationSender,
@@ -90,7 +90,7 @@ def _build_service(
     st = setting_repo or InMemoryNotificationSettingRepository()
     rl = reminder_log_repo or InMemoryReminderLogRepository()
     sn = sender or SpyNotificationSender()
-    service = SendReminderService(
+    service = SendReminderUseCase(
         schedule_repository=sr,
         notification_setting_repository=st,
         reminder_log_repository=rl,
@@ -99,8 +99,8 @@ def _build_service(
     return service, sr, rl, sn
 
 
-class TestSendReminderService:
-    """Tests for SendReminderService reminder logic."""
+class TestSendReminderUseCase:
+    """Tests for SendReminderUseCase reminder logic."""
 
     async def test_sends_reminder_to_both_participants(self) -> None:
         """Both organizer and counterpart receive reminders."""

--- a/backend/tests/contexts/preparation/presentation/test_router.py
+++ b/backend/tests/contexts/preparation/presentation/test_router.py
@@ -164,7 +164,7 @@ from contexts.preparation.presentation.router import router
 from contexts.record.application.get_last_session_summary import (
     ActionItemSummaryDTO,
     GetLastSessionSummaryOutput,
-    GetLastSessionSummaryService,
+    GetLastSessionSummaryQueryService,
 )
 from contexts.record.domain.value_objects import ActionItemId, RecordId
 from foundation.auth.dependencies import get_current_user_id
@@ -1237,7 +1237,7 @@ class TestGetLastSessionSummary:
         record_id = RecordId.generate()
         now = datetime.now(UTC)
         action_item_id = ActionItemId.generate()
-        mock_service = AsyncMock(spec=GetLastSessionSummaryService)
+        mock_service = AsyncMock(spec=GetLastSessionSummaryQueryService)
         mock_service.execute.return_value = GetLastSessionSummaryOutput(
             record_id=record_id,
             conducted_at=now,
@@ -1277,7 +1277,7 @@ class TestGetLastSessionSummary:
         assert len(body["action_items"]) == 1
 
     async def test_no_record_returns_200_null(self) -> None:
-        mock_service = AsyncMock(spec=GetLastSessionSummaryService)
+        mock_service = AsyncMock(spec=GetLastSessionSummaryQueryService)
         mock_service.execute.return_value = None
 
         app = _build_app()

--- a/backend/tests/contexts/record/application/test_get_last_session_summary.py
+++ b/backend/tests/contexts/record/application/test_get_last_session_summary.py
@@ -1,4 +1,4 @@
-"""Tests for GetLastSessionSummaryService."""
+"""Tests for GetLastSessionSummaryQueryService."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from contexts.record.application.get_last_session_summary import (
     GetLastSessionSummaryInput,
     GetLastSessionSummaryOutput,
-    GetLastSessionSummaryService,
+    GetLastSessionSummaryQueryService,
 )
 from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.memo import Memo
@@ -71,13 +71,13 @@ def _build_service(
     record_repo: InMemoryRecordRepository | None = None,
     action_item_repo: InMemoryActionItemRepository | None = None,
 ) -> tuple[
-    GetLastSessionSummaryService,
+    GetLastSessionSummaryQueryService,
     InMemoryRecordRepository,
     InMemoryActionItemRepository,
 ]:
     rr = record_repo or InMemoryRecordRepository()
     air = action_item_repo or InMemoryActionItemRepository()
-    svc = GetLastSessionSummaryService(
+    svc = GetLastSessionSummaryQueryService(
         record_repository=rr,
         action_item_repository=air,
     )

--- a/backend/tests/contexts/record/application/test_list_all_pending_action_items.py
+++ b/backend/tests/contexts/record/application/test_list_all_pending_action_items.py
@@ -1,4 +1,4 @@
-"""Tests for ListAllPendingActionItemsService."""
+"""Tests for ListAllPendingActionItemsQueryService."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from contexts.record.application.list_all_pending_action_items import (
     InvalidLimitError,
     ListAllPendingActionItemsInput,
     ListAllPendingActionItemsOutput,
-    ListAllPendingActionItemsService,
+    ListAllPendingActionItemsQueryService,
 )
 from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.record import Record
@@ -65,13 +65,13 @@ def _build_service(
     record_repo: InMemoryRecordRepository | None = None,
     action_item_repo: InMemoryActionItemRepository | None = None,
 ) -> tuple[
-    ListAllPendingActionItemsService,
+    ListAllPendingActionItemsQueryService,
     InMemoryRecordRepository,
     InMemoryActionItemRepository,
 ]:
     rr = record_repo or InMemoryRecordRepository()
     air = action_item_repo or InMemoryActionItemRepository()
-    svc = ListAllPendingActionItemsService(
+    svc = ListAllPendingActionItemsQueryService(
         action_item_repository=air,
         record_repository=rr,
     )

--- a/backend/tests/contexts/record/application/test_list_draft_records.py
+++ b/backend/tests/contexts/record/application/test_list_draft_records.py
@@ -1,4 +1,4 @@
-"""Tests for ListDraftRecordsService."""
+"""Tests for ListDraftRecordsQueryService."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from contexts.preparation.domain.value_objects import ScheduleId
 from contexts.record.application.list_draft_records import (
     ListDraftRecordsInput,
     ListDraftRecordsOutput,
-    ListDraftRecordsService,
+    ListDraftRecordsQueryService,
 )
 from contexts.record.domain.memo import Memo
 from contexts.record.domain.record import Record
@@ -62,9 +62,9 @@ def _make_published_record(
 def _build_service(
     *,
     record_repo: InMemoryRecordRepository | None = None,
-) -> tuple[ListDraftRecordsService, InMemoryRecordRepository]:
+) -> tuple[ListDraftRecordsQueryService, InMemoryRecordRepository]:
     rr = record_repo or InMemoryRecordRepository()
-    svc = ListDraftRecordsService(record_repository=rr)
+    svc = ListDraftRecordsQueryService(record_repository=rr)
     return svc, rr
 
 

--- a/backend/tests/contexts/record/application/test_list_oneonone_history.py
+++ b/backend/tests/contexts/record/application/test_list_oneonone_history.py
@@ -1,4 +1,4 @@
-"""Tests for ListOneOnOneHistoryService."""
+"""Tests for ListOneOnOneHistoryQueryService."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from contexts.record.application.list_oneonone_history import (
     InvalidPaginationError,
     ListOneOnOneHistoryInput,
     ListOneOnOneHistoryOutput,
-    ListOneOnOneHistoryService,
+    ListOneOnOneHistoryQueryService,
 )
 from contexts.record.domain.memo import Memo
 from contexts.record.domain.record import Record
@@ -48,9 +48,9 @@ def _make_published_record(
 def _build_service(
     *,
     record_repo: InMemoryRecordRepository | None = None,
-) -> tuple[ListOneOnOneHistoryService, InMemoryRecordRepository]:
+) -> tuple[ListOneOnOneHistoryQueryService, InMemoryRecordRepository]:
     rr = record_repo or InMemoryRecordRepository()
-    svc = ListOneOnOneHistoryService(record_repository=rr)
+    svc = ListOneOnOneHistoryQueryService(record_repository=rr)
     return svc, rr
 
 

--- a/backend/tests/contexts/record/application/test_list_pending_action_items.py
+++ b/backend/tests/contexts/record/application/test_list_pending_action_items.py
@@ -1,4 +1,4 @@
-"""Tests for ListPendingActionItemsService."""
+"""Tests for ListPendingActionItemsQueryService."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from contexts.record.application.list_pending_action_items import (
     InvalidLimitError,
     ListPendingActionItemsInput,
     ListPendingActionItemsOutput,
-    ListPendingActionItemsService,
+    ListPendingActionItemsQueryService,
 )
 from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.exceptions import UnauthorizedOperationError
@@ -66,13 +66,13 @@ def _build_service(
     record_repo: InMemoryRecordRepository | None = None,
     action_item_repo: InMemoryActionItemRepository | None = None,
 ) -> tuple[
-    ListPendingActionItemsService,
+    ListPendingActionItemsQueryService,
     InMemoryRecordRepository,
     InMemoryActionItemRepository,
 ]:
     rr = record_repo or InMemoryRecordRepository()
     air = action_item_repo or InMemoryActionItemRepository()
-    svc = ListPendingActionItemsService(
+    svc = ListPendingActionItemsQueryService(
         action_item_repository=air,
         record_repository=rr,
     )


### PR DESCRIPTION
## 概要
Issue #170 の PR-C。Record + Notification コンテキストの *Service を命名規則に基づきリネーム。

## 変更内容
### Record（5クラス → QueryService）
- ListDraftRecordsService → ListDraftRecordsQueryService
- ListAllPendingActionItemsService → ListAllPendingActionItemsQueryService
- ListOneOnOneHistoryService → ListOneOnOneHistoryQueryService
- ListPendingActionItemsService → ListPendingActionItemsQueryService
- GetLastSessionSummaryService → GetLastSessionSummaryQueryService

### Notification（1クラス → UseCase）
- SendReminderService → SendReminderUseCase

全参照（DI登録・router・tests・scheduler）を一括更新。

Related: #170