### PR TITLE
refactor: Workspace コンテキストの命名統一（PR-B）

### DIFF
--- a/backend/api/exception_handlers.py
+++ b/backend/api/exception_handlers.py
@@ -194,25 +194,25 @@ from contexts.record.domain.exceptions import (
 )
 
 # --- Workspace context: application exceptions ---
-from contexts.workspace.application.add_member_service import (
+from contexts.workspace.application.add_member_use_case import (
     WorkspaceNotFoundError as AddMemberWorkspaceNotFoundError,
 )
-from contexts.workspace.application.change_member_role_service import (
+from contexts.workspace.application.change_member_role_use_case import (
     WorkspaceNotFoundError as ChangeMemberRoleWorkspaceNotFoundError,
 )
-from contexts.workspace.application.change_workspace_parent_service import (
+from contexts.workspace.application.change_workspace_parent_use_case import (
     ParentWorkspaceNotFoundError as ChangeParentParentNotFoundError,
 )
-from contexts.workspace.application.change_workspace_parent_service import (
+from contexts.workspace.application.change_workspace_parent_use_case import (
     WorkspaceNotFoundError as ChangeParentWorkspaceNotFoundError,
 )
-from contexts.workspace.application.create_workspace_service import (
+from contexts.workspace.application.create_workspace_use_case import (
     ParentWorkspaceNotFoundError as CreateWorkspaceParentNotFoundError,
 )
-from contexts.workspace.application.remove_member_service import (
+from contexts.workspace.application.remove_member_use_case import (
     WorkspaceNotFoundError as RemoveMemberWorkspaceNotFoundError,
 )
-from contexts.workspace.application.rename_workspace_service import (
+from contexts.workspace.application.rename_workspace_use_case import (
     WorkspaceNotFoundError as RenameWorkspaceNotFoundError,
 )
 

--- a/backend/contexts/record/infrastructure/workspace_captain_query_service.py
+++ b/backend/contexts/record/infrastructure/workspace_captain_query_service.py
@@ -13,7 +13,7 @@ from contexts.workspace.application.captain_query_service import (
     CaptainQueryInput,
 )
 from contexts.workspace.application.captain_query_service import (
-    CaptainQueryService as WorkspaceCaptainQueryService,
+    CaptainQueryService as WorkspaceCaptainQueryServiceImpl,
 )
 from contexts.workspace.domain.workspace_repository import WorkspaceRepository
 from shared.domain.value_objects import UserId
@@ -28,7 +28,7 @@ class WorkspaceCaptainQueryService(CaptainQueryService):
     """
 
     def __init__(self, *, workspace_repo: WorkspaceRepository) -> None:
-        self._workspace_captain_query = WorkspaceCaptainQueryService(workspace_repo)
+        self._workspace_captain_query = WorkspaceCaptainQueryServiceImpl(workspace_repo)
 
     async def get_captains_for_user(self, user_id: UserId) -> list[UserId]:
         output = await self._workspace_captain_query.execute(

--- a/backend/contexts/workspace/application/add_member_use_case.py
+++ b/backend/contexts/workspace/application/add_member_use_case.py
@@ -1,11 +1,15 @@
-"""Use case: Remove a member from a workspace."""
+"""Use case: Add a member to a workspace."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from contexts.workspace.domain.value_objects import WorkspaceId
+from contexts.workspace.domain.value_objects import (
+    MembershipId,
+    MembershipRole,
+    WorkspaceId,
+)
 from contexts.workspace.domain.workspace_repository import WorkspaceRepository
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
@@ -21,17 +25,26 @@ class WorkspaceNotFoundError(Exception):
 
 
 @dataclass(frozen=True)
-class RemoveMemberInput:
-    """Input DTO for removing a member from a workspace."""
+class AddMemberInput:
+    """Input DTO for adding a member to a workspace."""
 
     workspace_id: WorkspaceId
     user_id: UserId
+    role: MembershipRole = MembershipRole.MEMBER
 
 
-class RemoveMemberService:
-    """Application service that removes a member from a workspace.
+@dataclass(frozen=True)
+class AddMemberOutput:
+    """Output DTO for adding a member to a workspace."""
 
-    Domain layer raises MembershipNotFoundError if the user is not a member.
+    membership_id: MembershipId
+
+
+class AddMemberUseCase:
+    """Application service that adds a member to a workspace.
+
+    The user is added with the specified role (defaults to Member).
+    Domain layer prevents duplicate memberships.
     """
 
     def __init__(
@@ -46,16 +59,19 @@ class RemoveMemberService:
 
     async def execute(
         self,
-        input_dto: RemoveMemberInput,
-    ) -> None:
-        """Remove a member from the workspace.
+        input_dto: AddMemberInput,
+    ) -> AddMemberOutput:
+        """Add a member to the workspace and return the membership id.
 
         Args:
-            input_dto: The input containing workspace id and user id.
+            input_dto: The input containing workspace id, user id, and role.
+
+        Returns:
+            Output containing the id of the newly created membership.
 
         Raises:
             WorkspaceNotFoundError: If the workspace does not exist.
-            MembershipNotFoundError: If the user is not a member.
+            DuplicateMembershipError: If the user is already a member.
         """
         now = datetime.now(UTC)
 
@@ -64,9 +80,15 @@ class RemoveMemberService:
             if workspace is None:
                 raise WorkspaceNotFoundError()
 
-            workspace.remove_member(user_id=input_dto.user_id, now=now)
+            membership = workspace.add_member(
+                user_id=input_dto.user_id,
+                role=input_dto.role,
+                now=now,
+            )
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
             await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
+
+        return AddMemberOutput(membership_id=membership.id)

--- a/backend/contexts/workspace/application/change_member_role_use_case.py
+++ b/backend/contexts/workspace/application/change_member_role_use_case.py
@@ -29,7 +29,7 @@ class ChangeMemberRoleInput:
     new_role: MembershipRole
 
 
-class ChangeMemberRoleService:
+class ChangeMemberRoleUseCase:
     """Application service that changes a member's role in a workspace.
 
     Domain layer raises MembershipNotFoundError if the user is not a member.

--- a/backend/contexts/workspace/application/change_workspace_parent_use_case.py
+++ b/backend/contexts/workspace/application/change_workspace_parent_use_case.py
@@ -35,7 +35,7 @@ class ChangeWorkspaceParentInput:
     new_parent_id: WorkspaceId | None
 
 
-class ChangeWorkspaceParentService:
+class ChangeWorkspaceParentUseCase:
     """Application service that changes a workspace's parent.
 
     Performs full ancestor-chain cycle detection using

--- a/backend/contexts/workspace/application/create_workspace_use_case.py
+++ b/backend/contexts/workspace/application/create_workspace_use_case.py
@@ -36,7 +36,7 @@ class CreateWorkspaceOutput:
     workspace_id: WorkspaceId
 
 
-class CreateWorkspaceService:
+class CreateWorkspaceUseCase:
     """Application service that creates a new workspace.
 
     The workspace is optionally placed under a parent workspace.

--- a/backend/contexts/workspace/application/get_captains_for_user.py
+++ b/backend/contexts/workspace/application/get_captains_for_user.py
@@ -1,4 +1,4 @@
-"""Use case: Get Captain user IDs for a given user.
+"""Query service: Get Captain user IDs for a given user.
 
 Looks up all Workspaces where the user has a Membership, walks up the
 ancestor chain for each, and returns deduplicated Captain UserIds.
@@ -16,19 +16,19 @@ from shared.domain.value_objects import UserId
 
 @dataclass(frozen=True)
 class GetCaptainsForUserInput:
-    """Input DTO for GetCaptainsForUserUseCase."""
+    """Input DTO for GetCaptainsForUserQueryService."""
 
     user_id: UserId
 
 
 @dataclass(frozen=True)
 class GetCaptainsForUserOutput:
-    """Output DTO for GetCaptainsForUserUseCase."""
+    """Output DTO for GetCaptainsForUserQueryService."""
 
     captain_ids: list[UserId]
 
 
-class GetCaptainsForUserUseCase:
+class GetCaptainsForUserQueryService:
     """Return deduplicated Captain UserIds from all Workspaces the user
     belongs to, including ancestor Workspaces.
 

--- a/backend/contexts/workspace/application/remove_member_use_case.py
+++ b/backend/contexts/workspace/application/remove_member_use_case.py
@@ -1,15 +1,11 @@
-"""Use case: Add a member to a workspace."""
+"""Use case: Remove a member from a workspace."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from contexts.workspace.domain.value_objects import (
-    MembershipId,
-    MembershipRole,
-    WorkspaceId,
-)
+from contexts.workspace.domain.value_objects import WorkspaceId
 from contexts.workspace.domain.workspace_repository import WorkspaceRepository
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
@@ -25,26 +21,17 @@ class WorkspaceNotFoundError(Exception):
 
 
 @dataclass(frozen=True)
-class AddMemberInput:
-    """Input DTO for adding a member to a workspace."""
+class RemoveMemberInput:
+    """Input DTO for removing a member from a workspace."""
 
     workspace_id: WorkspaceId
     user_id: UserId
-    role: MembershipRole = MembershipRole.MEMBER
 
 
-@dataclass(frozen=True)
-class AddMemberOutput:
-    """Output DTO for adding a member to a workspace."""
+class RemoveMemberUseCase:
+    """Application service that removes a member from a workspace.
 
-    membership_id: MembershipId
-
-
-class AddMemberService:
-    """Application service that adds a member to a workspace.
-
-    The user is added with the specified role (defaults to Member).
-    Domain layer prevents duplicate memberships.
+    Domain layer raises MembershipNotFoundError if the user is not a member.
     """
 
     def __init__(
@@ -59,19 +46,16 @@ class AddMemberService:
 
     async def execute(
         self,
-        input_dto: AddMemberInput,
-    ) -> AddMemberOutput:
-        """Add a member to the workspace and return the membership id.
+        input_dto: RemoveMemberInput,
+    ) -> None:
+        """Remove a member from the workspace.
 
         Args:
-            input_dto: The input containing workspace id, user id, and role.
-
-        Returns:
-            Output containing the id of the newly created membership.
+            input_dto: The input containing workspace id and user id.
 
         Raises:
             WorkspaceNotFoundError: If the workspace does not exist.
-            DuplicateMembershipError: If the user is already a member.
+            MembershipNotFoundError: If the user is not a member.
         """
         now = datetime.now(UTC)
 
@@ -80,15 +64,9 @@ class AddMemberService:
             if workspace is None:
                 raise WorkspaceNotFoundError()
 
-            membership = workspace.add_member(
-                user_id=input_dto.user_id,
-                role=input_dto.role,
-                now=now,
-            )
+            workspace.remove_member(user_id=input_dto.user_id, now=now)
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
             await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
-
-        return AddMemberOutput(membership_id=membership.id)

--- a/backend/contexts/workspace/application/rename_workspace_use_case.py
+++ b/backend/contexts/workspace/application/rename_workspace_use_case.py
@@ -28,7 +28,7 @@ class RenameWorkspaceInput:
     new_name: WorkspaceName
 
 
-class RenameWorkspaceService:
+class RenameWorkspaceUseCase:
     """Application service that renames an existing workspace."""
 
     def __init__(

--- a/backend/tests/contexts/workspace/application/test_add_member_use_case.py
+++ b/backend/tests/contexts/workspace/application/test_add_member_use_case.py
@@ -1,13 +1,13 @@
-"""Tests for AddMemberService."""
+"""Tests for AddMemberUseCase."""
 
 from __future__ import annotations
 
 import pytest
 
-from contexts.workspace.application.add_member_service import (
+from contexts.workspace.application.add_member_use_case import (
     AddMemberInput,
     AddMemberOutput,
-    AddMemberService,
+    AddMemberUseCase,
     WorkspaceNotFoundError,
 )
 from contexts.workspace.domain.events import MemberAdded
@@ -47,8 +47,8 @@ class TestAddMember:
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
         dispatcher: InMemoryEventDispatcher,
-    ) -> AddMemberService:
-        return AddMemberService(
+    ) -> AddMemberUseCase:
+        return AddMemberUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -64,7 +64,7 @@ class TestAddMember:
 
     async def test_adds_member_with_default_role(
         self,
-        service: AddMemberService,
+        service: AddMemberUseCase,
         repo: InMemoryWorkspaceRepository,
         workspace: Workspace,
     ) -> None:
@@ -84,7 +84,7 @@ class TestAddMember:
 
     async def test_adds_member_as_captain(
         self,
-        service: AddMemberService,
+        service: AddMemberUseCase,
         repo: InMemoryWorkspaceRepository,
         workspace: Workspace,
     ) -> None:
@@ -106,7 +106,7 @@ class TestAddMember:
 
     async def test_commits_via_uow(
         self,
-        service: AddMemberService,
+        service: AddMemberUseCase,
         uow: StubUnitOfWork,
         workspace: Workspace,
     ) -> None:
@@ -131,7 +131,7 @@ class TestAddMember:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(MemberAdded, capture_handler)  # type: ignore[arg-type]
-        service = AddMemberService(
+        service = AddMemberUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -151,7 +151,7 @@ class TestAddMember:
 
     async def test_raises_when_workspace_not_found(
         self,
-        service: AddMemberService,
+        service: AddMemberUseCase,
     ) -> None:
         """WorkspaceNotFoundError is raised when workspace does not exist."""
         with pytest.raises(WorkspaceNotFoundError):
@@ -164,7 +164,7 @@ class TestAddMember:
 
     async def test_raises_when_duplicate_membership(
         self,
-        service: AddMemberService,
+        service: AddMemberUseCase,
         workspace: Workspace,
     ) -> None:
         """DuplicateMembershipError is raised when user is already a member."""
@@ -180,7 +180,7 @@ class TestAddMember:
 
     async def test_user_can_join_multiple_workspaces(
         self,
-        service: AddMemberService,
+        service: AddMemberUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """A user can belong to multiple workspaces."""

--- a/backend/tests/contexts/workspace/application/test_change_member_role_use_case.py
+++ b/backend/tests/contexts/workspace/application/test_change_member_role_use_case.py
@@ -1,12 +1,12 @@
-"""Tests for ChangeMemberRoleService."""
+"""Tests for ChangeMemberRoleUseCase."""
 
 from __future__ import annotations
 
 import pytest
 
-from contexts.workspace.application.change_member_role_service import (
+from contexts.workspace.application.change_member_role_use_case import (
     ChangeMemberRoleInput,
-    ChangeMemberRoleService,
+    ChangeMemberRoleUseCase,
     WorkspaceNotFoundError,
 )
 from contexts.workspace.domain.events import MemberRoleChanged
@@ -46,8 +46,8 @@ class TestChangeMemberRole:
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
         dispatcher: InMemoryEventDispatcher,
-    ) -> ChangeMemberRoleService:
-        return ChangeMemberRoleService(
+    ) -> ChangeMemberRoleUseCase:
+        return ChangeMemberRoleUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -67,7 +67,7 @@ class TestChangeMemberRole:
 
     async def test_changes_role_to_captain(
         self,
-        service: ChangeMemberRoleService,
+        service: ChangeMemberRoleUseCase,
         repo: InMemoryWorkspaceRepository,
         workspace_with_member: tuple[Workspace, UserId],
     ) -> None:
@@ -99,7 +99,7 @@ class TestChangeMemberRole:
         ws.collect_events()
         await repo.save(ws)
 
-        service = ChangeMemberRoleService(
+        service = ChangeMemberRoleUseCase(
             uow=uow, workspace_repo=repo, event_dispatcher=dispatcher
         )
 
@@ -117,7 +117,7 @@ class TestChangeMemberRole:
 
     async def test_noop_when_same_role(
         self,
-        service: ChangeMemberRoleService,
+        service: ChangeMemberRoleUseCase,
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
         workspace_with_member: tuple[Workspace, UserId],
@@ -144,7 +144,7 @@ class TestChangeMemberRole:
 
     async def test_commits_via_uow(
         self,
-        service: ChangeMemberRoleService,
+        service: ChangeMemberRoleUseCase,
         uow: StubUnitOfWork,
         workspace_with_member: tuple[Workspace, UserId],
     ) -> None:
@@ -176,7 +176,7 @@ class TestChangeMemberRole:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(MemberRoleChanged, capture_handler)  # type: ignore[arg-type]
-        service = ChangeMemberRoleService(
+        service = ChangeMemberRoleUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -213,7 +213,7 @@ class TestChangeMemberRole:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(MemberRoleChanged, capture_handler)  # type: ignore[arg-type]
-        service = ChangeMemberRoleService(
+        service = ChangeMemberRoleUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -231,7 +231,7 @@ class TestChangeMemberRole:
 
     async def test_raises_when_workspace_not_found(
         self,
-        service: ChangeMemberRoleService,
+        service: ChangeMemberRoleUseCase,
     ) -> None:
         """WorkspaceNotFoundError is raised when workspace does not exist."""
         with pytest.raises(WorkspaceNotFoundError):
@@ -245,7 +245,7 @@ class TestChangeMemberRole:
 
     async def test_raises_when_membership_not_found(
         self,
-        service: ChangeMemberRoleService,
+        service: ChangeMemberRoleUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """MembershipNotFoundError is raised when user is not a member."""
@@ -264,7 +264,7 @@ class TestChangeMemberRole:
 
     async def test_multiple_captains_allowed(
         self,
-        service: ChangeMemberRoleService,
+        service: ChangeMemberRoleUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """Multiple members can be promoted to Captain in the same workspace."""

--- a/backend/tests/contexts/workspace/application/test_change_workspace_parent_use_case.py
+++ b/backend/tests/contexts/workspace/application/test_change_workspace_parent_use_case.py
@@ -1,12 +1,12 @@
-"""Tests for ChangeWorkspaceParentService."""
+"""Tests for ChangeWorkspaceParentUseCase."""
 
 from __future__ import annotations
 
 import pytest
 
-from contexts.workspace.application.change_workspace_parent_service import (
+from contexts.workspace.application.change_workspace_parent_use_case import (
     ChangeWorkspaceParentInput,
-    ChangeWorkspaceParentService,
+    ChangeWorkspaceParentUseCase,
     ParentWorkspaceNotFoundError,
     WorkspaceNotFoundError,
 )
@@ -43,8 +43,8 @@ class TestChangeWorkspaceParent:
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
         dispatcher: InMemoryEventDispatcher,
-    ) -> ChangeWorkspaceParentService:
-        return ChangeWorkspaceParentService(
+    ) -> ChangeWorkspaceParentUseCase:
+        return ChangeWorkspaceParentUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -67,7 +67,7 @@ class TestChangeWorkspaceParent:
 
     async def test_changes_parent(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """Workspace is moved under a new parent."""
@@ -87,7 +87,7 @@ class TestChangeWorkspaceParent:
 
     async def test_moves_to_root(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """Workspace can be moved to root (parent_id=None)."""
@@ -107,7 +107,7 @@ class TestChangeWorkspaceParent:
 
     async def test_commits_via_uow(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
@@ -137,7 +137,7 @@ class TestChangeWorkspaceParent:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(WorkspaceHierarchyChanged, capture_handler)  # type: ignore[arg-type]
-        service = ChangeWorkspaceParentService(
+        service = ChangeWorkspaceParentUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -162,7 +162,7 @@ class TestChangeWorkspaceParent:
 
     async def test_raises_when_workspace_not_found(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
     ) -> None:
         """WorkspaceNotFoundError is raised for a non-existent workspace."""
         with pytest.raises(WorkspaceNotFoundError):
@@ -175,7 +175,7 @@ class TestChangeWorkspaceParent:
 
     async def test_rejects_self_referencing_parent(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """CircularHierarchyError is raised when setting parent to self."""
@@ -191,7 +191,7 @@ class TestChangeWorkspaceParent:
 
     async def test_rejects_direct_cycle(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """CircularHierarchyError when A->B, then B tries to move under A."""
@@ -208,7 +208,7 @@ class TestChangeWorkspaceParent:
 
     async def test_rejects_indirect_cycle(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """CircularHierarchyError when A->B->C, then A tries to move under C."""
@@ -239,7 +239,7 @@ class TestChangeWorkspaceParent:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(WorkspaceHierarchyChanged, capture_handler)  # type: ignore[arg-type]
-        service = ChangeWorkspaceParentService(
+        service = ChangeWorkspaceParentUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -259,7 +259,7 @@ class TestChangeWorkspaceParent:
 
     async def test_raises_when_parent_workspace_not_found(
         self,
-        service: ChangeWorkspaceParentService,
+        service: ChangeWorkspaceParentUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """ParentWorkspaceNotFoundError is raised when new_parent_id does not exist."""

--- a/backend/tests/contexts/workspace/application/test_create_workspace_use_case.py
+++ b/backend/tests/contexts/workspace/application/test_create_workspace_use_case.py
@@ -1,13 +1,13 @@
-"""Tests for CreateWorkspaceService."""
+"""Tests for CreateWorkspaceUseCase."""
 
 from __future__ import annotations
 
 import pytest
 
-from contexts.workspace.application.create_workspace_service import (
+from contexts.workspace.application.create_workspace_use_case import (
     CreateWorkspaceInput,
     CreateWorkspaceOutput,
-    CreateWorkspaceService,
+    CreateWorkspaceUseCase,
     ParentWorkspaceNotFoundError,
 )
 from contexts.workspace.domain.events import WorkspaceCreated
@@ -41,8 +41,8 @@ class TestCreateWorkspace:
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
         dispatcher: InMemoryEventDispatcher,
-    ) -> CreateWorkspaceService:
-        return CreateWorkspaceService(
+    ) -> CreateWorkspaceUseCase:
+        return CreateWorkspaceUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -50,7 +50,7 @@ class TestCreateWorkspace:
 
     async def test_creates_root_workspace(
         self,
-        service: CreateWorkspaceService,
+        service: CreateWorkspaceUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """Root workspace (no parent) is persisted correctly."""
@@ -66,7 +66,7 @@ class TestCreateWorkspace:
 
     async def test_creates_child_workspace(
         self,
-        service: CreateWorkspaceService,
+        service: CreateWorkspaceUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """Child workspace is linked to the specified parent."""
@@ -87,7 +87,7 @@ class TestCreateWorkspace:
 
     async def test_commits_via_uow(
         self,
-        service: CreateWorkspaceService,
+        service: CreateWorkspaceUseCase,
         uow: StubUnitOfWork,
     ) -> None:
         """UoW commit is called after save."""
@@ -108,7 +108,7 @@ class TestCreateWorkspace:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(WorkspaceCreated, capture_handler)  # type: ignore[arg-type]
-        service = CreateWorkspaceService(
+        service = CreateWorkspaceUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -124,7 +124,7 @@ class TestCreateWorkspace:
 
     async def test_raises_when_parent_workspace_not_found(
         self,
-        service: CreateWorkspaceService,
+        service: CreateWorkspaceUseCase,
     ) -> None:
         """ParentWorkspaceNotFoundError is raised when parent_id does not exist."""
         with pytest.raises(ParentWorkspaceNotFoundError):

--- a/backend/tests/contexts/workspace/application/test_get_captains_for_user.py
+++ b/backend/tests/contexts/workspace/application/test_get_captains_for_user.py
@@ -1,4 +1,4 @@
-"""Tests for GetCaptainsForUserUseCase."""
+"""Tests for GetCaptainsForUserQueryService."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from datetime import datetime
 from contexts.workspace.application.get_captains_for_user import (
     GetCaptainsForUserInput,
     GetCaptainsForUserOutput,
-    GetCaptainsForUserUseCase,
+    GetCaptainsForUserQueryService,
 )
 from contexts.workspace.domain.value_objects import MembershipRole
 from contexts.workspace.domain.workspace import Workspace
@@ -18,9 +18,9 @@ from tests.contexts.workspace.application.conftest import InMemoryWorkspaceRepos
 
 def _build_use_case(
     repo: InMemoryWorkspaceRepository | None = None,
-) -> tuple[GetCaptainsForUserUseCase, InMemoryWorkspaceRepository]:
+) -> tuple[GetCaptainsForUserQueryService, InMemoryWorkspaceRepository]:
     r = repo or InMemoryWorkspaceRepository()
-    uc = GetCaptainsForUserUseCase(workspace_repository=r)
+    uc = GetCaptainsForUserQueryService(workspace_repository=r)
     return uc, r
 
 

--- a/backend/tests/contexts/workspace/application/test_remove_member_use_case.py
+++ b/backend/tests/contexts/workspace/application/test_remove_member_use_case.py
@@ -1,12 +1,12 @@
-"""Tests for RemoveMemberService."""
+"""Tests for RemoveMemberUseCase."""
 
 from __future__ import annotations
 
 import pytest
 
-from contexts.workspace.application.remove_member_service import (
+from contexts.workspace.application.remove_member_use_case import (
     RemoveMemberInput,
-    RemoveMemberService,
+    RemoveMemberUseCase,
     WorkspaceNotFoundError,
 )
 from contexts.workspace.domain.events import MemberRemoved
@@ -46,8 +46,8 @@ class TestRemoveMember:
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
         dispatcher: InMemoryEventDispatcher,
-    ) -> RemoveMemberService:
-        return RemoveMemberService(
+    ) -> RemoveMemberUseCase:
+        return RemoveMemberUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -67,7 +67,7 @@ class TestRemoveMember:
 
     async def test_removes_member(
         self,
-        service: RemoveMemberService,
+        service: RemoveMemberUseCase,
         repo: InMemoryWorkspaceRepository,
         workspace_with_member: tuple[Workspace, UserId],
     ) -> None:
@@ -82,7 +82,7 @@ class TestRemoveMember:
 
     async def test_commits_via_uow(
         self,
-        service: RemoveMemberService,
+        service: RemoveMemberUseCase,
         uow: StubUnitOfWork,
         workspace_with_member: tuple[Workspace, UserId],
     ) -> None:
@@ -108,7 +108,7 @@ class TestRemoveMember:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(MemberRemoved, capture_handler)  # type: ignore[arg-type]
-        service = RemoveMemberService(
+        service = RemoveMemberUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -124,7 +124,7 @@ class TestRemoveMember:
 
     async def test_raises_when_workspace_not_found(
         self,
-        service: RemoveMemberService,
+        service: RemoveMemberUseCase,
     ) -> None:
         """WorkspaceNotFoundError is raised when workspace does not exist."""
         with pytest.raises(WorkspaceNotFoundError):
@@ -137,7 +137,7 @@ class TestRemoveMember:
 
     async def test_raises_when_membership_not_found(
         self,
-        service: RemoveMemberService,
+        service: RemoveMemberUseCase,
         repo: InMemoryWorkspaceRepository,
     ) -> None:
         """MembershipNotFoundError is raised when user is not a member."""

--- a/backend/tests/contexts/workspace/application/test_rename_workspace_use_case.py
+++ b/backend/tests/contexts/workspace/application/test_rename_workspace_use_case.py
@@ -1,12 +1,12 @@
-"""Tests for RenameWorkspaceService."""
+"""Tests for RenameWorkspaceUseCase."""
 
 from __future__ import annotations
 
 import pytest
 
-from contexts.workspace.application.rename_workspace_service import (
+from contexts.workspace.application.rename_workspace_use_case import (
     RenameWorkspaceInput,
-    RenameWorkspaceService,
+    RenameWorkspaceUseCase,
     WorkspaceNotFoundError,
 )
 from contexts.workspace.domain.events import WorkspaceRenamed
@@ -41,8 +41,8 @@ class TestRenameWorkspace:
         uow: StubUnitOfWork,
         repo: InMemoryWorkspaceRepository,
         dispatcher: InMemoryEventDispatcher,
-    ) -> RenameWorkspaceService:
-        return RenameWorkspaceService(
+    ) -> RenameWorkspaceUseCase:
+        return RenameWorkspaceUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -61,7 +61,7 @@ class TestRenameWorkspace:
 
     async def test_renames_workspace(
         self,
-        service: RenameWorkspaceService,
+        service: RenameWorkspaceUseCase,
         repo: InMemoryWorkspaceRepository,
         existing_workspace: Workspace,
     ) -> None:
@@ -81,7 +81,7 @@ class TestRenameWorkspace:
 
     async def test_commits_via_uow(
         self,
-        service: RenameWorkspaceService,
+        service: RenameWorkspaceUseCase,
         uow: StubUnitOfWork,
         existing_workspace: Workspace,
     ) -> None:
@@ -109,7 +109,7 @@ class TestRenameWorkspace:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(WorkspaceRenamed, capture_handler)  # type: ignore[arg-type]
-        service = RenameWorkspaceService(
+        service = RenameWorkspaceUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -142,7 +142,7 @@ class TestRenameWorkspace:
 
         dispatcher = InMemoryEventDispatcher()
         dispatcher.register(WorkspaceRenamed, capture_handler)  # type: ignore[arg-type]
-        service = RenameWorkspaceService(
+        service = RenameWorkspaceUseCase(
             uow=uow,
             workspace_repo=repo,
             event_dispatcher=dispatcher,
@@ -159,7 +159,7 @@ class TestRenameWorkspace:
 
     async def test_raises_when_workspace_not_found(
         self,
-        service: RenameWorkspaceService,
+        service: RenameWorkspaceUseCase,
     ) -> None:
         """WorkspaceNotFoundError is raised for a non-existent workspace."""
         with pytest.raises(WorkspaceNotFoundError):


### PR DESCRIPTION
## 概要
Issue #170 の PR-B。Workspace コンテキストの *Service を命名規則に基づきリネーム。

## 変更内容
### UseCase（6クラス、状態変更）
- AddMemberService → AddMemberUseCase
- ChangeMemberRoleService → ChangeMemberRoleUseCase
- ChangeWorkspaceParentService → ChangeWorkspaceParentUseCase
- CreateWorkspaceService → CreateWorkspaceUseCase
- RemoveMemberService → RemoveMemberUseCase
- RenameWorkspaceService → RenameWorkspaceUseCase

### QueryService（1クラス、読み取り専用）
- GetCaptainsForUserUseCase → GetCaptainsForUserQueryService

ファイル名・テスト・DI登録・exception_handlers・cross-context importを一括更新。

Related: #170