### PR TITLE
ユーザー管理 API エンドポイント (#183 PR-2)

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -70,7 +70,8 @@ async def get_current_user(
     user = await user_repo.get_by_id(parsed_id)
     if user is None:
         raise HTTPException(
-            status_code=403, detail="User not found",
+            status_code=403,
+            detail="User not found",
         )
     if not user.is_active:
         raise HTTPException(
@@ -86,6 +87,7 @@ async def require_admin(
     """Ensure the current user has admin role."""
     if not current_user.is_admin:
         raise HTTPException(
-            status_code=403, detail="Admin access required",
+            status_code=403,
+            detail="Admin access required",
         )
     return current_user

--- a/backend/api/register_routers.py
+++ b/backend/api/register_routers.py
@@ -17,10 +17,13 @@ def register_routers(app: FastAPI) -> None:
         router as preparation_router,
     )
     from contexts.record.presentation.router import router as record_router
+    from shared.presentation.admin_router import admin_router
     from shared.presentation.router import router as users_router
 
     app.include_router(notification_router)
     app.include_router(notifications_router)
     app.include_router(preparation_router, tags=["Preparation"])
     app.include_router(record_router, tags=["Record"])
+    # Register /users/me routes before /users/{user_id} to avoid path conflicts
     app.include_router(users_router)
+    app.include_router(admin_router)

--- a/backend/shared/application/activate_user_use_case.py
+++ b/backend/shared/application/activate_user_use_case.py
@@ -1,0 +1,51 @@
+"""Use case: activate a deactivated user."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.domain.user_repository import UserRepository
+from shared.domain.value_objects import UserId, UserRole
+
+
+@dataclass(frozen=True)
+class ActivateUserInput:
+    user_id: UserId
+
+
+@dataclass(frozen=True)
+class ActivateUserOutput:
+    id: UserId
+    name: str
+    email: str
+    role: UserRole
+    is_active: bool
+    slack_user_id: str | None
+
+
+class UserNotFoundError(Exception):
+    """The requested user does not exist."""
+
+
+class ActivateUserUseCase:
+    """Activate a previously deactivated user."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        self._user_repo = user_repo
+
+    async def execute(self, input_dto: ActivateUserInput) -> ActivateUserOutput:
+        user = await self._user_repo.get_by_id(input_dto.user_id)
+        if user is None:
+            raise UserNotFoundError(f"User {input_dto.user_id.value} not found")
+
+        user.activate()
+        await self._user_repo.save(user)
+
+        return ActivateUserOutput(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            slack_user_id=user.slack_user_id,
+        )

--- a/backend/shared/application/create_user_use_case.py
+++ b/backend/shared/application/create_user_use_case.py
@@ -1,0 +1,59 @@
+"""Use case: create a new user."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.domain.user import User
+from shared.domain.user_repository import UserRepository
+from shared.domain.value_objects import UserId, UserRole
+
+
+@dataclass(frozen=True)
+class CreateUserInput:
+    name: str
+    email: str
+    role: UserRole
+
+
+@dataclass(frozen=True)
+class CreateUserOutput:
+    id: UserId
+    name: str
+    email: str
+    role: UserRole
+    is_active: bool
+    slack_user_id: str | None
+
+
+class EmailAlreadyTakenError(Exception):
+    """The email address is already used by another user."""
+
+
+class CreateUserUseCase:
+    """Create a new user in the system."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        self._user_repo = user_repo
+
+    async def execute(self, input_dto: CreateUserInput) -> CreateUserOutput:
+        existing = await self._user_repo.get_by_email(input_dto.email)
+        if existing is not None:
+            raise EmailAlreadyTakenError(f"Email {input_dto.email} is already taken")
+
+        user = User(
+            id=UserId.generate(),
+            name=input_dto.name,
+            email=input_dto.email,
+            role=input_dto.role,
+        )
+        await self._user_repo.save(user)
+
+        return CreateUserOutput(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            slack_user_id=user.slack_user_id,
+        )

--- a/backend/shared/application/deactivate_user_use_case.py
+++ b/backend/shared/application/deactivate_user_use_case.py
@@ -1,0 +1,61 @@
+"""Use case: deactivate a user."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.domain.user_repository import UserRepository
+from shared.domain.value_objects import UserId, UserRole
+
+
+@dataclass(frozen=True)
+class DeactivateUserInput:
+    user_id: UserId
+
+
+@dataclass(frozen=True)
+class DeactivateUserOutput:
+    id: UserId
+    name: str
+    email: str
+    role: UserRole
+    is_active: bool
+    slack_user_id: str | None
+
+
+class UserNotFoundError(Exception):
+    """The requested user does not exist."""
+
+
+class LastAdminError(Exception):
+    """Cannot deactivate the last active admin."""
+
+
+class DeactivateUserUseCase:
+    """Deactivate a user (soft delete)."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        self._user_repo = user_repo
+
+    async def execute(self, input_dto: DeactivateUserInput) -> DeactivateUserOutput:
+        user = await self._user_repo.get_by_id(input_dto.user_id)
+        if user is None:
+            raise UserNotFoundError(f"User {input_dto.user_id.value} not found")
+
+        # Last admin protection
+        if user.role == UserRole.ADMIN:
+            active_admin_count = await self._user_repo.count_active_admins()
+            if active_admin_count <= 1:
+                raise LastAdminError("Cannot deactivate the last active admin")
+
+        user.deactivate()
+        await self._user_repo.save(user)
+
+        return DeactivateUserOutput(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            slack_user_id=user.slack_user_id,
+        )

--- a/backend/shared/application/get_user_detail_query_service.py
+++ b/backend/shared/application/get_user_detail_query_service.py
@@ -1,0 +1,47 @@
+"""Query service: get a single user's detail."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.domain.user_repository import UserRepository
+from shared.domain.value_objects import UserId, UserRole
+
+
+@dataclass(frozen=True)
+class GetUserDetailInput:
+    user_id: UserId
+
+
+@dataclass(frozen=True)
+class GetUserDetailOutput:
+    id: UserId
+    name: str
+    email: str
+    role: UserRole
+    is_active: bool
+    slack_user_id: str | None
+
+
+class UserNotFoundError(Exception):
+    """The requested user does not exist."""
+
+
+class GetUserDetailQueryService:
+    """Return a single user's detail by ID."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        self._user_repo = user_repo
+
+    async def execute(self, input_dto: GetUserDetailInput) -> GetUserDetailOutput:
+        user = await self._user_repo.get_by_id(input_dto.user_id)
+        if user is None:
+            raise UserNotFoundError(f"User {input_dto.user_id.value} not found")
+        return GetUserDetailOutput(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            slack_user_id=user.slack_user_id,
+        )

--- a/backend/shared/application/list_users_query_service.py
+++ b/backend/shared/application/list_users_query_service.py
@@ -1,0 +1,46 @@
+"""Query service: list all users."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.domain.user_repository import UserRepository
+from shared.domain.value_objects import UserId, UserRole
+
+
+@dataclass(frozen=True)
+class ListUsersOutput:
+    users: list[ListUsersItem]
+
+
+@dataclass(frozen=True)
+class ListUsersItem:
+    id: UserId
+    name: str
+    email: str
+    role: UserRole
+    is_active: bool
+    slack_user_id: str | None
+
+
+class ListUsersQueryService:
+    """Return all users in the system."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        self._user_repo = user_repo
+
+    async def execute(self) -> ListUsersOutput:
+        users = await self._user_repo.list_all()
+        return ListUsersOutput(
+            users=[
+                ListUsersItem(
+                    id=u.id,
+                    name=u.name,
+                    email=u.email,
+                    role=u.role,
+                    is_active=u.is_active,
+                    slack_user_id=u.slack_user_id,
+                )
+                for u in users
+            ]
+        )

--- a/backend/shared/application/update_user_use_case.py
+++ b/backend/shared/application/update_user_use_case.py
@@ -1,0 +1,79 @@
+"""Use case: update a user's name, email, and/or role."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.domain.user_repository import UserRepository
+from shared.domain.value_objects import UserId, UserRole
+
+
+@dataclass(frozen=True)
+class UpdateUserInput:
+    user_id: UserId
+    name: str
+    email: str
+    role: UserRole
+
+
+@dataclass(frozen=True)
+class UpdateUserOutput:
+    id: UserId
+    name: str
+    email: str
+    role: UserRole
+    is_active: bool
+    slack_user_id: str | None
+
+
+class UserNotFoundError(Exception):
+    """The requested user does not exist."""
+
+
+class EmailAlreadyTakenError(Exception):
+    """The email address is already used by another user."""
+
+
+class LastAdminError(Exception):
+    """Cannot remove admin role from the last active admin."""
+
+
+class UpdateUserUseCase:
+    """Update a user's name, email, and role (admin only)."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        self._user_repo = user_repo
+
+    async def execute(self, input_dto: UpdateUserInput) -> UpdateUserOutput:
+        user = await self._user_repo.get_by_id(input_dto.user_id)
+        if user is None:
+            raise UserNotFoundError(f"User {input_dto.user_id.value} not found")
+
+        # Last admin protection: if changing role from admin to member
+        if user.role == UserRole.ADMIN and input_dto.role != UserRole.ADMIN:
+            active_admin_count = await self._user_repo.count_active_admins()
+            if active_admin_count <= 1:
+                raise LastAdminError(
+                    "Cannot remove admin role from the last active admin"
+                )
+
+        # Email uniqueness check
+        if user.email != input_dto.email:
+            existing = await self._user_repo.get_by_email(input_dto.email)
+            if existing is not None and existing.id != user.id:
+                raise EmailAlreadyTakenError(
+                    f"Email {input_dto.email} is already taken"
+                )
+
+        user.update_profile(name=input_dto.name, email=input_dto.email)
+        user.change_role(input_dto.role)
+        await self._user_repo.save(user)
+
+        return UpdateUserOutput(
+            id=user.id,
+            name=user.name,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            slack_user_id=user.slack_user_id,
+        )

--- a/backend/shared/domain/user_repository.py
+++ b/backend/shared/domain/user_repository.py
@@ -18,3 +18,9 @@ class UserRepository(ABC):
 
     @abstractmethod
     async def save(self, user: User) -> None: ...
+
+    @abstractmethod
+    async def list_all(self) -> list[User]: ...
+
+    @abstractmethod
+    async def count_active_admins(self) -> int: ...

--- a/backend/shared/infrastructure/in_memory_user_repository.py
+++ b/backend/shared/infrastructure/in_memory_user_repository.py
@@ -1,6 +1,6 @@
 from shared.domain.user import User
 from shared.domain.user_repository import UserRepository
-from shared.domain.value_objects import UserId
+from shared.domain.value_objects import UserId, UserRole
 
 
 class InMemoryUserRepository(UserRepository):
@@ -30,3 +30,11 @@ class InMemoryUserRepository(UserRepository):
 
     async def save(self, user: User) -> None:
         self._users[user.id] = user
+
+    async def list_all(self) -> list[User]:
+        return sorted(self._users.values(), key=lambda u: u.name)
+
+    async def count_active_admins(self) -> int:
+        return sum(
+            1 for u in self._users.values() if u.role == UserRole.ADMIN and u.is_active
+        )

--- a/backend/shared/infrastructure/sqlalchemy_user_repository.py
+++ b/backend/shared/infrastructure/sqlalchemy_user_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shared.domain.user import User
@@ -60,6 +60,24 @@ class SqlAlchemyUserRepository(UserRepository):
         existing.role = user.role.value
         existing.is_active = user.is_active
         existing.slack_user_id = user.slack_user_id
+
+    async def list_all(self) -> list[User]:
+        stmt = select(UserTable).order_by(UserTable.name)
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [self._to_entity(row) for row in rows]
+
+    async def count_active_admins(self) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(UserTable)
+            .where(
+                UserTable.role == UserRole.ADMIN.value,
+                UserTable.is_active.is_(True),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one()
 
     @staticmethod
     def _to_entity(row: UserTable) -> User:

--- a/backend/shared/presentation/admin_router.py
+++ b/backend/shared/presentation/admin_router.py
@@ -1,0 +1,253 @@
+"""FastAPI router for user management endpoints (admin only)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from api.dependencies import require_admin
+from shared.application.activate_user_use_case import (
+    ActivateUserInput,
+    ActivateUserUseCase,
+)
+from shared.application.activate_user_use_case import (
+    UserNotFoundError as ActivateUserNotFoundError,
+)
+from shared.application.create_user_use_case import (
+    CreateUserInput,
+    CreateUserUseCase,
+    EmailAlreadyTakenError,
+)
+from shared.application.deactivate_user_use_case import (
+    DeactivateUserInput,
+    DeactivateUserUseCase,
+)
+from shared.application.deactivate_user_use_case import (
+    LastAdminError as DeactivateLastAdminError,
+)
+from shared.application.deactivate_user_use_case import (
+    UserNotFoundError as DeactivateUserNotFoundError,
+)
+from shared.application.get_user_detail_query_service import (
+    GetUserDetailInput,
+    GetUserDetailQueryService,
+)
+from shared.application.get_user_detail_query_service import (
+    UserNotFoundError as GetUserNotFoundError,
+)
+from shared.application.list_users_query_service import ListUsersQueryService
+from shared.application.update_user_use_case import (
+    EmailAlreadyTakenError as UpdateEmailAlreadyTakenError,
+)
+from shared.application.update_user_use_case import (
+    LastAdminError as UpdateLastAdminError,
+)
+from shared.application.update_user_use_case import (
+    UpdateUserInput,
+    UpdateUserUseCase,
+)
+from shared.application.update_user_use_case import (
+    UserNotFoundError as UpdateUserNotFoundError,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId
+from shared.presentation.dependencies import (
+    get_activate_user_use_case,
+    get_create_user_use_case,
+    get_deactivate_user_use_case,
+    get_get_user_detail_query_service,
+    get_list_users_query_service,
+    get_update_user_use_case,
+)
+from shared.presentation.schemas import (
+    CreateUserRequest,
+    UpdateUserRequest,
+    UserListResponse,
+    UserProfileResponse,
+)
+
+admin_router = APIRouter(prefix="/users", tags=["User Management"])
+
+
+@admin_router.get("", response_model=UserListResponse)
+async def list_users(
+    _admin: Annotated[User, Depends(require_admin)],
+    query_service: Annotated[
+        ListUsersQueryService, Depends(get_list_users_query_service)
+    ],
+) -> UserListResponse:
+    """Return all users in the system."""
+    output = await query_service.execute()
+    return UserListResponse(
+        users=[
+            UserProfileResponse(
+                id=str(u.id.value),
+                name=u.name,
+                email=u.email,
+                role=u.role,
+                is_active=u.is_active,
+                slack_user_id=u.slack_user_id,
+            )
+            for u in output.users
+        ]
+    )
+
+
+@admin_router.post(
+    "", response_model=UserProfileResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_user(
+    body: CreateUserRequest,
+    _admin: Annotated[User, Depends(require_admin)],
+    use_case: Annotated[CreateUserUseCase, Depends(get_create_user_use_case)],
+) -> UserProfileResponse:
+    """Create a new user."""
+    try:
+        output = await use_case.execute(
+            input_dto=CreateUserInput(
+                name=body.name,
+                email=body.email,
+                role=body.role,
+            )
+        )
+    except EmailAlreadyTakenError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email address is already in use",
+        ) from None
+    return UserProfileResponse(
+        id=str(output.id.value),
+        name=output.name,
+        email=output.email,
+        role=output.role,
+        is_active=output.is_active,
+        slack_user_id=output.slack_user_id,
+    )
+
+
+@admin_router.get("/{user_id}", response_model=UserProfileResponse)
+async def get_user_detail(
+    user_id: str,
+    _admin: Annotated[User, Depends(require_admin)],
+    query_service: Annotated[
+        GetUserDetailQueryService, Depends(get_get_user_detail_query_service)
+    ],
+) -> UserProfileResponse:
+    """Return a single user's detail."""
+    try:
+        output = await query_service.execute(
+            input_dto=GetUserDetailInput(user_id=UserId.from_str(user_id))
+        )
+    except GetUserNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        ) from None
+    return UserProfileResponse(
+        id=str(output.id.value),
+        name=output.name,
+        email=output.email,
+        role=output.role,
+        is_active=output.is_active,
+        slack_user_id=output.slack_user_id,
+    )
+
+
+@admin_router.put("/{user_id}", response_model=UserProfileResponse)
+async def update_user(
+    user_id: str,
+    body: UpdateUserRequest,
+    _admin: Annotated[User, Depends(require_admin)],
+    use_case: Annotated[UpdateUserUseCase, Depends(get_update_user_use_case)],
+) -> UserProfileResponse:
+    """Update a user's name, email, and role."""
+    try:
+        output = await use_case.execute(
+            input_dto=UpdateUserInput(
+                user_id=UserId.from_str(user_id),
+                name=body.name,
+                email=body.email,
+                role=body.role,
+            )
+        )
+    except UpdateUserNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        ) from None
+    except UpdateEmailAlreadyTakenError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email address is already in use",
+        ) from None
+    except UpdateLastAdminError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot remove admin role from the last active admin",
+        ) from None
+    return UserProfileResponse(
+        id=str(output.id.value),
+        name=output.name,
+        email=output.email,
+        role=output.role,
+        is_active=output.is_active,
+        slack_user_id=output.slack_user_id,
+    )
+
+
+@admin_router.put("/{user_id}/deactivate", response_model=UserProfileResponse)
+async def deactivate_user(
+    user_id: str,
+    _admin: Annotated[User, Depends(require_admin)],
+    use_case: Annotated[DeactivateUserUseCase, Depends(get_deactivate_user_use_case)],
+) -> UserProfileResponse:
+    """Deactivate a user."""
+    try:
+        output = await use_case.execute(
+            input_dto=DeactivateUserInput(user_id=UserId.from_str(user_id))
+        )
+    except DeactivateUserNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        ) from None
+    except DeactivateLastAdminError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot deactivate the last active admin",
+        ) from None
+    return UserProfileResponse(
+        id=str(output.id.value),
+        name=output.name,
+        email=output.email,
+        role=output.role,
+        is_active=output.is_active,
+        slack_user_id=output.slack_user_id,
+    )
+
+
+@admin_router.put("/{user_id}/activate", response_model=UserProfileResponse)
+async def activate_user(
+    user_id: str,
+    _admin: Annotated[User, Depends(require_admin)],
+    use_case: Annotated[ActivateUserUseCase, Depends(get_activate_user_use_case)],
+) -> UserProfileResponse:
+    """Activate a deactivated user."""
+    try:
+        output = await use_case.execute(
+            input_dto=ActivateUserInput(user_id=UserId.from_str(user_id))
+        )
+    except ActivateUserNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        ) from None
+    return UserProfileResponse(
+        id=str(output.id.value),
+        name=output.name,
+        email=output.email,
+        role=output.role,
+        is_active=output.is_active,
+        slack_user_id=output.slack_user_id,
+    )

--- a/backend/shared/presentation/dependencies.py
+++ b/backend/shared/presentation/dependencies.py
@@ -7,7 +7,13 @@ from typing import Annotated
 from fastapi import Depends
 
 from api.dependencies import get_user_repository
+from shared.application.activate_user_use_case import ActivateUserUseCase
+from shared.application.create_user_use_case import CreateUserUseCase
+from shared.application.deactivate_user_use_case import DeactivateUserUseCase
+from shared.application.get_user_detail_query_service import GetUserDetailQueryService
+from shared.application.list_users_query_service import ListUsersQueryService
 from shared.application.update_my_profile_use_case import UpdateMyProfileUseCase
+from shared.application.update_user_use_case import UpdateUserUseCase
 from shared.domain.user_repository import UserRepository
 
 
@@ -15,3 +21,39 @@ def get_update_my_profile_use_case(
     repo: Annotated[UserRepository, Depends(get_user_repository)],
 ) -> UpdateMyProfileUseCase:
     return UpdateMyProfileUseCase(user_repo=repo)
+
+
+def get_list_users_query_service(
+    repo: Annotated[UserRepository, Depends(get_user_repository)],
+) -> ListUsersQueryService:
+    return ListUsersQueryService(user_repo=repo)
+
+
+def get_create_user_use_case(
+    repo: Annotated[UserRepository, Depends(get_user_repository)],
+) -> CreateUserUseCase:
+    return CreateUserUseCase(user_repo=repo)
+
+
+def get_get_user_detail_query_service(
+    repo: Annotated[UserRepository, Depends(get_user_repository)],
+) -> GetUserDetailQueryService:
+    return GetUserDetailQueryService(user_repo=repo)
+
+
+def get_update_user_use_case(
+    repo: Annotated[UserRepository, Depends(get_user_repository)],
+) -> UpdateUserUseCase:
+    return UpdateUserUseCase(user_repo=repo)
+
+
+def get_deactivate_user_use_case(
+    repo: Annotated[UserRepository, Depends(get_user_repository)],
+) -> DeactivateUserUseCase:
+    return DeactivateUserUseCase(user_repo=repo)
+
+
+def get_activate_user_use_case(
+    repo: Annotated[UserRepository, Depends(get_user_repository)],
+) -> ActivateUserUseCase:
+    return ActivateUserUseCase(user_repo=repo)

--- a/backend/shared/presentation/schemas.py
+++ b/backend/shared/presentation/schemas.py
@@ -32,3 +32,39 @@ class UpdateMyProfileRequest(BaseModel):
         if not _EMAIL_RE.match(v):
             raise ValueError("Invalid email address")
         return v
+
+
+class CreateUserRequest(BaseModel):
+    """Request schema for creating a user."""
+
+    name: str
+    email: str
+    role: UserRole
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        if not _EMAIL_RE.match(v):
+            raise ValueError("Invalid email address")
+        return v
+
+
+class UpdateUserRequest(BaseModel):
+    """Request schema for updating a user."""
+
+    name: str
+    email: str
+    role: UserRole
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        if not _EMAIL_RE.match(v):
+            raise ValueError("Invalid email address")
+        return v
+
+
+class UserListResponse(BaseModel):
+    """Response schema for user list."""
+
+    users: list[UserProfileResponse]

--- a/backend/tests/shared/application/test_activate_user_use_case.py
+++ b/backend/tests/shared/application/test_activate_user_use_case.py
@@ -1,0 +1,49 @@
+"""Tests for ActivateUserUseCase."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.application.activate_user_use_case import (
+    ActivateUserInput,
+    ActivateUserUseCase,
+    UserNotFoundError,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+@pytest.fixture
+def repo() -> InMemoryUserRepository:
+    return InMemoryUserRepository()
+
+
+@pytest.fixture
+def use_case(repo: InMemoryUserRepository) -> ActivateUserUseCase:
+    return ActivateUserUseCase(user_repo=repo)
+
+
+@pytest.mark.asyncio
+async def test_activate_user_success(
+    repo: InMemoryUserRepository, use_case: ActivateUserUseCase
+) -> None:
+    """A deactivated user can be activated."""
+    user = User(
+        id=UserId.generate(),
+        name="Inactive",
+        email="inactive@example.com",
+        role=UserRole.MEMBER,
+        is_active=False,
+    )
+    repo.add(user)
+
+    output = await use_case.execute(ActivateUserInput(user_id=user.id))
+    assert output.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_activate_not_found(use_case: ActivateUserUseCase) -> None:
+    """Activating a non-existent user raises UserNotFoundError."""
+    with pytest.raises(UserNotFoundError):
+        await use_case.execute(ActivateUserInput(user_id=UserId.generate()))

--- a/backend/tests/shared/application/test_create_user_use_case.py
+++ b/backend/tests/shared/application/test_create_user_use_case.py
@@ -1,0 +1,65 @@
+"""Tests for CreateUserUseCase."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.application.create_user_use_case import (
+    CreateUserInput,
+    CreateUserUseCase,
+    EmailAlreadyTakenError,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+@pytest.fixture
+def repo() -> InMemoryUserRepository:
+    return InMemoryUserRepository()
+
+
+@pytest.fixture
+def use_case(repo: InMemoryUserRepository) -> CreateUserUseCase:
+    return CreateUserUseCase(user_repo=repo)
+
+
+@pytest.mark.asyncio
+async def test_create_user_success(use_case: CreateUserUseCase) -> None:
+    """A new user is created with the given name, email, and role."""
+    output = await use_case.execute(
+        CreateUserInput(name="Alice", email="alice@example.com", role=UserRole.MEMBER)
+    )
+    assert output.name == "Alice"
+    assert output.email == "alice@example.com"
+    assert output.role == UserRole.MEMBER
+    assert output.is_active is True
+    assert output.slack_user_id is None
+
+
+@pytest.mark.asyncio
+async def test_create_admin_user(use_case: CreateUserUseCase) -> None:
+    """A user can be created with admin role."""
+    output = await use_case.execute(
+        CreateUserInput(name="Boss", email="boss@example.com", role=UserRole.ADMIN)
+    )
+    assert output.role == UserRole.ADMIN
+
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_email_raises(
+    repo: InMemoryUserRepository, use_case: CreateUserUseCase
+) -> None:
+    """Creating a user with an existing email raises EmailAlreadyTakenError."""
+    existing = User(
+        id=UserId.generate(),
+        name="Existing",
+        email="taken@example.com",
+        role=UserRole.MEMBER,
+    )
+    repo.add(existing)
+
+    with pytest.raises(EmailAlreadyTakenError):
+        await use_case.execute(
+            CreateUserInput(name="New", email="taken@example.com", role=UserRole.MEMBER)
+        )

--- a/backend/tests/shared/application/test_deactivate_user_use_case.py
+++ b/backend/tests/shared/application/test_deactivate_user_use_case.py
@@ -1,0 +1,86 @@
+"""Tests for DeactivateUserUseCase."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.application.deactivate_user_use_case import (
+    DeactivateUserInput,
+    DeactivateUserUseCase,
+    LastAdminError,
+    UserNotFoundError,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+@pytest.fixture
+def repo() -> InMemoryUserRepository:
+    return InMemoryUserRepository()
+
+
+@pytest.fixture
+def use_case(repo: InMemoryUserRepository) -> DeactivateUserUseCase:
+    return DeactivateUserUseCase(user_repo=repo)
+
+
+def _make_user(
+    *,
+    role: UserRole = UserRole.MEMBER,
+    is_active: bool = True,
+    email: str | None = None,
+) -> User:
+    uid = UserId.generate()
+    return User(
+        id=uid,
+        name="User",
+        email=email or f"{uid.value}@example.com",
+        role=role,
+        is_active=is_active,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deactivate_member_success(
+    repo: InMemoryUserRepository, use_case: DeactivateUserUseCase
+) -> None:
+    """A member user can be deactivated."""
+    user = _make_user(role=UserRole.MEMBER)
+    repo.add(user)
+
+    output = await use_case.execute(DeactivateUserInput(user_id=user.id))
+    assert output.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_deactivate_not_found(use_case: DeactivateUserUseCase) -> None:
+    """Deactivating a non-existent user raises UserNotFoundError."""
+    with pytest.raises(UserNotFoundError):
+        await use_case.execute(DeactivateUserInput(user_id=UserId.generate()))
+
+
+@pytest.mark.asyncio
+async def test_deactivate_last_admin_rejected(
+    repo: InMemoryUserRepository, use_case: DeactivateUserUseCase
+) -> None:
+    """Cannot deactivate the last active admin."""
+    admin = _make_user(role=UserRole.ADMIN)
+    repo.add(admin)
+
+    with pytest.raises(LastAdminError):
+        await use_case.execute(DeactivateUserInput(user_id=admin.id))
+
+
+@pytest.mark.asyncio
+async def test_deactivate_admin_allowed_when_multiple(
+    repo: InMemoryUserRepository, use_case: DeactivateUserUseCase
+) -> None:
+    """Deactivating an admin is allowed when there are multiple active admins."""
+    admin1 = _make_user(role=UserRole.ADMIN, email="a1@example.com")
+    admin2 = _make_user(role=UserRole.ADMIN, email="a2@example.com")
+    repo.add(admin1)
+    repo.add(admin2)
+
+    output = await use_case.execute(DeactivateUserInput(user_id=admin1.id))
+    assert output.is_active is False

--- a/backend/tests/shared/application/test_get_user_detail_query_service.py
+++ b/backend/tests/shared/application/test_get_user_detail_query_service.py
@@ -1,0 +1,54 @@
+"""Tests for GetUserDetailQueryService."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.application.get_user_detail_query_service import (
+    GetUserDetailInput,
+    GetUserDetailQueryService,
+    UserNotFoundError,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+@pytest.fixture
+def repo() -> InMemoryUserRepository:
+    return InMemoryUserRepository()
+
+
+@pytest.fixture
+def service(repo: InMemoryUserRepository) -> GetUserDetailQueryService:
+    return GetUserDetailQueryService(user_repo=repo)
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_success(
+    repo: InMemoryUserRepository, service: GetUserDetailQueryService
+) -> None:
+    """A user's detail is returned by ID."""
+    user = User(
+        id=UserId.generate(),
+        name="Alice",
+        email="alice@example.com",
+        role=UserRole.MEMBER,
+        slack_user_id="U123",
+    )
+    repo.add(user)
+
+    output = await service.execute(GetUserDetailInput(user_id=user.id))
+    assert output.name == "Alice"
+    assert output.email == "alice@example.com"
+    assert output.role == UserRole.MEMBER
+    assert output.slack_user_id == "U123"
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_not_found(
+    service: GetUserDetailQueryService,
+) -> None:
+    """Requesting a non-existent user raises UserNotFoundError."""
+    with pytest.raises(UserNotFoundError):
+        await service.execute(GetUserDetailInput(user_id=UserId.generate()))

--- a/backend/tests/shared/application/test_list_users_query_service.py
+++ b/backend/tests/shared/application/test_list_users_query_service.py
@@ -1,0 +1,55 @@
+"""Tests for ListUsersQueryService."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.application.list_users_query_service import ListUsersQueryService
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+@pytest.fixture
+def repo() -> InMemoryUserRepository:
+    return InMemoryUserRepository()
+
+
+@pytest.fixture
+def service(repo: InMemoryUserRepository) -> ListUsersQueryService:
+    return ListUsersQueryService(user_repo=repo)
+
+
+@pytest.mark.asyncio
+async def test_list_empty(service: ListUsersQueryService) -> None:
+    """An empty repository returns an empty list."""
+    output = await service.execute()
+    assert output.users == []
+
+
+@pytest.mark.asyncio
+async def test_list_users(
+    repo: InMemoryUserRepository, service: ListUsersQueryService
+) -> None:
+    """All users are returned."""
+    repo.add(
+        User(
+            id=UserId.generate(),
+            name="Alice",
+            email="alice@example.com",
+            role=UserRole.MEMBER,
+        )
+    )
+    repo.add(
+        User(
+            id=UserId.generate(),
+            name="Bob",
+            email="bob@example.com",
+            role=UserRole.ADMIN,
+        )
+    )
+
+    output = await service.execute()
+    assert len(output.users) == 2
+    names = {u.name for u in output.users}
+    assert names == {"Alice", "Bob"}

--- a/backend/tests/shared/application/test_update_user_use_case.py
+++ b/backend/tests/shared/application/test_update_user_use_case.py
@@ -1,0 +1,157 @@
+"""Tests for UpdateUserUseCase."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.application.update_user_use_case import (
+    EmailAlreadyTakenError,
+    LastAdminError,
+    UpdateUserInput,
+    UpdateUserUseCase,
+    UserNotFoundError,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+@pytest.fixture
+def repo() -> InMemoryUserRepository:
+    return InMemoryUserRepository()
+
+
+@pytest.fixture
+def use_case(repo: InMemoryUserRepository) -> UpdateUserUseCase:
+    return UpdateUserUseCase(user_repo=repo)
+
+
+def _make_user(
+    *,
+    name: str = "Test",
+    email: str = "test@example.com",
+    role: UserRole = UserRole.MEMBER,
+    is_active: bool = True,
+) -> User:
+    return User(
+        id=UserId.generate(),
+        name=name,
+        email=email,
+        role=role,
+        is_active=is_active,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_user_success(
+    repo: InMemoryUserRepository, use_case: UpdateUserUseCase
+) -> None:
+    """A user's name, email, and role can be updated."""
+    user = _make_user(name="Old", email="old@example.com", role=UserRole.MEMBER)
+    repo.add(user)
+
+    output = await use_case.execute(
+        UpdateUserInput(
+            user_id=user.id,
+            name="New",
+            email="new@example.com",
+            role=UserRole.ADMIN,
+        )
+    )
+    assert output.name == "New"
+    assert output.email == "new@example.com"
+    assert output.role == UserRole.ADMIN
+
+
+@pytest.mark.asyncio
+async def test_update_user_not_found(use_case: UpdateUserUseCase) -> None:
+    """Updating a non-existent user raises UserNotFoundError."""
+    with pytest.raises(UserNotFoundError):
+        await use_case.execute(
+            UpdateUserInput(
+                user_id=UserId.generate(),
+                name="X",
+                email="x@example.com",
+                role=UserRole.MEMBER,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_user_duplicate_email(
+    repo: InMemoryUserRepository, use_case: UpdateUserUseCase
+) -> None:
+    """Changing email to one already used raises EmailAlreadyTakenError."""
+    other = _make_user(name="Other", email="other@example.com")
+    target = _make_user(name="Target", email="target@example.com")
+    repo.add(other)
+    repo.add(target)
+
+    with pytest.raises(EmailAlreadyTakenError):
+        await use_case.execute(
+            UpdateUserInput(
+                user_id=target.id,
+                name="Target",
+                email="other@example.com",
+                role=UserRole.MEMBER,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_user_same_email_ok(
+    repo: InMemoryUserRepository, use_case: UpdateUserUseCase
+) -> None:
+    """Keeping the same email does not trigger the duplicate check."""
+    user = _make_user(name="Keep", email="keep@example.com")
+    repo.add(user)
+
+    output = await use_case.execute(
+        UpdateUserInput(
+            user_id=user.id,
+            name="Updated",
+            email="keep@example.com",
+            role=UserRole.MEMBER,
+        )
+    )
+    assert output.name == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_last_admin_role_change_rejected(
+    repo: InMemoryUserRepository, use_case: UpdateUserUseCase
+) -> None:
+    """Cannot change role of the last active admin from admin to member."""
+    admin = _make_user(name="Admin", email="admin@example.com", role=UserRole.ADMIN)
+    repo.add(admin)
+
+    with pytest.raises(LastAdminError):
+        await use_case.execute(
+            UpdateUserInput(
+                user_id=admin.id,
+                name="Admin",
+                email="admin@example.com",
+                role=UserRole.MEMBER,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_admin_role_change_allowed_when_multiple_admins(
+    repo: InMemoryUserRepository, use_case: UpdateUserUseCase
+) -> None:
+    """Changing admin role is allowed when there are multiple active admins."""
+    admin1 = _make_user(name="Admin1", email="a1@example.com", role=UserRole.ADMIN)
+    admin2 = _make_user(name="Admin2", email="a2@example.com", role=UserRole.ADMIN)
+    repo.add(admin1)
+    repo.add(admin2)
+
+    output = await use_case.execute(
+        UpdateUserInput(
+            user_id=admin1.id,
+            name="Admin1",
+            email="a1@example.com",
+            role=UserRole.MEMBER,
+        )
+    )
+    assert output.role == UserRole.MEMBER


### PR DESCRIPTION
## Summary
- GET/POST /users, GET/PUT /users/{id}, PUT deactivate/activate
- 最後の admin 保護、メール重複チェック
- 19件のユニットテスト

Related: #183 (PR-2/3)