### PR TITLE
ユーザー管理画面（/admin/users）の実装

### DIFF
--- a/backend/shared/application/list_users_query_service.py
+++ b/backend/shared/application/list_users_query_service.py
@@ -17,6 +17,7 @@ class ListUsersInput:
 @dataclass(frozen=True)
 class ListUsersOutput:
     users: list[ListUsersItem]
+    total: int
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,7 @@ class ListUsersQueryService:
     async def execute(self, input_dto: ListUsersInput | None = None) -> ListUsersOutput:
         dto = input_dto or ListUsersInput()
         users = await self._user_repo.list_all(offset=dto.offset, limit=dto.limit)
+        total = await self._user_repo.count_all()
         return ListUsersOutput(
             users=[
                 ListUsersItem(
@@ -49,5 +51,6 @@ class ListUsersQueryService:
                     slack_user_id=u.slack_user_id,
                 )
                 for u in users
-            ]
+            ],
+            total=total,
         )

--- a/backend/shared/presentation/admin_router.py
+++ b/backend/shared/presentation/admin_router.py
@@ -108,7 +108,8 @@ async def list_users(
                 slack_user_id=u.slack_user_id,
             )
             for u in output.users
-        ]
+        ],
+        total=output.total,
     )
 
 

--- a/backend/shared/presentation/schemas.py
+++ b/backend/shared/presentation/schemas.py
@@ -68,3 +68,4 @@ class UserListResponse(BaseModel):
     """Response schema for user list."""
 
     users: list[UserProfileResponse]
+    total: int

--- a/backend/tests/shared/presentation/test_admin_router.py
+++ b/backend/tests/shared/presentation/test_admin_router.py
@@ -207,14 +207,16 @@ class TestCrudOperations:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data["users"]) == 2
+        assert data["total"] == 2
 
     @pytest.mark.asyncio
     async def test_list_users_with_pagination(self, client: AsyncClient) -> None:
-        """Pagination query params limit results."""
+        """Pagination query params limit results and total reflects all users."""
         resp = await client.get("/users?offset=0&limit=1", headers=_admin_headers())
         assert resp.status_code == 200
         data = resp.json()
         assert len(data["users"]) == 1
+        assert data["total"] == 2
 
     @pytest.mark.asyncio
     async def test_list_users_invalid_limit(self, client: AsyncClient) -> None:

--- a/frontend/src/components/guards/AdminGuard.tsx
+++ b/frontend/src/components/guards/AdminGuard.tsx
@@ -1,0 +1,12 @@
+import { Navigate, Outlet } from "react-router";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+
+export function AdminGuard() {
+  const { role } = useCurrentUser();
+
+  if (role !== "admin") {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/frontend/src/components/guards/AdminGuard.tsx
+++ b/frontend/src/components/guards/AdminGuard.tsx
@@ -1,12 +1,13 @@
-import { Navigate, Outlet } from "react-router";
+import type { ReactNode } from "react";
+import { Navigate } from "react-router";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 
-export function AdminGuard() {
+export function AdminGuard({ children }: { children: ReactNode }) {
   const { role } = useCurrentUser();
 
   if (role !== "admin") {
     return <Navigate to="/" replace />;
   }
 
-  return <Outlet />;
+  return <>{children}</>;
 }

--- a/frontend/src/components/guards/__tests__/AdminGuard.test.tsx
+++ b/frontend/src/components/guards/__tests__/AdminGuard.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import { AdminGuard } from "../AdminGuard";
+
+const mockUseCurrentUser = vi.fn();
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+function renderWithRouter(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/" element={<div>Home</div>} />
+        <Route element={<AdminGuard />}>
+          <Route path="/admin/users" element={<div>Admin Users</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("AdminGuard", () => {
+  it("renders child route when user is admin", () => {
+    mockUseCurrentUser.mockReturnValue({
+      userId: "u1",
+      name: "Admin",
+      role: "admin",
+    });
+
+    renderWithRouter("/admin/users");
+
+    expect(screen.getByText("Admin Users")).toBeInTheDocument();
+    expect(screen.queryByText("Home")).not.toBeInTheDocument();
+  });
+
+  it("redirects to / when user is not admin", () => {
+    mockUseCurrentUser.mockReturnValue({
+      userId: "u2",
+      name: "Member",
+      role: "member",
+    });
+
+    renderWithRouter("/admin/users");
+
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.queryByText("Admin Users")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/guards/__tests__/AdminGuard.test.tsx
+++ b/frontend/src/components/guards/__tests__/AdminGuard.test.tsx
@@ -14,9 +14,14 @@ function renderWithRouter(initialPath: string) {
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/" element={<div>Home</div>} />
-        <Route element={<AdminGuard />}>
-          <Route path="/admin/users" element={<div>Admin Users</div>} />
-        </Route>
+        <Route
+          path="/admin/users"
+          element={
+            <AdminGuard>
+              <div>Admin Users</div>
+            </AdminGuard>
+          }
+        />
       </Routes>
     </MemoryRouter>,
   );

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from "react-router";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface NavItem {
   to: string;
@@ -8,6 +9,7 @@ interface NavItem {
 interface NavGroup {
   label: string;
   items: NavItem[];
+  adminOnly?: boolean;
 }
 
 const navGroups: NavGroup[] = [
@@ -35,16 +37,27 @@ const navGroups: NavGroup[] = [
     label: "設定",
     items: [{ to: "/settings/notifications", label: "通知設定" }],
   },
+  {
+    label: "管理",
+    items: [{ to: "/admin/users", label: "ユーザー管理" }],
+    adminOnly: true,
+  },
 ];
 
 export function Sidebar() {
+  const { role } = useCurrentUser();
+
+  const visibleGroups = navGroups.filter(
+    (group) => !group.adminOnly || role === "admin",
+  );
+
   return (
     <aside className="flex h-full w-[220px] flex-col border-r border-border-subtle bg-background overflow-y-auto px-4 pt-6">
       <div className="mb-5 border-b border-border-subtle pb-2.5">
         <span className="text-[13px] font-medium text-foreground">perigee</span>
       </div>
       <nav>
-        {navGroups.map((group) => (
+        {visibleGroups.map((group) => (
           <div key={group.label} className="mb-5">
             <div className="mb-1.5 text-[11px] tracking-[0.05em] text-text-muted">
               {group.label}

--- a/frontend/src/features/admin/__tests__/AdminUsersPage.test.tsx
+++ b/frontend/src/features/admin/__tests__/AdminUsersPage.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AdminUsersPage } from "../pages/AdminUsersPage";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockCreateUser = vi.fn();
+const mockUpdateUser = vi.fn();
+const mockDeactivateUser = vi.fn();
+const mockActivateUser = vi.fn();
+const mockRefetch = vi.fn();
+
+vi.mock("../hooks/useUsers", () => ({
+  useUsers: () => ({
+    users: [
+      {
+        id: "u1",
+        name: "Admin User",
+        email: "admin@example.com",
+        role: "admin",
+        is_active: true,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "u2",
+        name: "Member User",
+        email: "member@example.com",
+        role: "member",
+        is_active: false,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+    total: 2,
+    isLoading: false,
+    error: null,
+    offset: 0,
+    limit: 20,
+    setOffset: vi.fn(),
+    refetch: mockRefetch,
+  }),
+}));
+
+vi.mock("../hooks/useCreateUser", () => ({
+  useCreateUser: () => ({
+    createUser: mockCreateUser,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../hooks/useUpdateUser", () => ({
+  useUpdateUser: () => ({
+    updateUser: mockUpdateUser,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../hooks/useDeactivateUser", () => ({
+  useDeactivateUser: () => ({
+    deactivateUser: mockDeactivateUser,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../hooks/useActivateUser", () => ({
+  useActivateUser: () => ({
+    activateUser: mockActivateUser,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+    role: "admin",
+  }),
+}));
+
+describe("AdminUsersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefetch.mockResolvedValue(undefined);
+  });
+
+  it("renders the page title", () => {
+    render(<AdminUsersPage />);
+    expect(
+      screen.getByRole("heading", { name: "ユーザー管理" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the user table with users", () => {
+    render(<AdminUsersPage />);
+    expect(screen.getByText("Admin User")).toBeInTheDocument();
+    expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Member User")).toBeInTheDocument();
+    expect(screen.getByText("member@example.com")).toBeInTheDocument();
+  });
+
+  it("renders status badges correctly", () => {
+    render(<AdminUsersPage />);
+    expect(screen.getByText("有効")).toBeInTheDocument();
+    expect(screen.getByText("無効")).toBeInTheDocument();
+  });
+
+  it("renders role badges correctly", () => {
+    render(<AdminUsersPage />);
+    const badges = screen.getAllByText("admin");
+    const adminBadge = badges.find(
+      (el) => el.getAttribute("data-slot") === "badge",
+    );
+    expect(adminBadge).toBeInTheDocument();
+
+    const memberBadges = screen.getAllByText("member");
+    const memberBadge = memberBadges.find(
+      (el) => el.getAttribute("data-slot") === "badge",
+    );
+    expect(memberBadge).toBeInTheDocument();
+  });
+
+  it("renders the create user form", () => {
+    render(<AdminUsersPage />);
+    expect(screen.getByLabelText("名前")).toBeInTheDocument();
+    expect(screen.getByLabelText("メール")).toBeInTheDocument();
+    expect(screen.getByLabelText("ロール")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "ユーザーを追加" }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits the create user form", async () => {
+    const user = userEvent.setup();
+    mockCreateUser.mockResolvedValueOnce({ id: "u3" });
+    render(<AdminUsersPage />);
+
+    await user.type(screen.getByLabelText("名前"), "New User");
+    await user.type(screen.getByLabelText("メール"), "new@example.com");
+    await user.click(screen.getByRole("button", { name: "ユーザーを追加" }));
+
+    expect(mockCreateUser).toHaveBeenCalledWith({
+      name: "New User",
+      email: "new@example.com",
+      role: "member",
+    });
+  });
+
+  it("opens edit modal when clicking edit button", async () => {
+    const user = userEvent.setup();
+    render(<AdminUsersPage />);
+
+    const editButtons = screen.getAllByRole("button", { name: "編集" });
+    await user.click(editButtons[0]);
+
+    expect(
+      screen.getByRole("dialog", { name: "ユーザー編集" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls deactivateUser when clicking deactivate button for active user", async () => {
+    const user = userEvent.setup();
+    mockDeactivateUser.mockResolvedValueOnce({ id: "u1", is_active: false });
+    render(<AdminUsersPage />);
+
+    const deactivateButton = screen.getByRole("button", { name: "無効化" });
+    await user.click(deactivateButton);
+
+    expect(mockDeactivateUser).toHaveBeenCalledWith("u1");
+  });
+
+  it("calls activateUser when clicking activate button for inactive user", async () => {
+    const user = userEvent.setup();
+    mockActivateUser.mockResolvedValueOnce({ id: "u2", is_active: true });
+    render(<AdminUsersPage />);
+
+    const activateButton = screen.getByRole("button", { name: "有効化" });
+    await user.click(activateButton);
+
+    expect(mockActivateUser).toHaveBeenCalledWith("u2");
+  });
+
+  it("closes edit modal when clicking cancel", async () => {
+    const user = userEvent.setup();
+    render(<AdminUsersPage />);
+
+    const editButtons = screen.getAllByRole("button", { name: "編集" });
+    await user.click(editButtons[0]);
+
+    expect(
+      screen.getByRole("dialog", { name: "ユーザー編集" }),
+    ).toBeInTheDocument();
+
+    const modal = screen.getByRole("dialog", { name: "ユーザー編集" });
+    const cancelButton = within(modal).getByRole("button", {
+      name: "キャンセル",
+    });
+    await user.click(cancelButton);
+
+    expect(
+      screen.queryByRole("dialog", { name: "ユーザー編集" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/admin/__tests__/hooks.test.ts
+++ b/frontend/src/features/admin/__tests__/hooks.test.ts
@@ -1,0 +1,288 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ApiError } from "@/api/client";
+
+// -- Mock setup ---------------------------------------------------------------
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPut = vi.fn();
+
+vi.mock("@/api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    apiClient: {
+      get: (...args: unknown[]) => mockGet(...args),
+      post: (...args: unknown[]) => mockPost(...args),
+      put: (...args: unknown[]) => mockPut(...args),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    userId: "00000000-0000-0000-0000-000000000001",
+    name: "Dev User",
+    role: "admin",
+  }),
+}));
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// -- useUsers -----------------------------------------------------------------
+
+describe("useUsers", () => {
+  it("fetches users on mount and returns data", async () => {
+    const mockResponse = {
+      users: [
+        {
+          id: "u1",
+          name: "User 1",
+          email: "u1@example.com",
+          role: "admin",
+          is_active: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      total: 1,
+    };
+    mockGet.mockResolvedValueOnce(mockResponse);
+
+    const { useUsers } = await import("../hooks/useUsers");
+    const { result } = renderHook(() => useUsers());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/users?offset=0&limit=20",
+      TEST_USER_ID,
+    );
+    expect(result.current.users).toEqual(mockResponse.users);
+    expect(result.current.total).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when API call fails", async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(403, "Forbidden", {}));
+
+    const { useUsers } = await import("../hooks/useUsers");
+    const { result } = renderHook(() => useUsers());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.users).toEqual([]);
+    expect(result.current.error).toBeInstanceOf(ApiError);
+    expect(result.current.error?.status).toBe(403);
+  });
+});
+
+// -- useCreateUser ------------------------------------------------------------
+
+describe("useCreateUser", () => {
+  it("calls API and returns user on success", async () => {
+    const mockUser = {
+      id: "u2",
+      name: "New User",
+      email: "new@example.com",
+      role: "member",
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    mockPost.mockResolvedValueOnce(mockUser);
+
+    const { useCreateUser } = await import("../hooks/useCreateUser");
+    const { result } = renderHook(() => useCreateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.createUser({
+        name: "New User",
+        email: "new@example.com",
+        role: "member",
+      });
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("/users", TEST_USER_ID, {
+      name: "New User",
+      email: "new@example.com",
+      role: "member",
+    });
+    expect(response).toEqual(mockUser);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on failure", async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useCreateUser } = await import("../hooks/useCreateUser");
+    const { result } = renderHook(() => useCreateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.createUser({
+        name: "Fail",
+        email: "fail@example.com",
+        role: "member",
+      });
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error).toBeInstanceOf(ApiError);
+    expect(result.current.error?.status).toBe(400);
+  });
+});
+
+// -- useUpdateUser ------------------------------------------------------------
+
+describe("useUpdateUser", () => {
+  it("calls API and returns user on success", async () => {
+    const mockUser = {
+      id: "u1",
+      name: "Updated",
+      email: "u1@example.com",
+      role: "admin",
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    };
+    mockPut.mockResolvedValueOnce(mockUser);
+
+    const { useUpdateUser } = await import("../hooks/useUpdateUser");
+    const { result } = renderHook(() => useUpdateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.updateUser("u1", {
+        name: "Updated",
+        email: "u1@example.com",
+        role: "admin",
+      });
+    });
+
+    expect(mockPut).toHaveBeenCalledWith("/users/u1", TEST_USER_ID, {
+      name: "Updated",
+      email: "u1@example.com",
+      role: "admin",
+    });
+    expect(response).toEqual(mockUser);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error and returns null on failure", async () => {
+    mockPut.mockRejectedValueOnce(new ApiError(409, "Conflict", {}));
+
+    const { useUpdateUser } = await import("../hooks/useUpdateUser");
+    const { result } = renderHook(() => useUpdateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.updateUser("u1", {
+        name: "Fail",
+        email: "fail@example.com",
+        role: "admin",
+      });
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error?.status).toBe(409);
+  });
+});
+
+// -- useDeactivateUser --------------------------------------------------------
+
+describe("useDeactivateUser", () => {
+  it("calls API and returns user on success", async () => {
+    const mockUser = {
+      id: "u1",
+      name: "User",
+      email: "u1@example.com",
+      role: "member",
+      is_active: false,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    };
+    mockPut.mockResolvedValueOnce(mockUser);
+
+    const { useDeactivateUser } = await import("../hooks/useDeactivateUser");
+    const { result } = renderHook(() => useDeactivateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.deactivateUser("u1");
+    });
+
+    expect(mockPut).toHaveBeenCalledWith("/users/u1/deactivate", TEST_USER_ID);
+    expect(response).toEqual(mockUser);
+  });
+
+  it("sets error and returns null on failure", async () => {
+    mockPut.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useDeactivateUser } = await import("../hooks/useDeactivateUser");
+    const { result } = renderHook(() => useDeactivateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.deactivateUser("u1");
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error?.status).toBe(400);
+  });
+});
+
+// -- useActivateUser ----------------------------------------------------------
+
+describe("useActivateUser", () => {
+  it("calls API and returns user on success", async () => {
+    const mockUser = {
+      id: "u1",
+      name: "User",
+      email: "u1@example.com",
+      role: "member",
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    };
+    mockPut.mockResolvedValueOnce(mockUser);
+
+    const { useActivateUser } = await import("../hooks/useActivateUser");
+    const { result } = renderHook(() => useActivateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.activateUser("u1");
+    });
+
+    expect(mockPut).toHaveBeenCalledWith("/users/u1/activate", TEST_USER_ID);
+    expect(response).toEqual(mockUser);
+  });
+
+  it("sets error and returns null on failure", async () => {
+    mockPut.mockRejectedValueOnce(new ApiError(400, "Bad Request", {}));
+
+    const { useActivateUser } = await import("../hooks/useActivateUser");
+    const { result } = renderHook(() => useActivateUser());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.activateUser("u1");
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.error?.status).toBe(400);
+  });
+});

--- a/frontend/src/features/admin/components/CreateUserForm.tsx
+++ b/frontend/src/features/admin/components/CreateUserForm.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { ApiError } from "@/api/client";
+import type { CreateUserPayload } from "../types";
+
+interface CreateUserFormProps {
+  onSubmit: (payload: CreateUserPayload) => Promise<unknown>;
+  isLoading: boolean;
+  error: ApiError | null;
+}
+
+export function CreateUserForm({
+  onSubmit,
+  isLoading,
+  error,
+}: CreateUserFormProps) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<"admin" | "member">("member");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const result = await onSubmit({ name, email, role });
+    if (result) {
+      setName("");
+      setEmail("");
+      setRole("member");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="flex flex-col gap-3">
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <label
+              htmlFor="new-user-name"
+              className="mb-1.5 block text-sm text-text-subtle"
+            >
+              名前
+            </label>
+            <Input
+              id="new-user-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="山田 太郎"
+              required
+            />
+          </div>
+          <div className="flex-1">
+            <label
+              htmlFor="new-user-email"
+              className="mb-1.5 block text-sm text-text-subtle"
+            >
+              メール
+            </label>
+            <Input
+              id="new-user-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="taro@example.com"
+              required
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="new-user-role"
+              className="mb-1.5 block text-sm text-text-subtle"
+            >
+              ロール
+            </label>
+            <select
+              id="new-user-role"
+              value={role}
+              onChange={(e) => setRole(e.target.value as "admin" | "member")}
+              className="h-9 rounded-lg border border-border-subtle bg-surface-secondary px-3 text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+            >
+              <option value="member">member</option>
+              <option value="admin">admin</option>
+            </select>
+          </div>
+        </div>
+        {error && (
+          <p className="text-sm text-danger-text">
+            ユーザーの追加に失敗しました ({error.status})
+          </p>
+        )}
+        <div>
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? "追加中..." : "ユーザーを追加"}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/admin/components/EditUserModal.tsx
+++ b/frontend/src/features/admin/components/EditUserModal.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { ApiError } from "@/api/client";
+import type { UpdateUserPayload, User } from "../types";
+
+interface EditUserModalProps {
+  user: User;
+  onSubmit: (userId: string, payload: UpdateUserPayload) => Promise<unknown>;
+  onClose: () => void;
+  isLoading: boolean;
+  error: ApiError | null;
+}
+
+export function EditUserModal({
+  user,
+  onSubmit,
+  onClose,
+  isLoading,
+  error,
+}: EditUserModalProps) {
+  const [name, setName] = useState(user.name);
+  const [email, setEmail] = useState(user.email);
+  const [role, setRole] = useState<"admin" | "member">(user.role);
+
+  useEffect(() => {
+    setName(user.name);
+    setEmail(user.email);
+    setRole(user.role);
+  }, [user]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const result = await onSubmit(user.id, { name, email, role });
+    if (result) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/40"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="ユーザー編集"
+    >
+      <div
+        className="mx-4 w-full max-w-md rounded-xl border border-border-subtle bg-card p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-1 text-base font-medium text-foreground">
+          ユーザー編集
+        </h2>
+        <p className="mb-5 text-sm text-text-subtle">
+          ユーザー情報を編集します
+        </p>
+        <form onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-3">
+            <div>
+              <label
+                htmlFor="edit-user-name"
+                className="mb-1.5 block text-sm text-text-subtle"
+              >
+                名前
+              </label>
+              <Input
+                id="edit-user-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="edit-user-email"
+                className="mb-1.5 block text-sm text-text-subtle"
+              >
+                メール
+              </label>
+              <Input
+                id="edit-user-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="edit-user-role"
+                className="mb-1.5 block text-sm text-text-subtle"
+              >
+                ロール
+              </label>
+              <select
+                id="edit-user-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value as "admin" | "member")}
+                className="h-9 w-full rounded-lg border border-border-subtle bg-surface-secondary px-3 text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+              >
+                <option value="member">member</option>
+                <option value="admin">admin</option>
+              </select>
+            </div>
+            {error && (
+              <p className="text-sm text-danger-text">
+                ユーザーの更新に失敗しました ({error.status})
+              </p>
+            )}
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={onClose}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? "保存中..." : "保存"}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/components/UserTable.tsx
+++ b/frontend/src/features/admin/components/UserTable.tsx
@@ -1,0 +1,81 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { User } from "../types";
+
+interface UserTableProps {
+  users: User[];
+  onEdit: (user: User) => void;
+  onToggleActive: (user: User) => void;
+  isToggling: boolean;
+}
+
+export function UserTable({
+  users,
+  onEdit,
+  onToggleActive,
+  isToggling,
+}: UserTableProps) {
+  if (users.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-text-muted">
+        ユーザーが見つかりません
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border-subtle text-left">
+            <th className="pb-2 font-medium text-text-subtle">名前</th>
+            <th className="pb-2 font-medium text-text-subtle">メール</th>
+            <th className="pb-2 font-medium text-text-subtle">ロール</th>
+            <th className="pb-2 font-medium text-text-subtle">ステータス</th>
+            <th className="pb-2 font-medium text-text-subtle">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user) => (
+            <tr
+              key={user.id}
+              className="border-b border-border-subtle last:border-b-0"
+            >
+              <td className="py-3 text-foreground">{user.name}</td>
+              <td className="py-3 text-text-subtle">{user.email}</td>
+              <td className="py-3">
+                <Badge variant={user.role === "admin" ? "info" : "gray"}>
+                  {user.role}
+                </Badge>
+              </td>
+              <td className="py-3">
+                <Badge variant={user.is_active ? "published" : "destructive"}>
+                  {user.is_active ? "有効" : "無効"}
+                </Badge>
+              </td>
+              <td className="py-3">
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onEdit(user)}
+                  >
+                    編集
+                  </Button>
+                  <Button
+                    variant={user.is_active ? "danger" : "success"}
+                    size="sm"
+                    onClick={() => onToggleActive(user)}
+                    disabled={isToggling}
+                  >
+                    {user.is_active ? "無効化" : "有効化"}
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/hooks/useActivateUser.ts
+++ b/frontend/src/features/admin/hooks/useActivateUser.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { User } from "../types";
+
+interface UseActivateUserReturn {
+  activateUser: (targetUserId: string) => Promise<User | null>;
+  isLoading: boolean;
+  error: ApiError | null;
+}
+
+export function useActivateUser(): UseActivateUserReturn {
+  const { userId } = useCurrentUser();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<ApiError | null>(null);
+
+  const activateUser = useCallback(
+    async (targetUserId: string): Promise<User | null> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await apiClient.put<User>(
+          `/users/${targetUserId}/activate`,
+          userId,
+        );
+        return result;
+      } catch (e) {
+        const apiError =
+          e instanceof ApiError
+            ? e
+            : new ApiError(0, "Unknown error", String(e));
+        setError(apiError);
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [userId],
+  );
+
+  return { activateUser, isLoading, error };
+}

--- a/frontend/src/features/admin/hooks/useCreateUser.ts
+++ b/frontend/src/features/admin/hooks/useCreateUser.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { CreateUserPayload, User } from "../types";
+
+interface UseCreateUserReturn {
+  createUser: (payload: CreateUserPayload) => Promise<User | null>;
+  isLoading: boolean;
+  error: ApiError | null;
+}
+
+export function useCreateUser(): UseCreateUserReturn {
+  const { userId } = useCurrentUser();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<ApiError | null>(null);
+
+  const createUser = useCallback(
+    async (payload: CreateUserPayload): Promise<User | null> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await apiClient.post<User>("/users", userId, payload);
+        return result;
+      } catch (e) {
+        const apiError =
+          e instanceof ApiError
+            ? e
+            : new ApiError(0, "Unknown error", String(e));
+        setError(apiError);
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [userId],
+  );
+
+  return { createUser, isLoading, error };
+}

--- a/frontend/src/features/admin/hooks/useDeactivateUser.ts
+++ b/frontend/src/features/admin/hooks/useDeactivateUser.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { User } from "../types";
+
+interface UseDeactivateUserReturn {
+  deactivateUser: (targetUserId: string) => Promise<User | null>;
+  isLoading: boolean;
+  error: ApiError | null;
+}
+
+export function useDeactivateUser(): UseDeactivateUserReturn {
+  const { userId } = useCurrentUser();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<ApiError | null>(null);
+
+  const deactivateUser = useCallback(
+    async (targetUserId: string): Promise<User | null> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await apiClient.put<User>(
+          `/users/${targetUserId}/deactivate`,
+          userId,
+        );
+        return result;
+      } catch (e) {
+        const apiError =
+          e instanceof ApiError
+            ? e
+            : new ApiError(0, "Unknown error", String(e));
+        setError(apiError);
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [userId],
+  );
+
+  return { deactivateUser, isLoading, error };
+}

--- a/frontend/src/features/admin/hooks/useUpdateUser.ts
+++ b/frontend/src/features/admin/hooks/useUpdateUser.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { UpdateUserPayload, User } from "../types";
+
+interface UseUpdateUserReturn {
+  updateUser: (
+    targetUserId: string,
+    payload: UpdateUserPayload,
+  ) => Promise<User | null>;
+  isLoading: boolean;
+  error: ApiError | null;
+}
+
+export function useUpdateUser(): UseUpdateUserReturn {
+  const { userId } = useCurrentUser();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<ApiError | null>(null);
+
+  const updateUser = useCallback(
+    async (
+      targetUserId: string,
+      payload: UpdateUserPayload,
+    ): Promise<User | null> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await apiClient.put<User>(
+          `/users/${targetUserId}`,
+          userId,
+          payload,
+        );
+        return result;
+      } catch (e) {
+        const apiError =
+          e instanceof ApiError
+            ? e
+            : new ApiError(0, "Unknown error", String(e));
+        setError(apiError);
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [userId],
+  );
+
+  return { updateUser, isLoading, error };
+}

--- a/frontend/src/features/admin/hooks/useUsers.ts
+++ b/frontend/src/features/admin/hooks/useUsers.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { User, UsersResponse } from "../types";
+
+interface UseUsersReturn {
+  users: User[];
+  total: number;
+  isLoading: boolean;
+  error: ApiError | null;
+  offset: number;
+  limit: number;
+  setOffset: (offset: number) => void;
+  refetch: () => Promise<void>;
+}
+
+export function useUsers(initialLimit = 20): UseUsersReturn {
+  const { userId } = useCurrentUser();
+  const [users, setUsers] = useState<User[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [offset, setOffset] = useState(0);
+  const limit = initialLimit;
+
+  const fetchUsers = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await apiClient.get<UsersResponse>(
+        `/users?offset=${offset}&limit=${limit}`,
+        userId,
+      );
+      setUsers(result.users);
+      setTotal(result.total);
+    } catch (e) {
+      const apiError =
+        e instanceof ApiError ? e : new ApiError(0, "Unknown error", String(e));
+      setError(apiError);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, offset, limit]);
+
+  useEffect(() => {
+    void fetchUsers();
+  }, [fetchUsers]);
+
+  return {
+    users,
+    total,
+    isLoading,
+    error,
+    offset,
+    limit,
+    setOffset,
+    refetch: fetchUsers,
+  };
+}

--- a/frontend/src/features/admin/pages/AdminUsersPage.tsx
+++ b/frontend/src/features/admin/pages/AdminUsersPage.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { UserTable } from "../components/UserTable";
+import { CreateUserForm } from "../components/CreateUserForm";
+import { EditUserModal } from "../components/EditUserModal";
+import { useUsers } from "../hooks/useUsers";
+import { useCreateUser } from "../hooks/useCreateUser";
+import { useUpdateUser } from "../hooks/useUpdateUser";
+import { useDeactivateUser } from "../hooks/useDeactivateUser";
+import { useActivateUser } from "../hooks/useActivateUser";
+import type { User } from "../types";
+
+export function AdminUsersPage() {
+  const { users, total, isLoading, error, offset, limit, setOffset, refetch } =
+    useUsers();
+  const {
+    createUser,
+    isLoading: isCreating,
+    error: createError,
+  } = useCreateUser();
+  const {
+    updateUser,
+    isLoading: isUpdating,
+    error: updateError,
+  } = useUpdateUser();
+  const { deactivateUser, isLoading: isDeactivating } = useDeactivateUser();
+  const { activateUser, isLoading: isActivating } = useActivateUser();
+
+  const [editingUser, setEditingUser] = useState<User | null>(null);
+
+  const handleCreate = async (payload: Parameters<typeof createUser>[0]) => {
+    const result = await createUser(payload);
+    if (result) {
+      await refetch();
+    }
+    return result;
+  };
+
+  const handleUpdate = async (
+    userId: string,
+    payload: Parameters<typeof updateUser>[1],
+  ) => {
+    const result = await updateUser(userId, payload);
+    if (result) {
+      await refetch();
+    }
+    return result;
+  };
+
+  const handleToggleActive = async (user: User) => {
+    if (user.is_active) {
+      await deactivateUser(user.id);
+    } else {
+      await activateUser(user.id);
+    }
+    await refetch();
+  };
+
+  const totalPages = Math.ceil(total / limit);
+  const currentPage = Math.floor(offset / limit) + 1;
+
+  return (
+    <div>
+      <h1 className="mb-1 text-xl font-medium text-foreground">ユーザー管理</h1>
+      <p className="mb-5 text-sm text-text-subtle">
+        ユーザーの追加・編集・無効化を管理します
+      </p>
+
+      <Card className="mb-4">
+        <CardHeader>
+          <CardTitle>ユーザー追加</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CreateUserForm
+            onSubmit={handleCreate}
+            isLoading={isCreating}
+            error={createError}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>ユーザー一覧</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="py-8 text-center text-sm text-text-muted">
+              読み込み中...
+            </p>
+          ) : error ? (
+            <p className="py-8 text-center text-sm text-danger-text">
+              ユーザー一覧の取得に失敗しました ({error.status})
+            </p>
+          ) : (
+            <>
+              <UserTable
+                users={users}
+                onEdit={setEditingUser}
+                onToggleActive={handleToggleActive}
+                isToggling={isDeactivating || isActivating}
+              />
+              {totalPages > 1 && (
+                <div className="mt-4 flex items-center justify-between">
+                  <span className="text-sm text-text-subtle">
+                    {total} 件中 {offset + 1} -{" "}
+                    {Math.min(offset + limit, total)} 件を表示
+                  </span>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={currentPage <= 1}
+                      onClick={() => setOffset(offset - limit)}
+                    >
+                      前へ
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={currentPage >= totalPages}
+                      onClick={() => setOffset(offset + limit)}
+                    >
+                      次へ
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {editingUser && (
+        <EditUserModal
+          user={editingUser}
+          onSubmit={handleUpdate}
+          onClose={() => setEditingUser(null)}
+          isLoading={isUpdating}
+          error={updateError}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin/types.ts
+++ b/frontend/src/features/admin/types.ts
@@ -1,0 +1,26 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: "admin" | "member";
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UsersResponse {
+  users: User[];
+  total: number;
+}
+
+export interface CreateUserPayload {
+  name: string;
+  email: string;
+  role: "admin" | "member";
+}
+
+export interface UpdateUserPayload {
+  name: string;
+  email: string;
+  role: "admin" | "member";
+}

--- a/frontend/src/hooks/useCurrentUser.ts
+++ b/frontend/src/hooks/useCurrentUser.ts
@@ -1,14 +1,17 @@
 const DEV_USER_ID = "00000000-0000-0000-0000-000000000001";
 const DEV_USER_NAME = "Dev User";
+const DEV_USER_ROLE = "admin";
 
 interface CurrentUser {
   userId: string;
   name: string;
+  role: "admin" | "member";
 }
 
 export function useCurrentUser(): CurrentUser {
   return {
     userId: DEV_USER_ID,
     name: DEV_USER_NAME,
+    role: DEV_USER_ROLE,
   };
 }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router";
 import { AppLayout } from "@/components/layout/AppLayout";
+import { AdminGuard } from "@/components/guards/AdminGuard";
 import { DashboardPage } from "@/features/dashboard/pages/DashboardPage";
 import { SchedulingPage } from "@/features/scheduling/pages/SchedulingPage";
 import { PreparationPage } from "@/features/preparation/pages/PreparationPage";
@@ -13,6 +14,7 @@ import { DraftListPage } from "@/features/publishing/pages/DraftListPage";
 import { NotificationSettingPage } from "@/features/notification-settings/pages/NotificationSettingPage";
 import { SetupPage } from "@/features/setup/pages/SetupPage";
 import { SetupGuard } from "@/features/setup/components/SetupGuard";
+import { AdminUsersPage } from "@/features/admin/pages/AdminUsersPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 
 export const router = createBrowserRouter([
@@ -39,6 +41,14 @@ export const router = createBrowserRouter([
           {
             path: "settings/notifications",
             element: <NotificationSettingPage />,
+          },
+          {
+            path: "admin/users",
+            element: (
+              <AdminGuard>
+                <AdminUsersPage />
+              </AdminGuard>
+            ),
           },
           { path: "*", element: <NotFoundPage /> },
         ],


### PR DESCRIPTION
## Summary
Issue #183 の PR-3。ユーザー管理画面のフロントエンド実装。

- ユーザー一覧テーブル（名前、メール、ロール、ステータス）
- ユーザー追加フォーム
- ユーザー編集モーダル
- 無効化/有効化トグル
- Sidebar に admin のみ表示の「ユーザー管理」メニュー追加
- ルーティング: /admin/users
- hooks 個別テスト + ページレベルテスト（305テスト全通過）

Related: #183