### PR TITLE
feat: フロントエンド認証フロー（ログイン・トークンリフレッシュ・招待リンク）

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,3 +1,4 @@
 dist
 node_modules
+.pnpm-store
 pnpm-lock.yaml

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,53 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { DashboardPage } from "@/features/dashboard/pages/DashboardPage";
+
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "dev@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/dashboard/hooks/useUpcomingSchedules", () => ({
+  useUpcomingSchedules: () => ({
+    schedules: [],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/features/dashboard/hooks/useDraftRecords", () => ({
+  useDraftRecords: () => ({ drafts: [], isLoading: false, error: null }),
+}));
+
+vi.mock("@/features/dashboard/hooks/usePendingActionItems", () => ({
+  usePendingActionItems: () => ({
+    items: [],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/features/dashboard/hooks/useUnreadNotifications", () => ({
+  useUnreadNotifications: () => ({
+    notifications: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
 
 function renderWithProviders(initialEntries: string[] = ["/"]) {
   const queryClient = new QueryClient({

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { apiClient, ApiError } from "../client";
+import * as authStore from "../auth-store";
+import * as auth from "../auth";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+// Prevent actual navigation in tests
+const originalLocation = window.location;
+
+beforeEach(() => {
+  authStore.clearAccessToken();
+  fetchMock.mockReset();
+  vi.restoreAllMocks();
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: { ...originalLocation, href: "" },
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: originalLocation,
+  });
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("apiClient", () => {
+  it("sends Authorization header when token is set", async () => {
+    authStore.setAccessToken("test-token");
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { data: 1 }));
+
+    await apiClient.get("/test");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      "Bearer test-token",
+    );
+  });
+
+  it("sends credentials: include", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { data: 1 }));
+
+    await apiClient.get("/test");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.credentials).toBe("include");
+  });
+
+  it("throws ApiError on non-401 error", async () => {
+    authStore.setAccessToken("test-token");
+    fetchMock.mockResolvedValueOnce(jsonResponse(403, { detail: "Forbidden" }));
+
+    await expect(apiClient.get("/test")).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("401 → refresh → retry flow", () => {
+  it("retries request after successful refresh", async () => {
+    authStore.setAccessToken("old-token");
+
+    // First call → 401
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: "expired" }));
+    // refreshApi call (mocked below)
+    vi.spyOn(auth, "refreshApi").mockResolvedValueOnce({
+      access_token: "new-token",
+      token_type: "bearer",
+    });
+    // Retry call → 200
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+    const result = await apiClient.get<{ ok: boolean }>("/test");
+
+    expect(result).toEqual({ ok: true });
+    expect(authStore.getAccessToken()).toBe("new-token");
+  });
+
+  it("redirects to /login when refresh fails", async () => {
+    authStore.setAccessToken("old-token");
+
+    // First call → 401
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: "expired" }));
+    // refreshApi fails
+    vi.spyOn(auth, "refreshApi").mockRejectedValueOnce(
+      new auth.RefreshError(401),
+    );
+
+    await expect(apiClient.get("/test")).rejects.toBeInstanceOf(ApiError);
+    expect(authStore.getAccessToken()).toBeNull();
+    expect(window.location.href).toBe("/login");
+  });
+
+  it("deduplicates concurrent refresh attempts", async () => {
+    authStore.setAccessToken("old-token");
+
+    // Use a deferred promise to control refresh timing so both 401s
+    // hit tryRefresh before it resolves.
+    let resolveRefresh!: (v: auth.RefreshResponse) => void;
+    const refreshPromise = new Promise<auth.RefreshResponse>((r) => {
+      resolveRefresh = r;
+    });
+    const refreshSpy = vi
+      .spyOn(auth, "refreshApi")
+      .mockReturnValue(refreshPromise);
+
+    // Both calls return 401
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: "expired" }));
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: "expired" }));
+    // Both retry calls return 200
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { a: 1 }));
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { b: 2 }));
+
+    const p1 = apiClient.get("/a");
+    const p2 = apiClient.get("/b");
+
+    // Let microtasks run so both requests hit the 401 path
+    await vi.waitFor(() => expect(refreshSpy).toHaveBeenCalled());
+
+    // Now resolve the single shared refresh
+    resolveRefresh({ access_token: "new-token", token_type: "bearer" });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toEqual({ a: 1 });
+    expect(r2).toEqual({ b: 2 });
+    // refreshApi should only be called once despite two 401s
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/api/auth-store.ts
+++ b/frontend/src/api/auth-store.ts
@@ -1,0 +1,19 @@
+/**
+ * In-memory store for the access token.
+ * The token is never persisted to localStorage or cookies.
+ * Refresh tokens are handled via HttpOnly cookies by the server.
+ */
+
+let accessToken: string | null = null;
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export function setAccessToken(token: string | null): void {
+  accessToken = token;
+}
+
+export function clearAccessToken(): void {
+  accessToken = null;
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,125 @@
+/**
+ * Authentication API functions.
+ * These bypass the main apiClient because they have different auth requirements.
+ */
+
+const DEFAULT_BASE_URL = "http://localhost:8000";
+
+function getBaseUrl(): string {
+  return import.meta.env.VITE_API_BASE_URL ?? DEFAULT_BASE_URL;
+}
+
+export interface LoginResponse {
+  access_token: string;
+  token_type: string;
+}
+
+export interface RefreshResponse {
+  access_token: string;
+  token_type: string;
+}
+
+export interface SetPasswordResponse {
+  message: string;
+}
+
+export async function loginApi(
+  email: string,
+  password: string,
+): Promise<LoginResponse> {
+  const response = await fetch(`${getBaseUrl()}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    let detail = "ログインに失敗しました";
+    try {
+      const body = (await response.json()) as { detail?: string };
+      if (body.detail) {
+        detail = body.detail;
+      }
+    } catch {
+      // ignore parse error
+    }
+    throw new LoginError(response.status, detail);
+  }
+
+  return (await response.json()) as LoginResponse;
+}
+
+export async function refreshApi(): Promise<RefreshResponse> {
+  const response = await fetch(`${getBaseUrl()}/auth/refresh`, {
+    method: "POST",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new RefreshError(response.status);
+  }
+
+  return (await response.json()) as RefreshResponse;
+}
+
+export async function logoutApi(): Promise<void> {
+  await fetch(`${getBaseUrl()}/auth/logout`, {
+    method: "POST",
+    credentials: "include",
+  });
+}
+
+export async function setPasswordApi(
+  token: string,
+  password: string,
+): Promise<SetPasswordResponse> {
+  const response = await fetch(`${getBaseUrl()}/auth/set-password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ token, password }),
+  });
+
+  if (!response.ok) {
+    let detail = "パスワードの設定に失敗しました";
+    try {
+      const body = (await response.json()) as { detail?: string };
+      if (body.detail) {
+        detail = body.detail;
+      }
+    } catch {
+      // ignore parse error
+    }
+    throw new SetPasswordError(response.status, detail);
+  }
+
+  return (await response.json()) as SetPasswordResponse;
+}
+
+export class LoginError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly detail: string,
+  ) {
+    super(detail);
+    this.name = "LoginError";
+  }
+}
+
+export class RefreshError extends Error {
+  constructor(public readonly status: number) {
+    super(`Refresh failed with status ${status}`);
+    this.name = "RefreshError";
+  }
+}
+
+export class SetPasswordError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly detail: string,
+  ) {
+    super(detail);
+    this.name = "SetPasswordError";
+  }
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,3 +1,6 @@
+import { getAccessToken, setAccessToken, clearAccessToken } from "./auth-store";
+import { refreshApi, RefreshError } from "./auth";
+
 const DEFAULT_BASE_URL = "http://localhost:8000";
 
 function getBaseUrl(): string {
@@ -33,45 +36,92 @@ async function handleResponse<T>(response: Response): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-function buildHeaders(userId: string): HeadersInit {
-  return {
+function buildHeaders(): HeadersInit {
+  const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "X-User-Id": userId,
   };
+  const token = getAccessToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/**
+ * Singleton guard to prevent concurrent refresh attempts.
+ * When a 401 triggers a refresh, all parallel requests wait on the same promise.
+ */
+let refreshPromise: Promise<boolean> | null = null;
+
+async function tryRefresh(): Promise<boolean> {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+  refreshPromise = (async () => {
+    try {
+      const result = await refreshApi();
+      setAccessToken(result.access_token);
+      return true;
+    } catch (e) {
+      if (e instanceof RefreshError) {
+        clearAccessToken();
+        return false;
+      }
+      clearAccessToken();
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+  return refreshPromise;
+}
+
+async function fetchWithAuth<T>(path: string, init: RequestInit): Promise<T> {
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...init,
+    headers: buildHeaders(),
+    credentials: "include",
+  });
+
+  if (response.status === 401) {
+    const refreshed = await tryRefresh();
+    if (refreshed) {
+      // Retry with new token
+      const retryResponse = await fetch(`${getBaseUrl()}${path}`, {
+        ...init,
+        headers: buildHeaders(),
+        credentials: "include",
+      });
+      return handleResponse<T>(retryResponse);
+    }
+    // Refresh failed - redirect to login
+    window.location.href = "/login";
+    throw new ApiError(401, "Unauthorized", null);
+  }
+
+  return handleResponse<T>(response);
 }
 
 export const apiClient = {
-  async get<T>(path: string, userId: string): Promise<T> {
-    const response = await fetch(`${getBaseUrl()}${path}`, {
-      method: "GET",
-      headers: buildHeaders(userId),
-    });
-    return handleResponse<T>(response);
+  async get<T>(path: string): Promise<T> {
+    return fetchWithAuth<T>(path, { method: "GET" });
   },
 
-  async post<T>(path: string, userId: string, body?: unknown): Promise<T> {
-    const response = await fetch(`${getBaseUrl()}${path}`, {
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    return fetchWithAuth<T>(path, {
       method: "POST",
-      headers: buildHeaders(userId),
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
-    return handleResponse<T>(response);
   },
 
-  async put<T>(path: string, userId: string, body?: unknown): Promise<T> {
-    const response = await fetch(`${getBaseUrl()}${path}`, {
+  async put<T>(path: string, body?: unknown): Promise<T> {
+    return fetchWithAuth<T>(path, {
       method: "PUT",
-      headers: buildHeaders(userId),
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
-    return handleResponse<T>(response);
   },
 
-  async delete<T>(path: string, userId: string): Promise<T> {
-    const response = await fetch(`${getBaseUrl()}${path}`, {
-      method: "DELETE",
-      headers: buildHeaders(userId),
-    });
-    return handleResponse<T>(response);
+  async delete<T>(path: string): Promise<T> {
+    return fetchWithAuth<T>(path, { method: "DELETE" });
   },
 };

--- a/frontend/src/components/guards/AdminGuard.tsx
+++ b/frontend/src/components/guards/AdminGuard.tsx
@@ -3,9 +3,13 @@ import { Navigate } from "react-router";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 export function AdminGuard({ children }: { children: ReactNode }) {
-  const { role } = useCurrentUser();
+  const { user, isLoading } = useCurrentUser();
 
-  if (role !== "admin") {
+  if (isLoading) {
+    return null;
+  }
+
+  if (!user || user.role !== "admin") {
     return <Navigate to="/" replace />;
   }
 

--- a/frontend/src/components/guards/__tests__/AdminGuard.test.tsx
+++ b/frontend/src/components/guards/__tests__/AdminGuard.test.tsx
@@ -30,9 +30,16 @@ function renderWithRouter(initialPath: string) {
 describe("AdminGuard", () => {
   it("renders child route when user is admin", () => {
     mockUseCurrentUser.mockReturnValue({
-      userId: "u1",
-      name: "Admin",
-      role: "admin",
+      user: {
+        userId: "u1",
+        name: "Admin",
+        email: "test@example.com",
+        role: "admin",
+        isActive: true,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     renderWithRouter("/admin/users");
@@ -43,9 +50,16 @@ describe("AdminGuard", () => {
 
   it("redirects to / when user is not admin", () => {
     mockUseCurrentUser.mockReturnValue({
-      userId: "u2",
-      name: "Member",
-      role: "member",
+      user: {
+        userId: "u2",
+        name: "Member",
+        email: "test@example.com",
+        role: "member",
+        isActive: true,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     renderWithRouter("/admin/users");

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -9,9 +9,14 @@ export function Header() {
   const navigate = useNavigate();
 
   const handleLogout = async () => {
-    await logoutApi();
-    clearAccessToken();
-    void navigate("/login", { replace: true });
+    try {
+      await logoutApi();
+    } catch {
+      // サーバー側ログアウト失敗でもクライアント側は必ずクリアする
+    } finally {
+      clearAccessToken();
+      void navigate("/login", { replace: true });
+    }
   };
 
   return (

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,12 +1,28 @@
+import { useNavigate } from "react-router";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { logoutApi } from "@/api/auth";
+import { clearAccessToken } from "@/api/auth-store";
+import { Button } from "@/components/ui/button";
 
 export function Header() {
-  const { name } = useCurrentUser();
+  const { user } = useCurrentUser();
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await logoutApi();
+    clearAccessToken();
+    void navigate("/login", { replace: true });
+  };
 
   return (
     <header className="flex h-14 items-center border-b border-border px-6">
-      <div className="ml-auto flex items-center gap-2">
-        <span className="text-sm text-muted-foreground">{name}</span>
+      <div className="ml-auto flex items-center gap-3">
+        <span className="text-sm text-muted-foreground">
+          {user?.name ?? ""}
+        </span>
+        <Button variant="ghost" size="sm" onClick={() => void handleLogout()}>
+          ログアウト
+        </Button>
       </div>
     </header>
   );

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -45,10 +45,10 @@ const navGroups: NavGroup[] = [
 ];
 
 export function Sidebar() {
-  const { role } = useCurrentUser();
+  const { user } = useCurrentUser();
 
   const visibleGroups = navGroups.filter(
-    (group) => !group.adminOnly || role === "admin",
+    (group) => !group.adminOnly || user?.role === "admin",
   );
 
   return (

--- a/frontend/src/features/admin/__tests__/AdminUsersPage.test.tsx
+++ b/frontend/src/features/admin/__tests__/AdminUsersPage.test.tsx
@@ -75,11 +75,28 @@ vi.mock("../hooks/useActivateUser", () => ({
   }),
 }));
 
+const mockInviteUser = vi.fn();
+
+vi.mock("../hooks/useInviteUser", () => ({
+  useInviteUser: () => ({
+    inviteUser: mockInviteUser,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
-    role: "admin",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/admin/__tests__/hooks.test.ts
+++ b/frontend/src/features/admin/__tests__/hooks.test.ts
@@ -24,13 +24,18 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
-    role: "admin",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
-
-const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -63,10 +68,7 @@ describe("useUsers", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith(
-      "/users?offset=0&limit=20",
-      TEST_USER_ID,
-    );
+    expect(mockGet).toHaveBeenCalledWith("/users?offset=0&limit=20");
     expect(result.current.users).toEqual(mockResponse.users);
     expect(result.current.total).toBe(1);
     expect(result.current.error).toBeNull();
@@ -115,7 +117,7 @@ describe("useCreateUser", () => {
       });
     });
 
-    expect(mockPost).toHaveBeenCalledWith("/users", TEST_USER_ID, {
+    expect(mockPost).toHaveBeenCalledWith("/users", {
       name: "New User",
       email: "new@example.com",
       role: "member",
@@ -172,7 +174,7 @@ describe("useUpdateUser", () => {
       });
     });
 
-    expect(mockPut).toHaveBeenCalledWith("/users/u1", TEST_USER_ID, {
+    expect(mockPut).toHaveBeenCalledWith("/users/u1", {
       name: "Updated",
       email: "u1@example.com",
       role: "admin",
@@ -224,7 +226,7 @@ describe("useDeactivateUser", () => {
       response = await result.current.deactivateUser("u1");
     });
 
-    expect(mockPut).toHaveBeenCalledWith("/users/u1/deactivate", TEST_USER_ID);
+    expect(mockPut).toHaveBeenCalledWith("/users/u1/deactivate");
     expect(response).toEqual(mockUser);
   });
 
@@ -267,7 +269,7 @@ describe("useActivateUser", () => {
       response = await result.current.activateUser("u1");
     });
 
-    expect(mockPut).toHaveBeenCalledWith("/users/u1/activate", TEST_USER_ID);
+    expect(mockPut).toHaveBeenCalledWith("/users/u1/activate");
     expect(response).toEqual(mockUser);
   });
 

--- a/frontend/src/features/admin/components/InviteLinkModal.tsx
+++ b/frontend/src/features/admin/components/InviteLinkModal.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+interface InviteLinkModalProps {
+  link: string;
+  onClose: () => void;
+}
+
+export function InviteLinkModal({ link, onClose }: InviteLinkModalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(link);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle>招待リンク</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            以下のリンクをユーザーに共有してください。リンクの有効期限は72時間です。
+          </p>
+          <div className="flex gap-2">
+            <Input value={link} readOnly className="font-mono text-xs" />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleCopy()}
+              className="shrink-0"
+            >
+              {copied ? "コピー済み" : "コピー"}
+            </Button>
+          </div>
+          <div className="flex justify-end">
+            <Button variant="ghost" onClick={onClose}>
+              閉じる
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/components/UserTable.tsx
+++ b/frontend/src/features/admin/components/UserTable.tsx
@@ -6,14 +6,18 @@ interface UserTableProps {
   users: User[];
   onEdit: (user: User) => void;
   onToggleActive: (user: User) => void;
+  onInvite: (user: User) => void;
   isToggling: boolean;
+  isInviting: boolean;
 }
 
 export function UserTable({
   users,
   onEdit,
   onToggleActive,
+  onInvite,
   isToggling,
+  isInviting,
 }: UserTableProps) {
   if (users.length === 0) {
     return (
@@ -61,6 +65,14 @@ export function UserTable({
                     onClick={() => onEdit(user)}
                   >
                     編集
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onInvite(user)}
+                    disabled={isInviting || !user.is_active}
+                  >
+                    招待
                   </Button>
                   <Button
                     variant={user.is_active ? "danger" : "success"}

--- a/frontend/src/features/admin/hooks/useActivateUser.ts
+++ b/frontend/src/features/admin/hooks/useActivateUser.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { User } from "../types";
 
 interface UseActivateUserReturn {
@@ -10,7 +9,6 @@ interface UseActivateUserReturn {
 }
 
 export function useActivateUser(): UseActivateUserReturn {
-  const { userId } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
 
@@ -21,7 +19,6 @@ export function useActivateUser(): UseActivateUserReturn {
       try {
         const result = await apiClient.put<User>(
           `/users/${targetUserId}/activate`,
-          userId,
         );
         return result;
       } catch (e) {
@@ -35,7 +32,7 @@ export function useActivateUser(): UseActivateUserReturn {
         setIsLoading(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { activateUser, isLoading, error };

--- a/frontend/src/features/admin/hooks/useCreateUser.ts
+++ b/frontend/src/features/admin/hooks/useCreateUser.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { CreateUserPayload, User } from "../types";
 
 interface UseCreateUserReturn {
@@ -10,7 +9,6 @@ interface UseCreateUserReturn {
 }
 
 export function useCreateUser(): UseCreateUserReturn {
-  const { userId } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
 
@@ -19,7 +17,7 @@ export function useCreateUser(): UseCreateUserReturn {
       setIsLoading(true);
       setError(null);
       try {
-        const result = await apiClient.post<User>("/users", userId, payload);
+        const result = await apiClient.post<User>("/users", payload);
         return result;
       } catch (e) {
         const apiError =
@@ -32,7 +30,7 @@ export function useCreateUser(): UseCreateUserReturn {
         setIsLoading(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { createUser, isLoading, error };

--- a/frontend/src/features/admin/hooks/useInviteUser.ts
+++ b/frontend/src/features/admin/hooks/useInviteUser.ts
@@ -1,24 +1,28 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import type { User } from "../types";
 
-interface UseDeactivateUserReturn {
-  deactivateUser: (targetUserId: string) => Promise<User | null>;
+interface InvitationResponse {
+  token: string;
+  expires_at: string;
+}
+
+interface UseInviteUserReturn {
+  inviteUser: (userId: string) => Promise<InvitationResponse | null>;
   isLoading: boolean;
   error: ApiError | null;
 }
 
-export function useDeactivateUser(): UseDeactivateUserReturn {
+export function useInviteUser(): UseInviteUserReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
 
-  const deactivateUser = useCallback(
-    async (targetUserId: string): Promise<User | null> => {
+  const inviteUser = useCallback(
+    async (userId: string): Promise<InvitationResponse | null> => {
       setIsLoading(true);
       setError(null);
       try {
-        const result = await apiClient.put<User>(
-          `/users/${targetUserId}/deactivate`,
+        const result = await apiClient.post<InvitationResponse>(
+          `/users/${userId}/invite`,
         );
         return result;
       } catch (e) {
@@ -35,5 +39,5 @@ export function useDeactivateUser(): UseDeactivateUserReturn {
     [],
   );
 
-  return { deactivateUser, isLoading, error };
+  return { inviteUser, isLoading, error };
 }

--- a/frontend/src/features/admin/hooks/useUpdateUser.ts
+++ b/frontend/src/features/admin/hooks/useUpdateUser.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { UpdateUserPayload, User } from "../types";
 
 interface UseUpdateUserReturn {
@@ -13,7 +12,6 @@ interface UseUpdateUserReturn {
 }
 
 export function useUpdateUser(): UseUpdateUserReturn {
-  const { userId } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
 
@@ -27,7 +25,6 @@ export function useUpdateUser(): UseUpdateUserReturn {
       try {
         const result = await apiClient.put<User>(
           `/users/${targetUserId}`,
-          userId,
           payload,
         );
         return result;
@@ -42,7 +39,7 @@ export function useUpdateUser(): UseUpdateUserReturn {
         setIsLoading(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { updateUser, isLoading, error };

--- a/frontend/src/features/admin/hooks/useUsers.ts
+++ b/frontend/src/features/admin/hooks/useUsers.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { User, UsersResponse } from "../types";
 
 interface UseUsersReturn {
@@ -15,7 +14,6 @@ interface UseUsersReturn {
 }
 
 export function useUsers(initialLimit = 20): UseUsersReturn {
-  const { userId } = useCurrentUser();
   const [users, setUsers] = useState<User[]>([]);
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -29,7 +27,6 @@ export function useUsers(initialLimit = 20): UseUsersReturn {
     try {
       const result = await apiClient.get<UsersResponse>(
         `/users?offset=${offset}&limit=${limit}`,
-        userId,
       );
       setUsers(result.users);
       setTotal(result.total);
@@ -40,7 +37,7 @@ export function useUsers(initialLimit = 20): UseUsersReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [userId, offset, limit]);
+  }, [offset, limit]);
 
   useEffect(() => {
     void fetchUsers();

--- a/frontend/src/features/admin/pages/AdminUsersPage.tsx
+++ b/frontend/src/features/admin/pages/AdminUsersPage.tsx
@@ -4,11 +4,13 @@ import { Button } from "@/components/ui/button";
 import { UserTable } from "../components/UserTable";
 import { CreateUserForm } from "../components/CreateUserForm";
 import { EditUserModal } from "../components/EditUserModal";
+import { InviteLinkModal } from "../components/InviteLinkModal";
 import { useUsers } from "../hooks/useUsers";
 import { useCreateUser } from "../hooks/useCreateUser";
 import { useUpdateUser } from "../hooks/useUpdateUser";
 import { useDeactivateUser } from "../hooks/useDeactivateUser";
 import { useActivateUser } from "../hooks/useActivateUser";
+import { useInviteUser } from "../hooks/useInviteUser";
 import type { User } from "../types";
 
 export function AdminUsersPage() {
@@ -26,8 +28,10 @@ export function AdminUsersPage() {
   } = useUpdateUser();
   const { deactivateUser, isLoading: isDeactivating } = useDeactivateUser();
   const { activateUser, isLoading: isActivating } = useActivateUser();
+  const { inviteUser, isLoading: isInviting } = useInviteUser();
 
   const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [inviteLink, setInviteLink] = useState<string | null>(null);
 
   const handleCreate = async (payload: Parameters<typeof createUser>[0]) => {
     const result = await createUser(payload);
@@ -55,6 +59,14 @@ export function AdminUsersPage() {
       await activateUser(user.id);
     }
     await refetch();
+  };
+
+  const handleInvite = async (user: User) => {
+    const result = await inviteUser(user.id);
+    if (result) {
+      const url = `${window.location.origin}/set-password?token=${result.token}`;
+      setInviteLink(url);
+    }
   };
 
   const totalPages = Math.ceil(total / limit);
@@ -99,7 +111,9 @@ export function AdminUsersPage() {
                 users={users}
                 onEdit={setEditingUser}
                 onToggleActive={handleToggleActive}
+                onInvite={(user) => void handleInvite(user)}
                 isToggling={isDeactivating || isActivating}
+                isInviting={isInviting}
               />
               {totalPages > 1 && (
                 <div className="mt-4 flex items-center justify-between">
@@ -139,6 +153,13 @@ export function AdminUsersPage() {
           onClose={() => setEditingUser(null)}
           isLoading={isUpdating}
           error={updateError}
+        />
+      )}
+
+      {inviteLink && (
+        <InviteLinkModal
+          link={inviteLink}
+          onClose={() => setInviteLink(null)}
         />
       )}
     </div>

--- a/frontend/src/features/auth/__tests__/AuthGuard.test.tsx
+++ b/frontend/src/features/auth/__tests__/AuthGuard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AuthGuard } from "../components/AuthGuard";
+import * as authStore from "@/api/auth-store";
+import * as auth from "@/api/auth";
+
+beforeEach(() => {
+  authStore.clearAccessToken();
+});
+
+function renderGuard(initialRoute = "/") {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Routes>
+        <Route element={<AuthGuard />}>
+          <Route path="/" element={<div>Protected Content</div>} />
+        </Route>
+        <Route path="/login" element={<div>Login Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthGuard", () => {
+  it("renders children when access token exists", () => {
+    authStore.setAccessToken("valid-token");
+    renderGuard();
+    expect(screen.getByText("Protected Content")).toBeInTheDocument();
+  });
+
+  it("attempts silent refresh when no token and shows content on success", async () => {
+    vi.spyOn(auth, "refreshApi").mockResolvedValueOnce({
+      access_token: "restored-token",
+      token_type: "bearer",
+    });
+
+    renderGuard();
+
+    // Should show loading initially, then protected content
+    expect(
+      await screen.findByText("Protected Content"),
+    ).toBeInTheDocument();
+    expect(authStore.getAccessToken()).toBe("restored-token");
+  });
+
+  it("redirects to /login when refresh fails", async () => {
+    vi.spyOn(auth, "refreshApi").mockRejectedValueOnce(
+      new auth.RefreshError(401),
+    );
+
+    renderGuard();
+
+    expect(await screen.findByText("Login Page")).toBeInTheDocument();
+  });
+
+  it("redirects to /login on network error during refresh", async () => {
+    vi.spyOn(auth, "refreshApi").mockRejectedValueOnce(
+      new Error("Network error"),
+    );
+
+    renderGuard();
+
+    expect(await screen.findByText("Login Page")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/auth/__tests__/AuthGuard.test.tsx
+++ b/frontend/src/features/auth/__tests__/AuthGuard.test.tsx
@@ -38,9 +38,7 @@ describe("AuthGuard", () => {
     renderGuard();
 
     // Should show loading initially, then protected content
-    expect(
-      await screen.findByText("Protected Content"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Protected Content")).toBeInTheDocument();
     expect(authStore.getAccessToken()).toBe("restored-token");
   });
 

--- a/frontend/src/features/auth/components/AuthGuard.tsx
+++ b/frontend/src/features/auth/components/AuthGuard.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { Navigate, Outlet } from "react-router";
+import { getAccessToken, setAccessToken } from "@/api/auth-store";
+import { refreshApi, RefreshError } from "@/api/auth";
+
+/**
+ * Route guard that ensures the user is authenticated.
+ *
+ * On mount, if no access token is present in memory (e.g. after page refresh),
+ * it attempts a silent refresh using the HttpOnly cookie. If the refresh fails,
+ * it redirects to the login page.
+ */
+export function AuthGuard() {
+  const [status, setStatus] = useState<
+    "checking" | "authenticated" | "unauthenticated"
+  >(() => {
+    return getAccessToken() ? "authenticated" : "checking";
+  });
+
+  useEffect(() => {
+    if (status !== "checking") {
+      return;
+    }
+
+    let cancelled = false;
+
+    const tryRestore = async () => {
+      try {
+        const result = await refreshApi();
+        if (!cancelled) {
+          setAccessToken(result.access_token);
+          setStatus("authenticated");
+        }
+      } catch (e) {
+        if (!cancelled) {
+          if (e instanceof RefreshError) {
+            setStatus("unauthenticated");
+          } else {
+            setStatus("unauthenticated");
+          }
+        }
+      }
+    };
+
+    void tryRestore();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  if (status === "checking") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface">
+        <div className="h-48 w-96 animate-pulse rounded-xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (status === "unauthenticated") {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { loginApi, LoginError } from "@/api/auth";
+import { setAccessToken } from "@/api/auth-store";
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!email.trim()) {
+      setError("メールアドレスを入力してください");
+      return;
+    }
+    if (!password) {
+      setError("パスワードを入力してください");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const result = await loginApi(email.trim(), password);
+      setAccessToken(result.access_token);
+      void navigate("/", { replace: true });
+    } catch (e) {
+      if (e instanceof LoginError) {
+        if (e.status === 401) {
+          setError("メールアドレスまたはパスワードが正しくありません");
+        } else if (e.status === 429) {
+          setError(
+            "ログイン試行回数が上限に達しました。しばらくしてから再度お試しください",
+          );
+        } else if (e.status === 403) {
+          setError("アカウントが無効化されています");
+        } else {
+          setError(e.detail);
+        }
+      } else {
+        setError("ログインに失敗しました");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-lg">ログイン</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            メールアドレスとパスワードを入力してください
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-medium">
+                メールアドレス
+              </label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="user@example.com"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setError(null);
+                }}
+                autoComplete="email"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium">
+                パスワード
+              </label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="パスワード"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setError(null);
+                }}
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? "ログイン中..." : "ログイン"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/pages/SetPasswordPage.tsx
+++ b/frontend/src/features/auth/pages/SetPasswordPage.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { setPasswordApi, SetPasswordError } from "@/api/auth";
+
+export function SetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+
+  if (!token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="text-lg">パスワード設定</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-destructive">
+              招待リンクが無効です。管理者に新しい招待リンクを発行してもらってください。
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!password) {
+      setError("パスワードを入力してください");
+      return;
+    }
+    if (password.length < 8) {
+      setError("パスワードは8文字以上で入力してください");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("パスワードが一致しません");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await setPasswordApi(token, password);
+      setIsComplete(true);
+    } catch (e) {
+      if (e instanceof SetPasswordError) {
+        setError(e.detail);
+      } else {
+        setError("パスワードの設定に失敗しました");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isComplete) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="text-lg">パスワード設定完了</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              パスワードが設定されました。ログイン画面からログインしてください。
+            </p>
+            <Button
+              className="w-full"
+              onClick={() => void navigate("/login", { replace: true })}
+            >
+              ログイン画面へ
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-lg">パスワード設定</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            新しいパスワードを設定してください
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium">
+                パスワード
+              </label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="8文字以上"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setError(null);
+                }}
+                autoComplete="new-password"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="confirm-password" className="text-sm font-medium">
+                パスワード（確認）
+              </label>
+              <Input
+                id="confirm-password"
+                type="password"
+                placeholder="もう一度入力してください"
+                value={confirmPassword}
+                onChange={(e) => {
+                  setConfirmPassword(e.target.value);
+                  setError(null);
+                }}
+                autoComplete="new-password"
+              />
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? "設定中..." : "パスワードを設定"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
@@ -83,8 +83,16 @@ let unreadNotificationsReturn = {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/dashboard/hooks/useDraftRecords.ts
+++ b/frontend/src/features/dashboard/hooks/useDraftRecords.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { DraftRecordItem, DraftRecordsResponse } from "../types";
 
 interface UseDraftRecordsResult {
@@ -11,7 +10,6 @@ interface UseDraftRecordsResult {
 }
 
 export function useDraftRecords(): UseDraftRecordsResult {
-  const { userId } = useCurrentUser();
   const [drafts, setDrafts] = useState<DraftRecordItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,10 +18,7 @@ export function useDraftRecords(): UseDraftRecordsResult {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await apiClient.get<DraftRecordsResponse>(
-        "/records/drafts",
-        userId,
-      );
+      const data = await apiClient.get<DraftRecordsResponse>("/records/drafts");
       setDrafts(data.items);
     } catch (e) {
       if (e instanceof ApiError) {
@@ -34,7 +29,7 @@ export function useDraftRecords(): UseDraftRecordsResult {
     } finally {
       setIsLoading(false);
     }
-  }, [userId]);
+  }, []);
 
   useEffect(() => {
     void fetchDrafts();

--- a/frontend/src/features/dashboard/hooks/usePendingActionItems.ts
+++ b/frontend/src/features/dashboard/hooks/usePendingActionItems.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { PendingActionItem, PendingActionItemsResponse } from "../types";
 
 interface UsePendingActionItemsResult {
@@ -11,7 +10,6 @@ interface UsePendingActionItemsResult {
 }
 
 export function usePendingActionItems(): UsePendingActionItemsResult {
-  const { userId } = useCurrentUser();
   const [items, setItems] = useState<PendingActionItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +20,6 @@ export function usePendingActionItems(): UsePendingActionItemsResult {
     try {
       const data = await apiClient.get<PendingActionItemsResponse>(
         `/action-items/pending`,
-        userId,
       );
       setItems(data.items);
     } catch (e) {
@@ -34,7 +31,7 @@ export function usePendingActionItems(): UsePendingActionItemsResult {
     } finally {
       setIsLoading(false);
     }
-  }, [userId]);
+  }, []);
 
   useEffect(() => {
     void fetchItems();

--- a/frontend/src/features/dashboard/hooks/useUnreadNotifications.ts
+++ b/frontend/src/features/dashboard/hooks/useUnreadNotifications.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { NotificationListResponse, NotificationRecord } from "../types";
 
 interface UseUnreadNotificationsResult {
@@ -11,7 +10,6 @@ interface UseUnreadNotificationsResult {
 }
 
 export function useUnreadNotifications(): UseUnreadNotificationsResult {
-  const { userId } = useCurrentUser();
   const [notifications, setNotifications] = useState<NotificationRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +20,6 @@ export function useUnreadNotifications(): UseUnreadNotificationsResult {
     try {
       const data = await apiClient.get<NotificationListResponse>(
         "/notifications?unread=true",
-        userId,
       );
       setNotifications(data.notifications);
     } catch (e) {
@@ -34,7 +31,7 @@ export function useUnreadNotifications(): UseUnreadNotificationsResult {
     } finally {
       setIsLoading(false);
     }
-  }, [userId]);
+  }, []);
 
   useEffect(() => {
     void fetchNotifications();

--- a/frontend/src/features/dashboard/hooks/useUpcomingSchedules.ts
+++ b/frontend/src/features/dashboard/hooks/useUpcomingSchedules.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { UpcomingScheduleItem, UpcomingSchedulesResponse } from "../types";
 
 interface UseUpcomingSchedulesResult {
@@ -11,7 +10,6 @@ interface UseUpcomingSchedulesResult {
 }
 
 export function useUpcomingSchedules(): UseUpcomingSchedulesResult {
-  const { userId } = useCurrentUser();
   const [schedules, setSchedules] = useState<UpcomingScheduleItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +20,6 @@ export function useUpcomingSchedules(): UseUpcomingSchedulesResult {
     try {
       const data = await apiClient.get<UpcomingSchedulesResponse>(
         "/schedules/upcoming",
-        userId,
       );
       setSchedules(data.schedules);
     } catch (e) {
@@ -34,7 +31,7 @@ export function useUpcomingSchedules(): UseUpcomingSchedulesResult {
     } finally {
       setIsLoading(false);
     }
-  }, [userId]);
+  }, []);
 
   useEffect(() => {
     void fetchSchedules();

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -12,7 +12,8 @@ import { UnreadRecordList } from "../components/UnreadRecordList";
 import { countThisWeekSchedules, formatDateJa } from "../utils";
 
 export function DashboardPage() {
-  const { name: userName } = useCurrentUser();
+  const { user } = useCurrentUser();
+  const userName = user?.name ?? "";
   const {
     schedules,
     isLoading: schedulesLoading,

--- a/frontend/src/features/notification-settings/__tests__/NotificationSettingPage.test.tsx
+++ b/frontend/src/features/notification-settings/__tests__/NotificationSettingPage.test.tsx
@@ -32,8 +32,16 @@ let updateNotificationSettingReturn = {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/notification-settings/__tests__/hooks.test.ts
+++ b/frontend/src/features/notification-settings/__tests__/hooks.test.ts
@@ -21,8 +21,16 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 
@@ -51,10 +59,7 @@ describe("useNotificationSetting", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith(
-      "/notification-settings",
-      TEST_USER_ID,
-    );
+    expect(mockGet).toHaveBeenCalledWith("/notification-settings");
     expect(result.current.setting).toEqual(mockSetting);
     expect(result.current.error).toBeNull();
   });
@@ -139,11 +144,10 @@ describe("useUpdateNotificationSetting", () => {
       });
     });
 
-    expect(mockPut).toHaveBeenCalledWith(
-      "/notification-settings",
-      TEST_USER_ID,
-      { reminder_minutes_before: 15, is_enabled: false },
-    );
+    expect(mockPut).toHaveBeenCalledWith("/notification-settings", {
+      reminder_minutes_before: 15,
+      is_enabled: false,
+    });
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });

--- a/frontend/src/features/notification-settings/hooks/useNotificationSetting.ts
+++ b/frontend/src/features/notification-settings/hooks/useNotificationSetting.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { NotificationSetting } from "../types";
 
 interface UseNotificationSettingResult {
@@ -11,7 +10,6 @@ interface UseNotificationSettingResult {
 }
 
 export function useNotificationSetting(): UseNotificationSettingResult {
-  const { userId } = useCurrentUser();
   const [setting, setSetting] = useState<NotificationSetting | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +20,6 @@ export function useNotificationSetting(): UseNotificationSettingResult {
     try {
       const data = await apiClient.get<NotificationSetting>(
         "/notification-settings",
-        userId,
       );
       setSetting(data);
     } catch (e) {
@@ -34,7 +31,7 @@ export function useNotificationSetting(): UseNotificationSettingResult {
     } finally {
       setIsLoading(false);
     }
-  }, [userId]);
+  }, []);
 
   useEffect(() => {
     void fetchSetting();

--- a/frontend/src/features/notification-settings/hooks/useUpdateNotificationSetting.ts
+++ b/frontend/src/features/notification-settings/hooks/useUpdateNotificationSetting.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type {
   NotificationSetting,
   UpdateNotificationSettingPayload,
@@ -15,7 +14,6 @@ interface UseUpdateNotificationSettingResult {
 }
 
 export function useUpdateNotificationSetting(): UseUpdateNotificationSettingResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +26,6 @@ export function useUpdateNotificationSetting(): UseUpdateNotificationSettingResu
       try {
         const data = await apiClient.put<NotificationSetting>(
           "/notification-settings",
-          userId,
           payload,
         );
         return data;
@@ -43,7 +40,7 @@ export function useUpdateNotificationSetting(): UseUpdateNotificationSettingResu
         setIsSubmitting(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { updateSetting, isSubmitting, error };

--- a/frontend/src/features/preparation/__tests__/PreparationPage.test.tsx
+++ b/frontend/src/features/preparation/__tests__/PreparationPage.test.tsx
@@ -119,8 +119,16 @@ vi.mock("react-router", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/preparation/__tests__/hooks.test.ts
+++ b/frontend/src/features/preparation/__tests__/hooks.test.ts
@@ -23,12 +23,18 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
-
-const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -58,7 +64,7 @@ describe("useScheduleDetail", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith("/schedules/s1", TEST_USER_ID);
+    expect(mockGet).toHaveBeenCalledWith("/schedules/s1");
     expect(result.current.schedule).toEqual(mockSchedule);
     expect(result.current.error).toBeNull();
   });
@@ -116,7 +122,7 @@ describe("useScheduleAgendas", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith("/schedules/s1/agendas", TEST_USER_ID);
+    expect(mockGet).toHaveBeenCalledWith("/schedules/s1/agendas");
     expect(result.current.agendas).toEqual(mockAgendas.agendas);
     expect(result.current.error).toBeNull();
   });
@@ -164,13 +170,9 @@ describe("useAddAgenda", () => {
       response = await result.current.addAgenda("New topic");
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/schedules/s1/agendas",
-      TEST_USER_ID,
-      {
-        topic: "New topic",
-      },
-    );
+    expect(mockPost).toHaveBeenCalledWith("/schedules/s1/agendas", {
+      topic: "New topic",
+    });
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });
@@ -218,10 +220,7 @@ describe("useDeleteAgenda", () => {
       success = await result.current.deleteAgenda("a1");
     });
 
-    expect(mockDelete).toHaveBeenCalledWith(
-      "/schedules/s1/agendas/a1",
-      TEST_USER_ID,
-    );
+    expect(mockDelete).toHaveBeenCalledWith("/schedules/s1/agendas/a1");
     expect(success).toBe(true);
     expect(result.current.error).toBeNull();
   });
@@ -271,11 +270,9 @@ describe("useAddAgendaComment", () => {
       response = await result.current.addComment("a1", "Great point");
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/agendas/a1/comments",
-      TEST_USER_ID,
-      { body: "Great point" },
-    );
+    expect(mockPost).toHaveBeenCalledWith("/agendas/a1/comments", {
+      body: "Great point",
+    });
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });
@@ -337,10 +334,7 @@ describe("usePendingActionItems", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith(
-      "/action-items/pending/cp1",
-      TEST_USER_ID,
-    );
+    expect(mockGet).toHaveBeenCalledWith("/action-items/pending/cp1");
     expect(result.current.items).toEqual(mockItems.items);
     expect(result.current.error).toBeNull();
   });

--- a/frontend/src/features/preparation/hooks/useAddAgenda.ts
+++ b/frontend/src/features/preparation/hooks/useAddAgenda.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { AddAgendaResponse } from "../types";
 
 interface UseAddAgendaResult {
@@ -10,7 +9,6 @@ interface UseAddAgendaResult {
 }
 
 export function useAddAgenda(scheduleId: string): UseAddAgendaResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -25,7 +23,6 @@ export function useAddAgenda(scheduleId: string): UseAddAgendaResult {
       try {
         const data = await apiClient.post<AddAgendaResponse>(
           `/schedules/${scheduleId}/agendas`,
-          userId,
           { topic },
         );
         return data;
@@ -40,7 +37,7 @@ export function useAddAgenda(scheduleId: string): UseAddAgendaResult {
         setIsSubmitting(false);
       }
     },
-    [scheduleId, userId],
+    [scheduleId],
   );
 
   return { addAgenda, isSubmitting, error };

--- a/frontend/src/features/preparation/hooks/useAddAgendaComment.ts
+++ b/frontend/src/features/preparation/hooks/useAddAgendaComment.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { AddAgendaCommentResponse } from "../types";
 
 interface UseAddAgendaCommentResult {
@@ -13,7 +12,6 @@ interface UseAddAgendaCommentResult {
 }
 
 export function useAddAgendaComment(): UseAddAgendaCommentResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -27,7 +25,6 @@ export function useAddAgendaComment(): UseAddAgendaCommentResult {
       try {
         const data = await apiClient.post<AddAgendaCommentResponse>(
           `/agendas/${agendaId}/comments`,
-          userId,
           { body },
         );
         return data;
@@ -42,7 +39,7 @@ export function useAddAgendaComment(): UseAddAgendaCommentResult {
         setIsSubmitting(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { addComment, isSubmitting, error };

--- a/frontend/src/features/preparation/hooks/useDeleteAgenda.ts
+++ b/frontend/src/features/preparation/hooks/useDeleteAgenda.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface UseDeleteAgendaResult {
   deleteAgenda: (agendaId: string) => Promise<boolean>;
@@ -9,7 +8,6 @@ interface UseDeleteAgendaResult {
 }
 
 export function useDeleteAgenda(scheduleId: string): UseDeleteAgendaResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -20,7 +18,6 @@ export function useDeleteAgenda(scheduleId: string): UseDeleteAgendaResult {
       try {
         await apiClient.delete<void>(
           `/schedules/${scheduleId}/agendas/${agendaId}`,
-          userId,
         );
         return true;
       } catch (e) {
@@ -34,7 +31,7 @@ export function useDeleteAgenda(scheduleId: string): UseDeleteAgendaResult {
         setIsSubmitting(false);
       }
     },
-    [scheduleId, userId],
+    [scheduleId],
   );
 
   return { deleteAgenda, isSubmitting, error };

--- a/frontend/src/features/preparation/hooks/usePendingActionItems.ts
+++ b/frontend/src/features/preparation/hooks/usePendingActionItems.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { PendingActionItem, PendingActionItemsResponse } from "../types";
 
 interface UsePendingActionItemsResult {
@@ -13,7 +12,6 @@ interface UsePendingActionItemsResult {
 export function usePendingActionItems(
   counterpartId: string | null,
 ): UsePendingActionItemsResult {
-  const { userId } = useCurrentUser();
   const [items, setItems] = useState<PendingActionItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -29,7 +27,6 @@ export function usePendingActionItems(
     try {
       const data = await apiClient.get<PendingActionItemsResponse>(
         `/action-items/pending/${counterpartId}`,
-        userId,
       );
       setItems(data.items);
     } catch (e) {
@@ -41,7 +38,7 @@ export function usePendingActionItems(
     } finally {
       setIsLoading(false);
     }
-  }, [counterpartId, userId]);
+  }, [counterpartId]);
 
   useEffect(() => {
     void fetchItems();

--- a/frontend/src/features/preparation/hooks/useScheduleAgendas.ts
+++ b/frontend/src/features/preparation/hooks/useScheduleAgendas.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { AgendaItem, AgendasResponse } from "../types";
 
 interface UseScheduleAgendasResult {
@@ -13,7 +12,6 @@ interface UseScheduleAgendasResult {
 export function useScheduleAgendas(
   scheduleId: string,
 ): UseScheduleAgendasResult {
-  const { userId } = useCurrentUser();
   const [agendas, setAgendas] = useState<AgendaItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -24,7 +22,6 @@ export function useScheduleAgendas(
     try {
       const data = await apiClient.get<AgendasResponse>(
         `/schedules/${scheduleId}/agendas`,
-        userId,
       );
       setAgendas(data.agendas);
     } catch (e) {
@@ -36,7 +33,7 @@ export function useScheduleAgendas(
     } finally {
       setIsLoading(false);
     }
-  }, [scheduleId, userId]);
+  }, [scheduleId]);
 
   useEffect(() => {
     if (!scheduleId) {

--- a/frontend/src/features/preparation/hooks/useScheduleDetail.ts
+++ b/frontend/src/features/preparation/hooks/useScheduleDetail.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { ScheduleDetail } from "../types";
 
 interface UseScheduleDetailResult {
@@ -11,7 +10,6 @@ interface UseScheduleDetailResult {
 }
 
 export function useScheduleDetail(scheduleId: string): UseScheduleDetailResult {
-  const { userId } = useCurrentUser();
   const [schedule, setSchedule] = useState<ScheduleDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +20,6 @@ export function useScheduleDetail(scheduleId: string): UseScheduleDetailResult {
     try {
       const data = await apiClient.get<ScheduleDetail>(
         `/schedules/${scheduleId}`,
-        userId,
       );
       setSchedule(data);
     } catch (e) {
@@ -34,7 +31,7 @@ export function useScheduleDetail(scheduleId: string): UseScheduleDetailResult {
     } finally {
       setIsLoading(false);
     }
-  }, [scheduleId, userId]);
+  }, [scheduleId]);
 
   useEffect(() => {
     void fetchSchedule();

--- a/frontend/src/features/preparation/hooks/useStartSession.ts
+++ b/frontend/src/features/preparation/hooks/useStartSession.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { StartSessionResponse } from "../types";
 
 interface UseStartSessionResult {
@@ -13,7 +12,6 @@ interface UseStartSessionResult {
 }
 
 export function useStartSession(): UseStartSessionResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -27,7 +25,6 @@ export function useStartSession(): UseStartSessionResult {
       try {
         const data = await apiClient.post<StartSessionResponse>(
           `/records/from-schedule`,
-          userId,
           { schedule_id: scheduleId, conducted_at: conductedAt },
         );
         return data;
@@ -42,7 +39,7 @@ export function useStartSession(): UseStartSessionResult {
         setIsSubmitting(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { startSession, isSubmitting, error };

--- a/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
+++ b/frontend/src/features/publishing/__tests__/PublishingPage.test.tsx
@@ -100,8 +100,16 @@ vi.mock("react-router", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/publishing/__tests__/hooks.test.ts
+++ b/frontend/src/features/publishing/__tests__/hooks.test.ts
@@ -24,12 +24,18 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
-
-const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -52,10 +58,7 @@ describe("useSuggestedViewers", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith(
-      "/records/r1/suggested-viewers",
-      TEST_USER_ID,
-    );
+    expect(mockGet).toHaveBeenCalledWith("/records/r1/suggested-viewers");
     expect(result.current.suggestedViewerIds).toEqual(["viewer1", "viewer2"]);
     expect(result.current.error).toBeNull();
   });
@@ -107,7 +110,7 @@ describe("useSetViewers", () => {
       response = await result.current.setViewers(["v1", "v2"]);
     });
 
-    expect(mockPut).toHaveBeenCalledWith("/records/r1/viewers", TEST_USER_ID, {
+    expect(mockPut).toHaveBeenCalledWith("/records/r1/viewers", {
       viewer_ids: ["v1", "v2"],
     });
     expect(response).toEqual(mockResponse);
@@ -158,11 +161,7 @@ describe("usePublishRecord", () => {
       response = await result.current.publishRecord();
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/records/r1/publish",
-      TEST_USER_ID,
-      {},
-    );
+    expect(mockPost).toHaveBeenCalledWith("/records/r1/publish", {});
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });

--- a/frontend/src/features/publishing/hooks/usePublishRecord.ts
+++ b/frontend/src/features/publishing/hooks/usePublishRecord.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { PublishRecordResponse } from "../types";
 
 interface UsePublishRecordResult {
@@ -10,7 +9,6 @@ interface UsePublishRecordResult {
 }
 
 export function usePublishRecord(recordId: string): UsePublishRecordResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,7 +19,6 @@ export function usePublishRecord(recordId: string): UsePublishRecordResult {
       try {
         const data = await apiClient.post<PublishRecordResponse>(
           `/records/${recordId}/publish`,
-          userId,
           {},
         );
         return data;
@@ -35,7 +32,7 @@ export function usePublishRecord(recordId: string): UsePublishRecordResult {
       } finally {
         setIsSubmitting(false);
       }
-    }, [recordId, userId]);
+    }, [recordId]);
 
   return { publishRecord, isSubmitting, error };
 }

--- a/frontend/src/features/publishing/hooks/useSetViewers.ts
+++ b/frontend/src/features/publishing/hooks/useSetViewers.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { SetViewersResponse } from "../types";
 
 interface UseSetViewersResult {
@@ -10,7 +9,6 @@ interface UseSetViewersResult {
 }
 
 export function useSetViewers(recordId: string): UseSetViewersResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,7 +19,6 @@ export function useSetViewers(recordId: string): UseSetViewersResult {
       try {
         const data = await apiClient.put<SetViewersResponse>(
           `/records/${recordId}/viewers`,
-          userId,
           { viewer_ids: viewerIds },
         );
         return data;
@@ -36,7 +33,7 @@ export function useSetViewers(recordId: string): UseSetViewersResult {
         setIsSubmitting(false);
       }
     },
-    [recordId, userId],
+    [recordId],
   );
 
   return { setViewers, isSubmitting, error };

--- a/frontend/src/features/publishing/hooks/useSuggestedViewers.ts
+++ b/frontend/src/features/publishing/hooks/useSuggestedViewers.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { SuggestedViewersResponse } from "../types";
 
 interface UseSuggestedViewersResult {
@@ -13,7 +12,6 @@ interface UseSuggestedViewersResult {
 export function useSuggestedViewers(
   recordId: string,
 ): UseSuggestedViewersResult {
-  const { userId } = useCurrentUser();
   const [suggestedViewerIds, setSuggestedViewerIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -24,7 +22,6 @@ export function useSuggestedViewers(
     try {
       const data = await apiClient.get<SuggestedViewersResponse>(
         `/records/${recordId}/suggested-viewers`,
-        userId,
       );
       setSuggestedViewerIds(data.suggested_viewer_ids);
     } catch (e) {
@@ -36,7 +33,7 @@ export function useSuggestedViewers(
     } finally {
       setIsLoading(false);
     }
-  }, [recordId, userId]);
+  }, [recordId]);
 
   useEffect(() => {
     void fetchSuggestedViewers();

--- a/frontend/src/features/record-viewer/__tests__/RecordViewerPage.test.tsx
+++ b/frontend/src/features/record-viewer/__tests__/RecordViewerPage.test.tsx
@@ -98,8 +98,16 @@ vi.mock("react-router", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/record-viewer/__tests__/hooks.test.ts
+++ b/frontend/src/features/record-viewer/__tests__/hooks.test.ts
@@ -21,12 +21,18 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
-
-const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -58,7 +64,7 @@ describe("useRecordDetail", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith("/records/r1", TEST_USER_ID);
+    expect(mockGet).toHaveBeenCalledWith("/records/r1");
     expect(result.current.record).toEqual(mockRecord);
     expect(result.current.error).toBeNull();
   });
@@ -114,7 +120,7 @@ describe("useRecordComments", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith("/records/r1/comments", TEST_USER_ID);
+    expect(mockGet).toHaveBeenCalledWith("/records/r1/comments");
     expect(result.current.comments).toEqual(mockComments.comments);
     expect(result.current.error).toBeNull();
   });
@@ -163,7 +169,7 @@ describe("useRecordViewers", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith("/records/r1/viewers", TEST_USER_ID);
+    expect(mockGet).toHaveBeenCalledWith("/records/r1/viewers");
     expect(result.current.viewerIds).toEqual(["viewer1", "viewer2"]);
     expect(result.current.error).toBeNull();
   });
@@ -212,11 +218,9 @@ describe("useAddRecordComment", () => {
       response = await result.current.addComment("Nice work!");
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/records/r1/comments",
-      TEST_USER_ID,
-      { body: "Nice work!" },
-    );
+    expect(mockPost).toHaveBeenCalledWith("/records/r1/comments", {
+      body: "Nice work!",
+    });
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });
@@ -268,10 +272,7 @@ describe("useCompleteActionItem", () => {
       response = await result.current.completeItem("ai1");
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/action-items/ai1/complete",
-      TEST_USER_ID,
-    );
+    expect(mockPost).toHaveBeenCalledWith("/action-items/ai1/complete");
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });

--- a/frontend/src/features/record-viewer/hooks/useAddRecordComment.ts
+++ b/frontend/src/features/record-viewer/hooks/useAddRecordComment.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { AddRecordCommentResponse } from "../types";
 
 interface UseAddRecordCommentResult {
@@ -12,7 +11,6 @@ interface UseAddRecordCommentResult {
 export function useAddRecordComment(
   recordId: string,
 ): UseAddRecordCommentResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -23,7 +21,6 @@ export function useAddRecordComment(
       try {
         const data = await apiClient.post<AddRecordCommentResponse>(
           `/records/${recordId}/comments`,
-          userId,
           { body },
         );
         return data;
@@ -38,7 +35,7 @@ export function useAddRecordComment(
         setIsSubmitting(false);
       }
     },
-    [recordId, userId],
+    [recordId],
   );
 
   return { addComment, isSubmitting, error };

--- a/frontend/src/features/record-viewer/hooks/useCompleteActionItem.ts
+++ b/frontend/src/features/record-viewer/hooks/useCompleteActionItem.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { CompleteActionItemResponse } from "../types";
 
 interface UseCompleteActionItemResult {
@@ -12,7 +11,6 @@ interface UseCompleteActionItemResult {
 }
 
 export function useCompleteActionItem(): UseCompleteActionItemResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -25,7 +23,6 @@ export function useCompleteActionItem(): UseCompleteActionItemResult {
       try {
         const data = await apiClient.post<CompleteActionItemResponse>(
           `/action-items/${actionItemId}/complete`,
-          userId,
         );
         return data;
       } catch (e) {
@@ -39,7 +36,7 @@ export function useCompleteActionItem(): UseCompleteActionItemResult {
         setIsSubmitting(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { completeItem, isSubmitting, error };

--- a/frontend/src/features/record-viewer/hooks/useRecordComments.ts
+++ b/frontend/src/features/record-viewer/hooks/useRecordComments.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { RecordComment, ListRecordCommentsResponse } from "../types";
 
 interface UseRecordCommentsResult {
@@ -11,7 +10,6 @@ interface UseRecordCommentsResult {
 }
 
 export function useRecordComments(recordId: string): UseRecordCommentsResult {
-  const { userId } = useCurrentUser();
   const [comments, setComments] = useState<RecordComment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +20,6 @@ export function useRecordComments(recordId: string): UseRecordCommentsResult {
     try {
       const data = await apiClient.get<ListRecordCommentsResponse>(
         `/records/${recordId}/comments`,
-        userId,
       );
       setComments(data.comments);
     } catch (e) {
@@ -34,7 +31,7 @@ export function useRecordComments(recordId: string): UseRecordCommentsResult {
     } finally {
       setIsLoading(false);
     }
-  }, [recordId, userId]);
+  }, [recordId]);
 
   useEffect(() => {
     void fetchComments();

--- a/frontend/src/features/record-viewer/hooks/useRecordDetail.ts
+++ b/frontend/src/features/record-viewer/hooks/useRecordDetail.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { RecordDetail } from "../types";
 
 interface UseRecordDetailResult {
@@ -11,7 +10,6 @@ interface UseRecordDetailResult {
 }
 
 export function useRecordDetail(recordId: string): UseRecordDetailResult {
-  const { userId } = useCurrentUser();
   const [record, setRecord] = useState<RecordDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,10 +18,7 @@ export function useRecordDetail(recordId: string): UseRecordDetailResult {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await apiClient.get<RecordDetail>(
-        `/records/${recordId}`,
-        userId,
-      );
+      const data = await apiClient.get<RecordDetail>(`/records/${recordId}`);
       setRecord(data);
     } catch (e) {
       if (e instanceof ApiError) {
@@ -34,7 +29,7 @@ export function useRecordDetail(recordId: string): UseRecordDetailResult {
     } finally {
       setIsLoading(false);
     }
-  }, [recordId, userId]);
+  }, [recordId]);
 
   useEffect(() => {
     void fetchRecord();

--- a/frontend/src/features/record-viewer/hooks/useRecordViewers.ts
+++ b/frontend/src/features/record-viewer/hooks/useRecordViewers.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { GetViewersResponse } from "../types";
 
 interface UseRecordViewersResult {
@@ -11,7 +10,6 @@ interface UseRecordViewersResult {
 }
 
 export function useRecordViewers(recordId: string): UseRecordViewersResult {
-  const { userId } = useCurrentUser();
   const [viewerIds, setViewerIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +20,6 @@ export function useRecordViewers(recordId: string): UseRecordViewersResult {
     try {
       const data = await apiClient.get<GetViewersResponse>(
         `/records/${recordId}/viewers`,
-        userId,
       );
       setViewerIds(data.viewer_ids);
     } catch (e) {
@@ -34,7 +31,7 @@ export function useRecordViewers(recordId: string): UseRecordViewersResult {
     } finally {
       setIsLoading(false);
     }
-  }, [recordId, userId]);
+  }, [recordId]);
 
   useEffect(() => {
     void fetchViewers();

--- a/frontend/src/features/record-viewer/pages/RecordViewerPage.tsx
+++ b/frontend/src/features/record-viewer/pages/RecordViewerPage.tsx
@@ -16,7 +16,8 @@ import { determineRole } from "../utils";
 export function RecordViewerPage() {
   const { recordId } = useParams<{ recordId: string }>();
   const navigate = useNavigate();
-  const { userId } = useCurrentUser();
+  const { user } = useCurrentUser();
+  const userId = user?.userId ?? "";
 
   const {
     record,

--- a/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
+++ b/frontend/src/features/recording/__tests__/RecordingPage.test.tsx
@@ -125,8 +125,16 @@ vi.mock("react-router", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/recording/__tests__/hooks.test.ts
+++ b/frontend/src/features/recording/__tests__/hooks.test.ts
@@ -25,12 +25,18 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
-
-const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -62,7 +68,7 @@ describe("useRecordDetail", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(mockGet).toHaveBeenCalledWith("/records/r1", TEST_USER_ID);
+    expect(mockGet).toHaveBeenCalledWith("/records/r1");
     expect(result.current.record).toEqual(mockRecord);
     expect(result.current.error).toBeNull();
   });
@@ -110,10 +116,7 @@ describe("useConfirmAgenda", () => {
       response = await result.current.confirmAgenda("a1");
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/records/r1/agendas/a1/confirm",
-      TEST_USER_ID,
-    );
+    expect(mockPost).toHaveBeenCalledWith("/records/r1/agendas/a1/confirm");
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });
@@ -162,11 +165,9 @@ describe("useAddActionItem", () => {
       response = await result.current.addActionItem("New action");
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/records/r1/action-items",
-      TEST_USER_ID,
-      { title: "New action" },
-    );
+    expect(mockPost).toHaveBeenCalledWith("/records/r1/action-items", {
+      title: "New action",
+    });
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });
@@ -217,10 +218,7 @@ describe("useDeleteActionItem", () => {
       success = await result.current.deleteActionItem("ai1");
     });
 
-    expect(mockDelete).toHaveBeenCalledWith(
-      "/records/r1/action-items/ai1",
-      TEST_USER_ID,
-    );
+    expect(mockDelete).toHaveBeenCalledWith("/records/r1/action-items/ai1");
     expect(success).toBe(true);
     expect(result.current.error).toBeNull();
   });

--- a/frontend/src/features/recording/hooks/useAddActionItem.ts
+++ b/frontend/src/features/recording/hooks/useAddActionItem.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { AddActionItemResponse } from "../types";
 
 interface UseAddActionItemResult {
@@ -10,7 +9,6 @@ interface UseAddActionItemResult {
 }
 
 export function useAddActionItem(recordId: string): UseAddActionItemResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,7 +19,6 @@ export function useAddActionItem(recordId: string): UseAddActionItemResult {
       try {
         const data = await apiClient.post<AddActionItemResponse>(
           `/records/${recordId}/action-items`,
-          userId,
           { title },
         );
         return data;
@@ -36,7 +33,7 @@ export function useAddActionItem(recordId: string): UseAddActionItemResult {
         setIsSubmitting(false);
       }
     },
-    [recordId, userId],
+    [recordId],
   );
 
   return { addActionItem, isSubmitting, error };

--- a/frontend/src/features/recording/hooks/useConfirmAgenda.ts
+++ b/frontend/src/features/recording/hooks/useConfirmAgenda.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { ConfirmAgendaResponse } from "../types";
 
 interface UseConfirmAgendaResult {
@@ -10,7 +9,6 @@ interface UseConfirmAgendaResult {
 }
 
 export function useConfirmAgenda(recordId: string): UseConfirmAgendaResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,7 +19,6 @@ export function useConfirmAgenda(recordId: string): UseConfirmAgendaResult {
       try {
         const data = await apiClient.post<ConfirmAgendaResponse>(
           `/records/${recordId}/agendas/${agendaId}/confirm`,
-          userId,
         );
         return data;
       } catch (e) {
@@ -35,7 +32,7 @@ export function useConfirmAgenda(recordId: string): UseConfirmAgendaResult {
         setIsSubmitting(false);
       }
     },
-    [recordId, userId],
+    [recordId],
   );
 
   return { confirmAgenda, isSubmitting, error };

--- a/frontend/src/features/recording/hooks/useDeleteActionItem.ts
+++ b/frontend/src/features/recording/hooks/useDeleteActionItem.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface UseDeleteActionItemResult {
   deleteActionItem: (actionItemId: string) => Promise<boolean>;
@@ -11,7 +10,6 @@ interface UseDeleteActionItemResult {
 export function useDeleteActionItem(
   recordId: string,
 ): UseDeleteActionItemResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,7 +20,6 @@ export function useDeleteActionItem(
       try {
         await apiClient.delete<void>(
           `/records/${recordId}/action-items/${actionItemId}`,
-          userId,
         );
         return true;
       } catch (e) {
@@ -36,7 +33,7 @@ export function useDeleteActionItem(
         setIsSubmitting(false);
       }
     },
-    [recordId, userId],
+    [recordId],
   );
 
   return { deleteActionItem, isSubmitting, error };

--- a/frontend/src/features/recording/hooks/useRecordDetail.ts
+++ b/frontend/src/features/recording/hooks/useRecordDetail.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { RecordDetail } from "../types";
 
 interface UseRecordDetailResult {
@@ -11,7 +10,6 @@ interface UseRecordDetailResult {
 }
 
 export function useRecordDetail(recordId: string): UseRecordDetailResult {
-  const { userId } = useCurrentUser();
   const [record, setRecord] = useState<RecordDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,10 +18,7 @@ export function useRecordDetail(recordId: string): UseRecordDetailResult {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await apiClient.get<RecordDetail>(
-        `/records/${recordId}`,
-        userId,
-      );
+      const data = await apiClient.get<RecordDetail>(`/records/${recordId}`);
       setRecord(data);
     } catch (e) {
       if (e instanceof ApiError) {
@@ -34,7 +29,7 @@ export function useRecordDetail(recordId: string): UseRecordDetailResult {
     } finally {
       setIsLoading(false);
     }
-  }, [recordId, userId]);
+  }, [recordId]);
 
   useEffect(() => {
     void fetchRecord();

--- a/frontend/src/features/scheduling/__tests__/ConsultationRequestForm.test.tsx
+++ b/frontend/src/features/scheduling/__tests__/ConsultationRequestForm.test.tsx
@@ -6,8 +6,16 @@ import { ApiError } from "@/api/client";
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/scheduling/__tests__/ScheduleGroupForm.test.tsx
+++ b/frontend/src/features/scheduling/__tests__/ScheduleGroupForm.test.tsx
@@ -6,8 +6,16 @@ import { ApiError } from "@/api/client";
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/scheduling/__tests__/SchedulingPage.test.tsx
+++ b/frontend/src/features/scheduling/__tests__/SchedulingPage.test.tsx
@@ -25,8 +25,16 @@ vi.mock("../hooks/useSendConsultationRequest", () => ({
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/scheduling/hooks/useCreateFromTemplate.ts
+++ b/frontend/src/features/scheduling/hooks/useCreateFromTemplate.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface CounterpartSchedulePayload {
   counterpart_id: string;
@@ -28,7 +27,6 @@ interface UseCreateFromTemplateReturn {
 export type { CreateFromTemplatePayload, CreateFromTemplateResult };
 
 export function useCreateFromTemplate(): UseCreateFromTemplateReturn {
-  const { userId } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
 
@@ -41,7 +39,6 @@ export function useCreateFromTemplate(): UseCreateFromTemplateReturn {
       try {
         const result = await apiClient.post<CreateFromTemplateResult>(
           "/schedule-groups/from-template",
-          userId,
           payload,
         );
         return result;
@@ -56,7 +53,7 @@ export function useCreateFromTemplate(): UseCreateFromTemplateReturn {
         setIsLoading(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { createFromTemplate, isLoading, error };

--- a/frontend/src/features/scheduling/hooks/useCreateScheduleGroup.ts
+++ b/frontend/src/features/scheduling/hooks/useCreateScheduleGroup.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface CounterpartSchedulePayload {
   counterpart_id: string;
@@ -33,7 +32,6 @@ export type {
 };
 
 export function useCreateScheduleGroup(): UseCreateScheduleGroupReturn {
-  const { userId } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
 
@@ -46,7 +44,6 @@ export function useCreateScheduleGroup(): UseCreateScheduleGroupReturn {
       try {
         const result = await apiClient.post<CreateScheduleGroupResult>(
           "/schedule-groups",
-          userId,
           payload,
         );
         return result;
@@ -61,7 +58,7 @@ export function useCreateScheduleGroup(): UseCreateScheduleGroupReturn {
         setIsLoading(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { createScheduleGroup, isLoading, error };

--- a/frontend/src/features/scheduling/hooks/useSendConsultationRequest.ts
+++ b/frontend/src/features/scheduling/hooks/useSendConsultationRequest.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface SendConsultationRequestPayload {
   organizer_id: string;
@@ -24,7 +23,6 @@ interface UseSendConsultationRequestReturn {
 export type { SendConsultationRequestPayload, SendConsultationRequestResult };
 
 export function useSendConsultationRequest(): UseSendConsultationRequestReturn {
-  const { userId } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
 
@@ -37,7 +35,6 @@ export function useSendConsultationRequest(): UseSendConsultationRequestReturn {
       try {
         const result = await apiClient.post<SendConsultationRequestResult>(
           "/schedules/consultation-request",
-          userId,
           payload,
         );
         return result;
@@ -52,7 +49,7 @@ export function useSendConsultationRequest(): UseSendConsultationRequestReturn {
         setIsLoading(false);
       }
     },
-    [userId],
+    [],
   );
 
   return { sendConsultationRequest, isLoading, error };

--- a/frontend/src/features/scheduling/hooks/useTemplateDetail.ts
+++ b/frontend/src/features/scheduling/hooks/useTemplateDetail.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface TemplateDetail {
   template_id: string;
@@ -24,7 +23,6 @@ export type { TemplateDetail };
 export function useTemplateDetail(
   templateId: string | null,
 ): UseTemplateDetailReturn {
-  const { userId } = useCurrentUser();
   const [template, setTemplate] = useState<TemplateDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
@@ -39,7 +37,6 @@ export function useTemplateDetail(
     try {
       const result = await apiClient.get<TemplateDetail>(
         `/templates/${templateId}`,
-        userId,
       );
       setTemplate(result);
     } catch (e) {
@@ -49,7 +46,7 @@ export function useTemplateDetail(
     } finally {
       setIsLoading(false);
     }
-  }, [templateId, userId]);
+  }, [templateId]);
 
   useEffect(() => {
     void fetchTemplate();

--- a/frontend/src/features/scheduling/hooks/useTemplates.ts
+++ b/frontend/src/features/scheduling/hooks/useTemplates.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface TemplateListItem {
   template_id: string;
@@ -25,7 +24,6 @@ interface UseTemplatesReturn {
 export type { TemplateListItem };
 
 export function useTemplates(): UseTemplatesReturn {
-  const { userId } = useCurrentUser();
   const [templates, setTemplates] = useState<TemplateListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<ApiError | null>(null);
@@ -34,10 +32,7 @@ export function useTemplates(): UseTemplatesReturn {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await apiClient.get<ListTemplatesResponse>(
-        "/templates",
-        userId,
-      );
+      const result = await apiClient.get<ListTemplatesResponse>("/templates");
       setTemplates(result.templates);
     } catch (e) {
       const apiError =
@@ -46,7 +41,7 @@ export function useTemplates(): UseTemplatesReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [userId]);
+  }, []);
 
   useEffect(() => {
     void fetchTemplates();

--- a/frontend/src/features/setup/__tests__/SetupPage.test.tsx
+++ b/frontend/src/features/setup/__tests__/SetupPage.test.tsx
@@ -132,6 +132,7 @@ describe("SetupPage", () => {
     expect(screen.getByText("初期セットアップ")).toBeInTheDocument();
     expect(screen.getByLabelText("名前")).toBeInTheDocument();
     expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "登録" })).toBeInTheDocument();
   });
 
@@ -182,6 +183,43 @@ describe("SetupPage", () => {
     expect(mockSetupUser).not.toHaveBeenCalled();
   });
 
+  it("shows validation error when password is empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("名前"), "Admin");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "admin@example.com",
+    );
+
+    await user.click(screen.getByRole("button", { name: "登録" }));
+
+    expect(
+      screen.getByText("パスワードを入力してください"),
+    ).toBeInTheDocument();
+    expect(mockSetupUser).not.toHaveBeenCalled();
+  });
+
+  it("shows validation error when password is too short", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("名前"), "Admin");
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "admin@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "short");
+
+    await user.click(screen.getByRole("button", { name: "登録" }));
+
+    expect(
+      screen.getByText("パスワードは8文字以上で入力してください"),
+    ).toBeInTheDocument();
+    expect(mockSetupUser).not.toHaveBeenCalled();
+  });
+
   it("clears validation error when user types", async () => {
     const user = userEvent.setup();
     renderPage();
@@ -214,12 +252,14 @@ describe("SetupPage", () => {
       screen.getByLabelText("メールアドレス"),
       "admin@example.com",
     );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
     await user.click(screen.getByRole("button", { name: "登録" }));
 
     await waitFor(() => {
       expect(mockSetupUser).toHaveBeenCalledWith({
         name: "Admin",
         email: "admin@example.com",
+        password: "password123",
       });
     });
 
@@ -238,6 +278,7 @@ describe("SetupPage", () => {
       screen.getByLabelText("メールアドレス"),
       "admin@example.com",
     );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
     await user.click(screen.getByRole("button", { name: "登録" }));
 
     await waitFor(() => {

--- a/frontend/src/features/setup/__tests__/SetupPage.test.tsx
+++ b/frontend/src/features/setup/__tests__/SetupPage.test.tsx
@@ -264,7 +264,7 @@ describe("SetupPage", () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+      expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true });
     });
   });
 

--- a/frontend/src/features/setup/hooks/useSetupFirstUser.ts
+++ b/frontend/src/features/setup/hooks/useSetupFirstUser.ts
@@ -4,6 +4,7 @@ import { ApiError } from "@/api/client";
 interface SetupFirstUserRequest {
   name: string;
   email: string;
+  password: string;
 }
 
 interface SetupFirstUserResponse {

--- a/frontend/src/features/setup/pages/SetupPage.tsx
+++ b/frontend/src/features/setup/pages/SetupPage.tsx
@@ -79,7 +79,7 @@ export function SetupPage() {
       password,
     });
     if (result) {
-      void navigate("/", { replace: true });
+      void navigate("/login", { replace: true });
     }
   };
 

--- a/frontend/src/features/setup/pages/SetupPage.tsx
+++ b/frontend/src/features/setup/pages/SetupPage.tsx
@@ -18,6 +18,7 @@ export function SetupPage() {
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
 
   // Redirect to dashboard if setup is already complete
@@ -63,8 +64,20 @@ export function SetupPage() {
       setValidationError("有効なメールアドレスを入力してください");
       return;
     }
+    if (!password) {
+      setValidationError("パスワードを入力してください");
+      return;
+    }
+    if (password.length < 8) {
+      setValidationError("パスワードは8文字以上で入力してください");
+      return;
+    }
 
-    const result = await setupUser({ name: name.trim(), email: email.trim() });
+    const result = await setupUser({
+      name: name.trim(),
+      email: email.trim(),
+      password,
+    });
     if (result) {
       void navigate("/", { replace: true });
     }
@@ -109,6 +122,22 @@ export function SetupPage() {
                   setEmail(e.target.value);
                   setValidationError(null);
                 }}
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium">
+                パスワード
+              </label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="8文字以上"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setValidationError(null);
+                }}
+                autoComplete="new-password"
               />
             </div>
 

--- a/frontend/src/hooks/__tests__/useSaveDraft.test.ts
+++ b/frontend/src/hooks/__tests__/useSaveDraft.test.ts
@@ -22,12 +22,18 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
-
-const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -48,10 +54,7 @@ describe("useSaveDraft", () => {
       response = await result.current.saveDraft();
     });
 
-    expect(mockPost).toHaveBeenCalledWith(
-      "/records/r1/save-draft",
-      TEST_USER_ID,
-    );
+    expect(mockPost).toHaveBeenCalledWith("/records/r1/save-draft");
     expect(response).toEqual(mockResponse);
     expect(result.current.error).toBeNull();
   });

--- a/frontend/src/hooks/__tests__/useUpdateMemo.test.ts
+++ b/frontend/src/hooks/__tests__/useUpdateMemo.test.ts
@@ -22,12 +22,18 @@ vi.mock("@/api/client", async () => {
 
 vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => ({
-    userId: "00000000-0000-0000-0000-000000000001",
-    name: "Dev User",
+    user: {
+      userId: "00000000-0000-0000-0000-000000000001",
+      name: "Dev User",
+      email: "test@example.com",
+      role: "admin",
+      isActive: true,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }));
-
-const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -48,7 +54,7 @@ describe("useUpdateMemo", () => {
       response = await result.current.updateMemo("Updated memo");
     });
 
-    expect(mockPut).toHaveBeenCalledWith("/records/r1/memo", TEST_USER_ID, {
+    expect(mockPut).toHaveBeenCalledWith("/records/r1/memo", {
       memo: "Updated memo",
     });
     expect(response).toEqual(mockResponse);

--- a/frontend/src/hooks/useCurrentUser.ts
+++ b/frontend/src/hooks/useCurrentUser.ts
@@ -1,17 +1,70 @@
-const DEV_USER_ID = "00000000-0000-0000-0000-000000000001";
-const DEV_USER_NAME = "Dev User";
-const DEV_USER_ROLE = "admin";
+import { useCallback, useEffect, useState } from "react";
+import { apiClient, ApiError } from "@/api/client";
+import { getAccessToken } from "@/api/auth-store";
 
-interface CurrentUser {
+export interface CurrentUser {
   userId: string;
   name: string;
+  email: string;
   role: "admin" | "member";
+  isActive: boolean;
 }
 
-export function useCurrentUser(): CurrentUser {
-  return {
-    userId: DEV_USER_ID,
-    name: DEV_USER_NAME,
-    role: DEV_USER_ROLE,
-  };
+interface UserMeResponse {
+  id: string;
+  name: string;
+  email: string;
+  role: "admin" | "member";
+  is_active: boolean;
+  slack_user_id: string | null;
+}
+
+interface UseCurrentUserResult {
+  user: CurrentUser | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useCurrentUser(): UseCurrentUserResult {
+  const [user, setUser] = useState<CurrentUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchUser = useCallback(async () => {
+    const token = getAccessToken();
+    if (!token) {
+      setUser(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<UserMeResponse>("/users/me");
+      setUser({
+        userId: data.id,
+        name: data.name,
+        email: data.email,
+        role: data.role,
+        isActive: data.is_active,
+      });
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(`ユーザー情報の取得に失敗しました (${e.status})`);
+      } else {
+        setError("ユーザー情報の取得に失敗しました");
+      }
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchUser();
+  }, [fetchUser]);
+
+  return { user, isLoading, error, refetch: fetchUser };
 }

--- a/frontend/src/hooks/useSaveDraft.ts
+++ b/frontend/src/hooks/useSaveDraft.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface SaveDraftResponse {
   record_id: string;
@@ -13,7 +12,6 @@ interface UseSaveDraftResult {
 }
 
 export function useSaveDraft(recordId: string): UseSaveDraftResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -23,7 +21,6 @@ export function useSaveDraft(recordId: string): UseSaveDraftResult {
     try {
       const data = await apiClient.post<SaveDraftResponse>(
         `/records/${recordId}/save-draft`,
-        userId,
       );
       return data;
     } catch (e) {
@@ -36,7 +33,7 @@ export function useSaveDraft(recordId: string): UseSaveDraftResult {
     } finally {
       setIsSubmitting(false);
     }
-  }, [recordId, userId]);
+  }, [recordId]);
 
   return { saveDraft, isSubmitting, error };
 }

--- a/frontend/src/hooks/useUpdateMemo.ts
+++ b/frontend/src/hooks/useUpdateMemo.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { apiClient, ApiError } from "@/api/client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface UpdateMemoResponse {
   record_id: string;
@@ -13,7 +12,6 @@ interface UseUpdateMemoResult {
 }
 
 export function useUpdateMemo(recordId: string): UseUpdateMemoResult {
-  const { userId } = useCurrentUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,7 +22,6 @@ export function useUpdateMemo(recordId: string): UseUpdateMemoResult {
       try {
         const data = await apiClient.put<UpdateMemoResponse>(
           `/records/${recordId}/memo`,
-          userId,
           { memo },
         );
         return data;
@@ -39,7 +36,7 @@ export function useUpdateMemo(recordId: string): UseUpdateMemoResult {
         setIsSubmitting(false);
       }
     },
-    [recordId, userId],
+    [recordId],
   );
 
   return { updateMemo, isSubmitting, error };

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,6 +1,9 @@
 import { createBrowserRouter } from "react-router";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { AdminGuard } from "@/components/guards/AdminGuard";
+import { AuthGuard } from "@/features/auth/components/AuthGuard";
+import { LoginPage } from "@/features/auth/pages/LoginPage";
+import { SetPasswordPage } from "@/features/auth/pages/SetPasswordPage";
 import { DashboardPage } from "@/features/dashboard/pages/DashboardPage";
 import { SchedulingPage } from "@/features/scheduling/pages/SchedulingPage";
 import { PreparationPage } from "@/features/preparation/pages/PreparationPage";
@@ -18,39 +21,52 @@ import { AdminUsersPage } from "@/features/admin/pages/AdminUsersPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 
 export const router = createBrowserRouter([
+  { path: "login", element: <LoginPage /> },
+  { path: "set-password", element: <SetPasswordPage /> },
   { path: "setup", element: <SetupPage /> },
   {
-    element: <SetupGuard />,
+    element: <AuthGuard />,
     children: [
       {
-        element: <AppLayout />,
+        element: <SetupGuard />,
         children: [
-          { index: true, element: <DashboardPage /> },
-          { path: "scheduling", element: <SchedulingPage /> },
-          { path: "schedules", element: <ScheduleListPage /> },
           {
-            path: "schedules/:scheduleId/preparation",
-            element: <PreparationPage />,
+            element: <AppLayout />,
+            children: [
+              { index: true, element: <DashboardPage /> },
+              { path: "scheduling", element: <SchedulingPage /> },
+              { path: "schedules", element: <ScheduleListPage /> },
+              {
+                path: "schedules/:scheduleId/preparation",
+                element: <PreparationPage />,
+              },
+              { path: "records/in-progress", element: <RecordingListPage /> },
+              { path: "records/drafts", element: <DraftListPage /> },
+              {
+                path: "records/:recordId/recording",
+                element: <RecordingPage />,
+              },
+              {
+                path: "records/:recordId/publish",
+                element: <PublishingPage />,
+              },
+              { path: "records", element: <RecordListPage /> },
+              { path: "records/:recordId", element: <RecordViewerPage /> },
+              {
+                path: "settings/notifications",
+                element: <NotificationSettingPage />,
+              },
+              {
+                path: "admin/users",
+                element: (
+                  <AdminGuard>
+                    <AdminUsersPage />
+                  </AdminGuard>
+                ),
+              },
+              { path: "*", element: <NotFoundPage /> },
+            ],
           },
-          { path: "records/in-progress", element: <RecordingListPage /> },
-          { path: "records/drafts", element: <DraftListPage /> },
-          { path: "records/:recordId/recording", element: <RecordingPage /> },
-          { path: "records/:recordId/publish", element: <PublishingPage /> },
-          { path: "records", element: <RecordListPage /> },
-          { path: "records/:recordId", element: <RecordViewerPage /> },
-          {
-            path: "settings/notifications",
-            element: <NotificationSettingPage />,
-          },
-          {
-            path: "admin/users",
-            element: (
-              <AdminGuard>
-                <AdminUsersPage />
-              </AdminGuard>
-            ),
-          },
-          { path: "*", element: <NotFoundPage /> },
         ],
       },
     ],


### PR DESCRIPTION
## 概要

Issue #194 の PR2: フロントエンド認証フローの実装。PR1（バックエンド認証基盤）がdevelopにマージ済みであることを前提としている。

## 変更内容

### 認証基盤
- `auth-store.ts`: アクセストークンのメモリ保持（localStorage/Cookieに保存しない）
- `auth.ts`: 認証API関数（login, refresh, logout, set-password）
- `client.ts`: APIクライアントを`X-User-Id`ヘッダーから`Authorization: Bearer <token>`に切替、`credentials: 'include'`追加、401時の自動リフレッシュ+リトライ

### 新規画面
- **ログイン画面** (`LoginPage.tsx`): メールアドレス+パスワード認証
- **パスワード設定画面** (`SetPasswordPage.tsx`): 招待リンクからの遷移先
- **AuthGuard**: 未認証時にログインページへリダイレクト、ページリフレッシュ時にCookieからサイレントリフレッシュ

### 既存画面の更新
- **セットアップ画面**: パスワード入力欄を追加
- **管理画面ユーザー管理**: 招待リンク生成ボタン+モーダル追加
- **ヘッダー**: ログアウトボタン追加

### APIクライアント・hooks更新
- 全hooks（37ファイル）からuserIdパラメータを削除（Bearer認証に移行）
- `useCurrentUser`を`/users/me`ベースに書き換え（ハードコードのダミーユーザーを廃止）
- `AdminGuard`, `Header`, `Sidebar`, `DashboardPage`, `RecordViewerPage`を新しいuseCurrentUserインターフェースに対応

### ルーティング
- `/login`, `/set-password`ルート追加
- `AuthGuard`を`SetupGuard`の外側に配置（未認証→ログイン→セットアップ→アプリの順）

### テスト
- 全テストファイル（33ファイル）を新しいuseCurrentUser/apiClientインターフェースに対応
- SetupPageテストにパスワード関連のテストケースを追加
- 全334テストがパス

## 設計方針
- アクセストークンはメモリ（変数）保持、Cookie/localStorageに入れない
- リフレッシュトークンはHttpOnly Cookieで自動送信（フロントから触れない）
- 401応答 → `/auth/refresh`試行 → 成功ならリトライ → 失敗ならログイン画面へ
- 並行リクエストのリフレッシュ重複防止（singleton guard）
- `useCurrentUser`はJWTデコードではなく`/users/me`でDBの最新状態を取得

## テスト方法
- [ ] ログイン画面でメール+パスワードでログインできること
- [ ] 未認証時にログイン画面へリダイレクトされること
- [ ] ページリフレッシュ後もセッションが維持されること（Cookieリフレッシュ）
- [ ] ログアウトボタンでログアウトできること
- [ ] セットアップ画面でパスワードが必須になっていること
- [ ] 管理画面でユーザーに招待リンクを発行できること
- [ ] パスワード設定画面でパスワードを設定できること
- [ ] `npx vitest run` で全334テストがパスすること

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)