### PR TITLE
test: 認証機能のテスト全面追加 (Issue #194 PR3)

### DIFF
--- a/backend/foundation/auth/in_memory_invitation_token_repository.py
+++ b/backend/foundation/auth/in_memory_invitation_token_repository.py
@@ -1,0 +1,28 @@
+"""In-memory implementation of InvitationTokenRepository for testing."""
+
+from __future__ import annotations
+
+from foundation.auth.invitation_token_repository import (
+    InvitationTokenRecord,
+    InvitationTokenRepository,
+)
+
+
+class InMemoryInvitationTokenRepository(InvitationTokenRepository):
+    """In-memory stub for InvitationTokenRepository."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, InvitationTokenRecord] = {}
+
+    async def save(self, record: InvitationTokenRecord) -> None:
+        self._records[record.id] = record
+
+    async def find_by_token_hash(self, token_hash: str) -> InvitationTokenRecord | None:
+        for record in self._records.values():
+            if record.token_hash == token_hash:
+                return record
+        return None
+
+    async def mark_as_used(self, token_id: str) -> None:
+        if token_id in self._records:
+            self._records[token_id].is_used = True

--- a/backend/foundation/auth/in_memory_login_attempt_repository.py
+++ b/backend/foundation/auth/in_memory_login_attempt_repository.py
@@ -1,0 +1,32 @@
+"""In-memory implementation of LoginAttemptRepository for testing."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from foundation.auth.login_attempt_repository import (
+    LoginAttemptRecord,
+    LoginAttemptRepository,
+)
+
+
+class InMemoryLoginAttemptRepository(LoginAttemptRepository):
+    """In-memory stub for LoginAttemptRepository."""
+
+    def __init__(self) -> None:
+        self._records: list[LoginAttemptRecord] = []
+
+    async def save(self, record: LoginAttemptRecord) -> None:
+        self._records.append(record)
+
+    async def count_recent_failures(self, email: str, since: datetime) -> int:
+        return sum(
+            1
+            for r in self._records
+            if r.email == email and not r.is_success and r.attempted_at >= since
+        )
+
+    async def delete_older_than(self, before: datetime) -> int:
+        original_len = len(self._records)
+        self._records = [r for r in self._records if r.attempted_at >= before]
+        return original_len - len(self._records)

--- a/backend/foundation/auth/in_memory_refresh_token_repository.py
+++ b/backend/foundation/auth/in_memory_refresh_token_repository.py
@@ -1,0 +1,46 @@
+"""In-memory implementation of RefreshTokenRepository for testing."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from foundation.auth.refresh_token_repository import (
+    RefreshTokenRecord,
+    RefreshTokenRepository,
+)
+
+
+class InMemoryRefreshTokenRepository(RefreshTokenRepository):
+    """In-memory stub for RefreshTokenRepository."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, RefreshTokenRecord] = {}
+
+    async def save(self, record: RefreshTokenRecord) -> None:
+        self._records[record.id] = record
+
+    async def find_by_token_hash(self, token_hash: str) -> RefreshTokenRecord | None:
+        for record in self._records.values():
+            if record.token_hash == token_hash:
+                return record
+        return None
+
+    async def revoke_by_family_id(self, family_id: str) -> None:
+        for record in self._records.values():
+            if record.token_family_id == family_id:
+                record.is_revoked = True
+
+    async def revoke_by_user_id(self, user_id: str) -> None:
+        for record in self._records.values():
+            if record.user_id == user_id:
+                record.is_revoked = True
+
+    async def delete_expired(self, before: datetime) -> int:
+        to_delete = [
+            rid
+            for rid, r in self._records.items()
+            if r.expires_at < before and r.is_revoked
+        ]
+        for rid in to_delete:
+            del self._records[rid]
+        return len(to_delete)

--- a/backend/tests/api/test_auth_router.py
+++ b/backend/tests/api/test_auth_router.py
@@ -1,0 +1,426 @@
+"""Unit tests for auth router endpoints using DI overrides."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.auth_router import auth_router
+from api.dependencies import (
+    get_invitation_token_repository,
+    get_login_attempt_repository,
+    get_refresh_token_repository,
+    get_session,
+    get_user_repository,
+)
+from foundation.auth.in_memory_invitation_token_repository import (
+    InMemoryInvitationTokenRepository,
+)
+from foundation.auth.in_memory_login_attempt_repository import (
+    InMemoryLoginAttemptRepository,
+)
+from foundation.auth.in_memory_refresh_token_repository import (
+    InMemoryRefreshTokenRepository,
+)
+from foundation.auth.password import hash_password
+from foundation.auth.refresh_token_repository import RefreshTokenRecord
+from foundation.auth.token_hash import generate_token, hash_token
+from foundation.auth.use_cases.create_invitation_use_case import (
+    CreateInvitationInput,
+    CreateInvitationUseCase,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import (
+    InMemoryUserRepository,
+)
+
+_TEST_SECRET = "test-secret-key-for-unit-tests-32chars!"
+_ALLOWED_ORIGINS = ["http://localhost:5173"]
+
+
+class _FakeSettings:
+    jwt_secret_key = _TEST_SECRET
+    jwt_access_token_expire_minutes = 30
+    jwt_refresh_token_expire_days = 7
+    debug = True
+    cors_origins_list = _ALLOWED_ORIGINS
+
+
+def _patch_settings():  # type: ignore[no-untyped-def]
+    return patch("api.auth_router.settings", _FakeSettings())
+
+
+# ---------------------------------------------------------------------------
+# App builder
+# ---------------------------------------------------------------------------
+
+
+def _build_app(
+    user_repo: InMemoryUserRepository,
+    refresh_repo: InMemoryRefreshTokenRepository,
+    login_attempt_repo: InMemoryLoginAttemptRepository,
+    invitation_repo: InMemoryInvitationTokenRepository,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(auth_router)
+
+    async def _noop() -> None:
+        pass
+
+    _fake_session_obj = SimpleNamespace(commit=_noop)
+
+    async def _fake_session() -> AsyncGenerator[SimpleNamespace]:
+        yield _fake_session_obj
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_user_repository] = lambda: user_repo
+    app.dependency_overrides[get_refresh_token_repository] = lambda: refresh_repo
+    app.dependency_overrides[get_login_attempt_repository] = lambda: login_attempt_repo
+    app.dependency_overrides[get_invitation_token_repository] = lambda: invitation_repo
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_user(
+    *,
+    email: str = "user@example.com",
+    password: str = "correct-password",
+    is_active: bool = True,
+) -> User:
+    return User(
+        id=UserId.generate(),
+        name="Test User",
+        email=email,
+        role=UserRole.MEMBER,
+        is_active=is_active,
+        password_hash=hash_password(password),
+    )
+
+
+@pytest.fixture
+def user_repo() -> InMemoryUserRepository:
+    return InMemoryUserRepository()
+
+
+@pytest.fixture
+def refresh_repo() -> InMemoryRefreshTokenRepository:
+    return InMemoryRefreshTokenRepository()
+
+
+@pytest.fixture
+def login_attempt_repo() -> InMemoryLoginAttemptRepository:
+    return InMemoryLoginAttemptRepository()
+
+
+@pytest.fixture
+def invitation_repo() -> InMemoryInvitationTokenRepository:
+    return InMemoryInvitationTokenRepository()
+
+
+@pytest.fixture
+def app(
+    user_repo: InMemoryUserRepository,
+    refresh_repo: InMemoryRefreshTokenRepository,
+    login_attempt_repo: InMemoryLoginAttemptRepository,
+    invitation_repo: InMemoryInvitationTokenRepository,
+) -> FastAPI:
+    return _build_app(user_repo, refresh_repo, login_attempt_repo, invitation_repo)
+
+
+@pytest.fixture
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /auth/login
+# ---------------------------------------------------------------------------
+
+
+class TestLogin:
+    """Tests for POST /auth/login."""
+
+    async def test_successful_login_returns_token(
+        self,
+        user_repo: InMemoryUserRepository,
+        client: AsyncClient,
+    ) -> None:
+        """Successful login returns access token and sets refresh cookie."""
+        user = _make_user()
+        user_repo.add(user)
+
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/login",
+                json={"email": "user@example.com", "password": "correct-password"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+        # Check refresh token cookie is set
+        assert "refresh_token" in resp.cookies
+
+    async def test_wrong_password_returns_401(
+        self,
+        user_repo: InMemoryUserRepository,
+        client: AsyncClient,
+    ) -> None:
+        """Wrong password returns 401."""
+        user = _make_user()
+        user_repo.add(user)
+
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/login",
+                json={"email": "user@example.com", "password": "wrong-password"},
+            )
+
+        assert resp.status_code == 401
+
+    async def test_nonexistent_user_returns_401(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Nonexistent email returns 401."""
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/login",
+                json={"email": "noone@example.com", "password": "any"},
+            )
+
+        assert resp.status_code == 401
+
+    async def test_invalid_email_returns_422(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Invalid email format returns 422."""
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/login",
+                json={"email": "not-an-email", "password": "any"},
+            )
+
+        assert resp.status_code == 422
+
+    async def test_deactivated_user_returns_403(
+        self,
+        user_repo: InMemoryUserRepository,
+        client: AsyncClient,
+    ) -> None:
+        """Deactivated user returns 403."""
+        user = _make_user(is_active=False)
+        user_repo.add(user)
+
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/login",
+                json={"email": "user@example.com", "password": "correct-password"},
+            )
+
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /auth/refresh
+# ---------------------------------------------------------------------------
+
+
+class TestRefresh:
+    """Tests for POST /auth/refresh."""
+
+    async def test_successful_refresh_returns_new_token(
+        self,
+        user_repo: InMemoryUserRepository,
+        refresh_repo: InMemoryRefreshTokenRepository,
+        client: AsyncClient,
+    ) -> None:
+        """Successful refresh returns new access token and rotates cookie."""
+        user = _make_user()
+        user_repo.add(user)
+
+        # Create a refresh token
+        raw_token = generate_token()
+        record = RefreshTokenRecord(
+            id=str(uuid.uuid4()),
+            token_hash=hash_token(raw_token),
+            user_id=str(user.id.value),
+            token_family_id=str(uuid.uuid4()),
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+            is_revoked=False,
+            created_at=datetime.now(UTC),
+        )
+        await refresh_repo.save(record)
+
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/refresh",
+                cookies={"refresh_token": raw_token},
+                headers={"origin": "http://localhost:5173"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+
+    async def test_missing_cookie_returns_401(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Missing refresh cookie returns 401."""
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/refresh",
+                headers={"origin": "http://localhost:5173"},
+            )
+
+        assert resp.status_code == 401
+
+    async def test_missing_origin_returns_403(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Missing Origin header returns 403 (CSRF protection)."""
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/refresh",
+                cookies={"refresh_token": "some-token"},
+            )
+
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /auth/logout
+# ---------------------------------------------------------------------------
+
+
+class TestLogout:
+    """Tests for POST /auth/logout."""
+
+    async def test_successful_logout(
+        self,
+        refresh_repo: InMemoryRefreshTokenRepository,
+        client: AsyncClient,
+    ) -> None:
+        """Logout revokes token and deletes cookie."""
+        raw_token = generate_token()
+        record = RefreshTokenRecord(
+            id=str(uuid.uuid4()),
+            token_hash=hash_token(raw_token),
+            user_id=str(uuid.uuid4()),
+            token_family_id=str(uuid.uuid4()),
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+            is_revoked=False,
+            created_at=datetime.now(UTC),
+        )
+        await refresh_repo.save(record)
+
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/logout",
+                cookies={"refresh_token": raw_token},
+                headers={"origin": "http://localhost:5173"},
+            )
+
+        assert resp.status_code == 204
+
+    async def test_logout_without_cookie_succeeds(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Logout without a cookie still returns 204."""
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/logout",
+                headers={"origin": "http://localhost:5173"},
+            )
+
+        assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /auth/set-password
+# ---------------------------------------------------------------------------
+
+
+class TestSetPassword:
+    """Tests for POST /auth/set-password."""
+
+    async def test_successful_set_password(
+        self,
+        user_repo: InMemoryUserRepository,
+        invitation_repo: InMemoryInvitationTokenRepository,
+        client: AsyncClient,
+    ) -> None:
+        """Valid invitation token allows password setting."""
+        user = User(
+            id=UserId.generate(),
+            name="Invited User",
+            email="invited@example.com",
+            role=UserRole.MEMBER,
+        )
+        user_repo.add(user)
+
+        # Create invitation
+        use_case = CreateInvitationUseCase(
+            user_repo=user_repo,
+            invitation_token_repo=invitation_repo,
+        )
+        output = await use_case.execute(CreateInvitationInput(user_id=user.id))
+
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/set-password",
+                json={"token": output.token, "password": "new-password-123"},
+                headers={"origin": "http://localhost:5173"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["message"] == "Password set successfully"
+
+    async def test_invalid_token_returns_400(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Invalid invitation token returns 400."""
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/set-password",
+                json={"token": "bad-token", "password": "password123"},
+                headers={"origin": "http://localhost:5173"},
+            )
+
+        assert resp.status_code == 400
+
+    async def test_short_password_returns_422(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Password shorter than 8 characters returns 422."""
+        with _patch_settings():
+            resp = await client.post(
+                "/auth/set-password",
+                json={"token": "any-token", "password": "short"},
+                headers={"origin": "http://localhost:5173"},
+            )
+
+        assert resp.status_code == 422

--- a/backend/tests/api/test_system_router.py
+++ b/backend/tests/api/test_system_router.py
@@ -216,6 +216,46 @@ class TestSetupFirstUser:
         assert response.status_code == 409
 
     @pytest.mark.asyncio
+    async def test_setup_with_password_stores_hash(
+        self,
+        client: AsyncClient,
+        user_repo: InMemoryUserRepository,
+    ) -> None:
+        """POST /system/setup with password stores the password hash."""
+        response = await client.post(
+            "/system/setup",
+            json={
+                "name": "Admin",
+                "email": "admin@example.com",
+                "password": "secure-password-123",
+            },
+        )
+
+        assert response.status_code == 201
+
+        saved = await user_repo.get_by_email("admin@example.com")
+        assert saved is not None
+        assert saved.has_password is True
+
+        from foundation.auth.password import verify_password
+
+        assert verify_password("secure-password-123", saved.password_hash)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_setup_rejects_short_password(self, client: AsyncClient) -> None:
+        """POST /system/setup returns 422 for password shorter than 8 chars."""
+        response = await client.post(
+            "/system/setup",
+            json={
+                "name": "Admin",
+                "email": "admin@example.com",
+                "password": "short",
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
     async def test_setup_rejects_invalid_email(self, client: AsyncClient) -> None:
         """POST /system/setup returns 422 for invalid email."""
         response = await client.post(

--- a/backend/tests/api/test_system_router_integration.py
+++ b/backend/tests/api/test_system_router_integration.py
@@ -59,3 +59,39 @@ class TestSetupFirstUserIntegration:
         # Cleanup
         async with async_session_factory() as session:
             await _cleanup(session)
+
+    async def test_setup_with_password_stores_hash(self) -> None:
+        """POST /system/setup with password stores a password hash."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Ensure clean state
+            async with async_session_factory() as session:
+                await _cleanup(session)
+
+            response = await client.post(
+                "/system/setup",
+                json={
+                    "name": "Admin",
+                    "email": "admin@example.com",
+                    "password": "secure-password-123",
+                },
+            )
+            assert response.status_code == 201
+            data = response.json()
+            assert data["name"] == "Admin"
+            assert data["role"] == "admin"
+
+            # Verify the password hash was stored by attempting to login
+            login_resp = await client.post(
+                "/auth/login",
+                json={
+                    "email": "admin@example.com",
+                    "password": "secure-password-123",
+                },
+            )
+            assert login_resp.status_code == 200
+            assert "access_token" in login_resp.json()
+
+        # Cleanup
+        async with async_session_factory() as session:
+            await _cleanup(session)

--- a/backend/tests/foundation/auth/use_cases/test_create_invitation_use_case.py
+++ b/backend/tests/foundation/auth/use_cases/test_create_invitation_use_case.py
@@ -1,0 +1,61 @@
+"""Tests for CreateInvitationUseCase."""
+
+from __future__ import annotations
+
+import pytest
+
+from foundation.auth.in_memory_invitation_token_repository import (
+    InMemoryInvitationTokenRepository,
+)
+from foundation.auth.use_cases.create_invitation_use_case import (
+    CreateInvitationInput,
+    CreateInvitationUseCase,
+    UserNotFoundError,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+def _make_user(user_id: UserId | None = None) -> User:
+    return User(
+        id=user_id or UserId.generate(),
+        name="Test User",
+        email="user@example.com",
+        role=UserRole.MEMBER,
+    )
+
+
+class TestCreateInvitation:
+    """Tests for CreateInvitationUseCase."""
+
+    async def test_creates_invitation_token(self) -> None:
+        """Creates an invitation token for an existing user."""
+        user = _make_user()
+        user_repo = InMemoryUserRepository(users=[user])
+        invitation_repo = InMemoryInvitationTokenRepository()
+
+        use_case = CreateInvitationUseCase(
+            user_repo=user_repo,
+            invitation_token_repo=invitation_repo,
+        )
+
+        output = await use_case.execute(CreateInvitationInput(user_id=user.id))
+
+        assert output.token
+        assert output.expires_at is not None
+        # Verify a record was stored
+        assert len(invitation_repo._records) == 1
+
+    async def test_user_not_found_raises(self) -> None:
+        """Raises UserNotFoundError for nonexistent user."""
+        user_repo = InMemoryUserRepository()
+        invitation_repo = InMemoryInvitationTokenRepository()
+
+        use_case = CreateInvitationUseCase(
+            user_repo=user_repo,
+            invitation_token_repo=invitation_repo,
+        )
+
+        with pytest.raises(UserNotFoundError):
+            await use_case.execute(CreateInvitationInput(user_id=UserId.generate()))

--- a/backend/tests/foundation/auth/use_cases/test_login_use_case.py
+++ b/backend/tests/foundation/auth/use_cases/test_login_use_case.py
@@ -1,0 +1,185 @@
+"""Tests for LoginUseCase."""
+
+from __future__ import annotations
+
+import pytest
+
+from foundation.auth.in_memory_login_attempt_repository import (
+    InMemoryLoginAttemptRepository,
+)
+from foundation.auth.in_memory_refresh_token_repository import (
+    InMemoryRefreshTokenRepository,
+)
+from foundation.auth.password import hash_password
+from foundation.auth.use_cases.login_use_case import (
+    AccountDeactivatedError,
+    AccountLockedError,
+    InvalidCredentialsError,
+    LoginInput,
+    LoginUseCase,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import (
+    InMemoryUserRepository,
+)
+
+_SECRET = "test-secret-key-for-unit-tests-32chars!"
+_ACCESS_EXPIRE = 30
+_REFRESH_EXPIRE = 7
+_IP = "127.0.0.1"
+
+
+def _login(
+    email: str = "user@example.com",
+    password: str = "correct-password",
+) -> LoginInput:
+    return LoginInput(email=email, password=password, ip_address=_IP)
+
+
+def _make_user(
+    *,
+    email: str = "user@example.com",
+    password: str = "correct-password",
+    is_active: bool = True,
+    role: UserRole = UserRole.MEMBER,
+) -> User:
+    return User(
+        id=UserId.generate(),
+        name="Test User",
+        email=email,
+        role=role,
+        is_active=is_active,
+        password_hash=hash_password(password),
+    )
+
+
+def _make_use_case(
+    user_repo: InMemoryUserRepository,
+    refresh_repo: InMemoryRefreshTokenRepository | None = None,
+    login_attempt_repo: InMemoryLoginAttemptRepository | None = None,
+) -> LoginUseCase:
+    return LoginUseCase(
+        user_repo=user_repo,
+        refresh_token_repo=(refresh_repo or InMemoryRefreshTokenRepository()),
+        login_attempt_repo=(login_attempt_repo or InMemoryLoginAttemptRepository()),
+        jwt_secret_key=_SECRET,
+        access_token_expire_minutes=_ACCESS_EXPIRE,
+        refresh_token_expire_days=_REFRESH_EXPIRE,
+    )
+
+
+class TestLoginSuccess:
+    """Tests for successful login."""
+
+    async def test_returns_tokens(self) -> None:
+        """Successful login returns access and refresh tokens."""
+        user = _make_user()
+        repo = InMemoryUserRepository(users=[user])
+        use_case = _make_use_case(repo)
+
+        output = await use_case.execute(_login())
+
+        assert output.access_token
+        assert output.refresh_token
+        assert output.user_id == str(user.id.value)
+
+    async def test_records_successful_attempt(self) -> None:
+        """Successful login records a success attempt."""
+        user = _make_user()
+        repo = InMemoryUserRepository(users=[user])
+        attempts = InMemoryLoginAttemptRepository()
+        use_case = _make_use_case(repo, login_attempt_repo=attempts)
+
+        await use_case.execute(_login())
+
+        assert len(attempts._records) == 1
+        assert attempts._records[0].is_success is True
+
+    async def test_stores_refresh_token(self) -> None:
+        """Successful login stores a refresh token record."""
+        user = _make_user()
+        repo = InMemoryUserRepository(users=[user])
+        refresh_repo = InMemoryRefreshTokenRepository()
+        use_case = _make_use_case(repo, refresh_repo=refresh_repo)
+
+        await use_case.execute(_login())
+
+        assert len(refresh_repo._records) == 1
+
+
+class TestLoginFailure:
+    """Tests for login failures."""
+
+    async def test_wrong_password_raises(self) -> None:
+        """Wrong password raises InvalidCredentialsError."""
+        user = _make_user()
+        repo = InMemoryUserRepository(users=[user])
+        use_case = _make_use_case(repo)
+
+        with pytest.raises(InvalidCredentialsError):
+            await use_case.execute(_login(password="wrong-password"))
+
+    async def test_nonexistent_user_raises(self) -> None:
+        """Nonexistent email raises InvalidCredentialsError."""
+        repo = InMemoryUserRepository()
+        use_case = _make_use_case(repo)
+
+        with pytest.raises(InvalidCredentialsError):
+            await use_case.execute(_login(email="noone@example.com", password="any"))
+
+    async def test_user_without_password_raises(self) -> None:
+        """User with no password hash raises InvalidCredentialsError."""
+        user = User(
+            id=UserId.generate(),
+            name="No Password",
+            email="nopass@example.com",
+            role=UserRole.MEMBER,
+        )
+        repo = InMemoryUserRepository(users=[user])
+        use_case = _make_use_case(repo)
+
+        with pytest.raises(InvalidCredentialsError):
+            await use_case.execute(_login(email="nopass@example.com", password="any"))
+
+    async def test_deactivated_user_raises(self) -> None:
+        """Deactivated user raises AccountDeactivatedError."""
+        user = _make_user(is_active=False)
+        repo = InMemoryUserRepository(users=[user])
+        use_case = _make_use_case(repo)
+
+        with pytest.raises(AccountDeactivatedError):
+            await use_case.execute(_login())
+
+    async def test_records_failed_attempt(self) -> None:
+        """Failed login records a failure attempt."""
+        user = _make_user()
+        repo = InMemoryUserRepository(users=[user])
+        attempts = InMemoryLoginAttemptRepository()
+        use_case = _make_use_case(repo, login_attempt_repo=attempts)
+
+        with pytest.raises(InvalidCredentialsError):
+            await use_case.execute(_login(password="wrong"))
+
+        assert len(attempts._records) == 1
+        assert attempts._records[0].is_success is False
+
+
+class TestAccountLockout:
+    """Tests for account lockout after too many failed attempts."""
+
+    async def test_lockout_after_10_failures(self) -> None:
+        """Account is locked after 10 consecutive failures."""
+        user = _make_user()
+        repo = InMemoryUserRepository(users=[user])
+        attempts = InMemoryLoginAttemptRepository()
+        use_case = _make_use_case(repo, login_attempt_repo=attempts)
+
+        # Fail 10 times
+        for _ in range(10):
+            with pytest.raises(InvalidCredentialsError):
+                await use_case.execute(_login(password="wrong"))
+
+        # 11th attempt should be locked even with correct password
+        with pytest.raises(AccountLockedError):
+            await use_case.execute(_login())

--- a/backend/tests/foundation/auth/use_cases/test_logout_use_case.py
+++ b/backend/tests/foundation/auth/use_cases/test_logout_use_case.py
@@ -1,0 +1,65 @@
+"""Tests for LogoutUseCase."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from foundation.auth.in_memory_refresh_token_repository import (
+    InMemoryRefreshTokenRepository,
+)
+from foundation.auth.refresh_token_repository import RefreshTokenRecord
+from foundation.auth.token_hash import generate_token, hash_token
+from foundation.auth.use_cases.logout_use_case import LogoutUseCase
+
+
+def _make_refresh_record(
+    user_id: str,
+    raw_token: str,
+    *,
+    family_id: str | None = None,
+) -> RefreshTokenRecord:
+    return RefreshTokenRecord(
+        id=str(uuid.uuid4()),
+        token_hash=hash_token(raw_token),
+        user_id=user_id,
+        token_family_id=family_id or str(uuid.uuid4()),
+        expires_at=datetime.now(UTC) + timedelta(days=7),
+        is_revoked=False,
+        created_at=datetime.now(UTC),
+    )
+
+
+class TestLogoutUseCase:
+    """Tests for LogoutUseCase."""
+
+    async def test_revokes_token_family(self) -> None:
+        """Logout revokes the entire token family."""
+        family_id = str(uuid.uuid4())
+        raw_token = generate_token()
+        record = _make_refresh_record("user-1", raw_token, family_id=family_id)
+
+        # Add a second token in the same family
+        raw_token2 = generate_token()
+        record2 = _make_refresh_record("user-1", raw_token2, family_id=family_id)
+
+        repo = InMemoryRefreshTokenRepository()
+        await repo.save(record)
+        await repo.save(record2)
+
+        use_case = LogoutUseCase(refresh_token_repo=repo)
+        await use_case.execute(raw_token)
+
+        # Both tokens should be revoked
+        r1 = await repo.find_by_token_hash(hash_token(raw_token))
+        r2 = await repo.find_by_token_hash(hash_token(raw_token2))
+        assert r1 is not None and r1.is_revoked is True
+        assert r2 is not None and r2.is_revoked is True
+
+    async def test_unknown_token_is_noop(self) -> None:
+        """Logging out with an unknown token does nothing (no error)."""
+        repo = InMemoryRefreshTokenRepository()
+        use_case = LogoutUseCase(refresh_token_repo=repo)
+
+        # Should not raise
+        await use_case.execute("nonexistent-token")

--- a/backend/tests/foundation/auth/use_cases/test_refresh_use_case.py
+++ b/backend/tests/foundation/auth/use_cases/test_refresh_use_case.py
@@ -1,0 +1,191 @@
+"""Tests for RefreshUseCase."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from foundation.auth.in_memory_refresh_token_repository import (
+    InMemoryRefreshTokenRepository,
+)
+from foundation.auth.refresh_token_repository import RefreshTokenRecord
+from foundation.auth.token_hash import generate_token, hash_token
+from foundation.auth.use_cases.refresh_use_case import (
+    InvalidRefreshTokenError,
+    RefreshUseCase,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+_SECRET = "test-secret-key-for-unit-tests-32chars!"
+_ACCESS_EXPIRE = 30
+_REFRESH_EXPIRE = 7
+
+
+def _make_user(
+    user_id: UserId | None = None,
+    *,
+    is_active: bool = True,
+) -> User:
+    return User(
+        id=user_id or UserId.generate(),
+        name="Test User",
+        email="user@example.com",
+        role=UserRole.MEMBER,
+        is_active=is_active,
+    )
+
+
+def _make_refresh_record(
+    user_id: str,
+    raw_token: str,
+    *,
+    is_revoked: bool = False,
+    expires_at: datetime | None = None,
+    family_id: str | None = None,
+) -> RefreshTokenRecord:
+    return RefreshTokenRecord(
+        id=str(uuid.uuid4()),
+        token_hash=hash_token(raw_token),
+        user_id=user_id,
+        token_family_id=family_id or str(uuid.uuid4()),
+        expires_at=expires_at or (datetime.now(UTC) + timedelta(days=7)),
+        is_revoked=is_revoked,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_use_case(
+    user_repo: InMemoryUserRepository,
+    refresh_repo: InMemoryRefreshTokenRepository,
+) -> RefreshUseCase:
+    return RefreshUseCase(
+        user_repo=user_repo,
+        refresh_token_repo=refresh_repo,
+        jwt_secret_key=_SECRET,
+        access_token_expire_minutes=_ACCESS_EXPIRE,
+        refresh_token_expire_days=_REFRESH_EXPIRE,
+    )
+
+
+class TestRefreshSuccess:
+    """Tests for successful token refresh."""
+
+    async def test_returns_new_tokens(self) -> None:
+        """Successful refresh returns new access and refresh tokens."""
+        user = _make_user()
+        raw_token = generate_token()
+        record = _make_refresh_record(str(user.id.value), raw_token)
+
+        user_repo = InMemoryUserRepository(users=[user])
+        refresh_repo = InMemoryRefreshTokenRepository()
+        await refresh_repo.save(record)
+
+        use_case = _make_use_case(user_repo, refresh_repo)
+        output = await use_case.execute(raw_token)
+
+        assert output.access_token
+        assert output.refresh_token
+        assert output.refresh_token != raw_token
+        assert output.user_id == str(user.id.value)
+
+    async def test_old_token_is_revoked(self) -> None:
+        """The old refresh token is revoked after successful refresh."""
+        user = _make_user()
+        raw_token = generate_token()
+        family_id = str(uuid.uuid4())
+        record = _make_refresh_record(
+            str(user.id.value), raw_token, family_id=family_id
+        )
+
+        user_repo = InMemoryUserRepository(users=[user])
+        refresh_repo = InMemoryRefreshTokenRepository()
+        await refresh_repo.save(record)
+
+        use_case = _make_use_case(user_repo, refresh_repo)
+        await use_case.execute(raw_token)
+
+        # The old token should be revoked
+        old_record = await refresh_repo.find_by_token_hash(hash_token(raw_token))
+        assert old_record is not None
+        assert old_record.is_revoked is True
+
+
+class TestRefreshFailure:
+    """Tests for refresh failures."""
+
+    async def test_unknown_token_raises(self) -> None:
+        """Unknown refresh token raises InvalidRefreshTokenError."""
+        user_repo = InMemoryUserRepository()
+        refresh_repo = InMemoryRefreshTokenRepository()
+        use_case = _make_use_case(user_repo, refresh_repo)
+
+        with pytest.raises(InvalidRefreshTokenError, match="not found"):
+            await use_case.execute("nonexistent-token")
+
+    async def test_revoked_token_raises_and_invalidates_family(self) -> None:
+        """Reusing a revoked token raises error and revokes entire family."""
+        user = _make_user()
+        family_id = str(uuid.uuid4())
+
+        raw_old = generate_token()
+        old_record = _make_refresh_record(
+            str(user.id.value), raw_old, family_id=family_id, is_revoked=True
+        )
+
+        raw_new = generate_token()
+        new_record = _make_refresh_record(
+            str(user.id.value), raw_new, family_id=family_id
+        )
+
+        user_repo = InMemoryUserRepository(users=[user])
+        refresh_repo = InMemoryRefreshTokenRepository()
+        await refresh_repo.save(old_record)
+        await refresh_repo.save(new_record)
+
+        use_case = _make_use_case(user_repo, refresh_repo)
+
+        with pytest.raises(InvalidRefreshTokenError, match="revoked"):
+            await use_case.execute(raw_old)
+
+        # Both tokens in the family should be revoked
+        found = await refresh_repo.find_by_token_hash(hash_token(raw_new))
+        assert found is not None
+        assert found.is_revoked is True
+
+    async def test_expired_token_raises(self) -> None:
+        """Expired refresh token raises InvalidRefreshTokenError."""
+        user = _make_user()
+        raw_token = generate_token()
+        record = _make_refresh_record(
+            str(user.id.value),
+            raw_token,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+
+        user_repo = InMemoryUserRepository(users=[user])
+        refresh_repo = InMemoryRefreshTokenRepository()
+        await refresh_repo.save(record)
+
+        use_case = _make_use_case(user_repo, refresh_repo)
+
+        with pytest.raises(InvalidRefreshTokenError, match="expired"):
+            await use_case.execute(raw_token)
+
+    async def test_deactivated_user_raises(self) -> None:
+        """Refresh for a deactivated user raises InvalidRefreshTokenError."""
+        user = _make_user(is_active=False)
+        raw_token = generate_token()
+        record = _make_refresh_record(str(user.id.value), raw_token)
+
+        user_repo = InMemoryUserRepository(users=[user])
+        refresh_repo = InMemoryRefreshTokenRepository()
+        await refresh_repo.save(record)
+
+        use_case = _make_use_case(user_repo, refresh_repo)
+
+        with pytest.raises(InvalidRefreshTokenError, match="deactivated"):
+            await use_case.execute(raw_token)

--- a/backend/tests/foundation/auth/use_cases/test_set_password_use_case.py
+++ b/backend/tests/foundation/auth/use_cases/test_set_password_use_case.py
@@ -1,0 +1,215 @@
+"""Tests for SetPasswordUseCase."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from foundation.auth.in_memory_invitation_token_repository import (
+    InMemoryInvitationTokenRepository,
+)
+from foundation.auth.in_memory_refresh_token_repository import (
+    InMemoryRefreshTokenRepository,
+)
+from foundation.auth.invitation_token_repository import InvitationTokenRecord
+from foundation.auth.password import verify_password
+from foundation.auth.refresh_token_repository import RefreshTokenRecord
+from foundation.auth.token_hash import generate_token, hash_token
+from foundation.auth.use_cases.set_password_use_case import (
+    InvalidInvitationTokenError,
+    SetPasswordInput,
+    SetPasswordUseCase,
+)
+from shared.domain.user import User
+from shared.domain.value_objects import UserId, UserRole
+from shared.infrastructure.in_memory_user_repository import InMemoryUserRepository
+
+
+def _make_user(user_id: UserId | None = None) -> User:
+    return User(
+        id=user_id or UserId.generate(),
+        name="Test User",
+        email="user@example.com",
+        role=UserRole.MEMBER,
+    )
+
+
+def _make_invitation_record(
+    user_id: str,
+    raw_token: str,
+    *,
+    is_used: bool = False,
+    expires_at: datetime | None = None,
+) -> InvitationTokenRecord:
+    return InvitationTokenRecord(
+        id=str(uuid.uuid4()),
+        token_hash=hash_token(raw_token),
+        user_id=user_id,
+        expires_at=expires_at or (datetime.now(UTC) + timedelta(hours=72)),
+        is_used=is_used,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_use_case(
+    user_repo: InMemoryUserRepository,
+    invitation_repo: InMemoryInvitationTokenRepository,
+    refresh_repo: InMemoryRefreshTokenRepository | None = None,
+) -> SetPasswordUseCase:
+    return SetPasswordUseCase(
+        user_repo=user_repo,
+        invitation_token_repo=invitation_repo,
+        refresh_token_repo=refresh_repo or InMemoryRefreshTokenRepository(),
+    )
+
+
+class TestSetPasswordSuccess:
+    """Tests for successful password setting."""
+
+    async def test_sets_password_hash(self) -> None:
+        """Password is hashed and saved to the user."""
+        user = _make_user()
+        raw_token = generate_token()
+        invitation = _make_invitation_record(str(user.id.value), raw_token)
+
+        user_repo = InMemoryUserRepository(users=[user])
+        invitation_repo = InMemoryInvitationTokenRepository()
+        await invitation_repo.save(invitation)
+
+        use_case = _make_use_case(user_repo, invitation_repo)
+        output = await use_case.execute(
+            SetPasswordInput(token=raw_token, password="new-password-123")
+        )
+
+        assert output.user_id == str(user.id.value)
+
+        # Verify password was set
+        saved_user = await user_repo.get_by_id(user.id)
+        assert saved_user is not None
+        assert saved_user.has_password is True
+        assert verify_password("new-password-123", saved_user.password_hash)  # type: ignore[arg-type]
+
+    async def test_marks_invitation_as_used(self) -> None:
+        """Invitation token is marked as used after password is set."""
+        user = _make_user()
+        raw_token = generate_token()
+        invitation = _make_invitation_record(str(user.id.value), raw_token)
+
+        user_repo = InMemoryUserRepository(users=[user])
+        invitation_repo = InMemoryInvitationTokenRepository()
+        await invitation_repo.save(invitation)
+
+        use_case = _make_use_case(user_repo, invitation_repo)
+        await use_case.execute(
+            SetPasswordInput(token=raw_token, password="new-password-123")
+        )
+
+        found = await invitation_repo.find_by_token_hash(hash_token(raw_token))
+        assert found is not None
+        assert found.is_used is True
+
+    async def test_revokes_existing_refresh_tokens(self) -> None:
+        """All refresh tokens for the user are revoked when password is set."""
+        user = _make_user()
+        raw_token = generate_token()
+        invitation = _make_invitation_record(str(user.id.value), raw_token)
+
+        user_repo = InMemoryUserRepository(users=[user])
+        invitation_repo = InMemoryInvitationTokenRepository()
+        await invitation_repo.save(invitation)
+
+        # Create existing refresh token
+        refresh_repo = InMemoryRefreshTokenRepository()
+        existing_refresh = RefreshTokenRecord(
+            id=str(uuid.uuid4()),
+            token_hash=hash_token("old-refresh"),
+            user_id=str(user.id.value),
+            token_family_id=str(uuid.uuid4()),
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+            is_revoked=False,
+            created_at=datetime.now(UTC),
+        )
+        await refresh_repo.save(existing_refresh)
+
+        use_case = _make_use_case(user_repo, invitation_repo, refresh_repo)
+        await use_case.execute(
+            SetPasswordInput(token=raw_token, password="new-password-123")
+        )
+
+        # Verify refresh token was revoked
+        found = await refresh_repo.find_by_token_hash(hash_token("old-refresh"))
+        assert found is not None
+        assert found.is_revoked is True
+
+
+class TestSetPasswordFailure:
+    """Tests for set-password failures."""
+
+    async def test_unknown_token_raises(self) -> None:
+        """Unknown invitation token raises InvalidInvitationTokenError."""
+        user_repo = InMemoryUserRepository()
+        invitation_repo = InMemoryInvitationTokenRepository()
+        use_case = _make_use_case(user_repo, invitation_repo)
+
+        with pytest.raises(InvalidInvitationTokenError, match="not found"):
+            await use_case.execute(
+                SetPasswordInput(token="nonexistent", password="password123")
+            )
+
+    async def test_used_token_raises(self) -> None:
+        """Already-used invitation token raises InvalidInvitationTokenError."""
+        user = _make_user()
+        raw_token = generate_token()
+        invitation = _make_invitation_record(
+            str(user.id.value), raw_token, is_used=True
+        )
+
+        user_repo = InMemoryUserRepository(users=[user])
+        invitation_repo = InMemoryInvitationTokenRepository()
+        await invitation_repo.save(invitation)
+
+        use_case = _make_use_case(user_repo, invitation_repo)
+
+        with pytest.raises(InvalidInvitationTokenError, match="already been used"):
+            await use_case.execute(
+                SetPasswordInput(token=raw_token, password="password123")
+            )
+
+    async def test_expired_token_raises(self) -> None:
+        """Expired invitation token raises InvalidInvitationTokenError."""
+        user = _make_user()
+        raw_token = generate_token()
+        invitation = _make_invitation_record(
+            str(user.id.value),
+            raw_token,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+
+        user_repo = InMemoryUserRepository(users=[user])
+        invitation_repo = InMemoryInvitationTokenRepository()
+        await invitation_repo.save(invitation)
+
+        use_case = _make_use_case(user_repo, invitation_repo)
+
+        with pytest.raises(InvalidInvitationTokenError, match="expired"):
+            await use_case.execute(
+                SetPasswordInput(token=raw_token, password="password123")
+            )
+
+    async def test_user_not_found_raises(self) -> None:
+        """Token for nonexistent user raises InvalidInvitationTokenError."""
+        raw_token = generate_token()
+        invitation = _make_invitation_record(str(uuid.uuid4()), raw_token)
+
+        user_repo = InMemoryUserRepository()
+        invitation_repo = InMemoryInvitationTokenRepository()
+        await invitation_repo.save(invitation)
+
+        use_case = _make_use_case(user_repo, invitation_repo)
+
+        with pytest.raises(InvalidInvitationTokenError, match="User not found"):
+            await use_case.execute(
+                SetPasswordInput(token=raw_token, password="password123")
+            )

--- a/backend/tests/shared/application/test_setup_first_user_use_case.py
+++ b/backend/tests/shared/application/test_setup_first_user_use_case.py
@@ -127,3 +127,40 @@ async def test_setup_first_user_raises_when_already_complete(
     # Verify UoW was NOT committed (rolled back via __aexit__)
     assert uow.committed is False
     assert uow.rolled_back is True
+
+
+@pytest.mark.asyncio
+async def test_setup_with_password_stores_hash(
+    use_case: SetupFirstUserUseCase,
+    user_repo: InMemoryUserRepository,
+) -> None:
+    """Password is hashed and stored when provided."""
+    output = await use_case.execute(
+        SetupFirstUserInput(
+            name="Admin",
+            email="admin@example.com",
+            password="secure-password-123",
+        )
+    )
+    assert output.role == UserRole.ADMIN
+
+    saved = await user_repo.get_by_email("admin@example.com")
+    assert saved is not None
+    assert saved.has_password is True
+
+    from foundation.auth.password import verify_password
+
+    assert verify_password("secure-password-123", saved.password_hash)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_setup_without_password_has_no_hash(
+    use_case: SetupFirstUserUseCase,
+    user_repo: InMemoryUserRepository,
+) -> None:
+    """When no password is provided, password_hash is None."""
+    await use_case.execute(SetupFirstUserInput(name="Admin", email="admin@example.com"))
+
+    saved = await user_repo.get_by_email("admin@example.com")
+    assert saved is not None
+    assert saved.has_password is False

--- a/frontend/src/features/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/features/auth/__tests__/LoginPage.test.tsx
@@ -1,0 +1,239 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { LoginPage } from "../pages/LoginPage";
+import * as auth from "@/api/auth";
+import * as authStore from "@/api/auth-store";
+
+// -- Mocks --------------------------------------------------------------------
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// -- Helpers ------------------------------------------------------------------
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authStore.clearAccessToken();
+  });
+
+  // -- Rendering --------------------------------------------------------------
+
+  it("renders the login form", () => {
+    renderPage();
+    expect(
+      screen.getByText("メールアドレスとパスワードを入力してください"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "ログイン" }),
+    ).toBeInTheDocument();
+  });
+
+  // -- Validation errors -------------------------------------------------------
+
+  it("shows error when email is empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      screen.getByText("メールアドレスを入力してください"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error when password is empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      screen.getByText("パスワードを入力してください"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Successful login --------------------------------------------------------
+
+  it("calls loginApi and navigates on success", async () => {
+    vi.spyOn(auth, "loginApi").mockResolvedValueOnce({
+      access_token: "test-access-token",
+      token_type: "bearer",
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() => {
+      expect(auth.loginApi).toHaveBeenCalledWith(
+        "user@example.com",
+        "password123",
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    });
+
+    expect(authStore.getAccessToken()).toBe("test-access-token");
+  });
+
+  // -- Login errors ------------------------------------------------------------
+
+  it("shows error message on 401 (invalid credentials)", async () => {
+    vi.spyOn(auth, "loginApi").mockRejectedValueOnce(
+      new auth.LoginError(401, "Invalid email or password"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrong");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      await screen.findByText(
+        "メールアドレスまたはパスワードが正しくありません",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error message on 429 (too many attempts)", async () => {
+    vi.spyOn(auth, "loginApi").mockRejectedValueOnce(
+      new auth.LoginError(429, "Account locked"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      await screen.findByText(
+        "ログイン試行回数が上限に達しました。しばらくしてから再度お試しください",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error message on 403 (deactivated)", async () => {
+    vi.spyOn(auth, "loginApi").mockRejectedValueOnce(
+      new auth.LoginError(403, "Account is deactivated"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      await screen.findByText("アカウントが無効化されています"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows generic error on network failure", async () => {
+    vi.spyOn(auth, "loginApi").mockRejectedValueOnce(
+      new Error("Network error"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "password");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      await screen.findByText("ログインに失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Clears error on input ---------------------------------------------------
+
+  it("clears error when user types in email field", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+    expect(
+      screen.getByText("メールアドレスを入力してください"),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("メールアドレス"), "a");
+    expect(
+      screen.queryByText("メールアドレスを入力してください"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears error when user types in password field", async () => {
+    vi.spyOn(auth, "loginApi").mockRejectedValueOnce(
+      new auth.LoginError(401, "Invalid"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "user@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrong");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await screen.findByText("メールアドレスまたはパスワードが正しくありません");
+
+    await user.type(screen.getByLabelText("パスワード"), "x");
+    expect(
+      screen.queryByText("メールアドレスまたはパスワードが正しくありません"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/auth/__tests__/SetPasswordPage.test.tsx
+++ b/frontend/src/features/auth/__tests__/SetPasswordPage.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SetPasswordPage } from "../pages/SetPasswordPage";
+import * as auth from "@/api/auth";
+
+// -- Mocks --------------------------------------------------------------------
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// -- Helpers ------------------------------------------------------------------
+
+function renderPage(initialRoute = "/set-password?token=valid-token") {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Routes>
+        <Route path="/set-password" element={<SetPasswordPage />} />
+        <Route path="/login" element={<div>Login Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("SetPasswordPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -- No token ---------------------------------------------------------------
+
+  it("shows invalid link message when token is missing", () => {
+    renderPage("/set-password");
+    expect(
+      screen.getByText(
+        "招待リンクが無効です。管理者に新しい招待リンクを発行してもらってください。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  // -- Rendering with token ---------------------------------------------------
+
+  it("renders the password form when token is present", () => {
+    renderPage();
+    expect(
+      screen.getByText("新しいパスワードを設定してください"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード（確認）")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "パスワードを設定" }),
+    ).toBeInTheDocument();
+  });
+
+  // -- Validation errors -------------------------------------------------------
+
+  it("shows error when password is empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    expect(
+      screen.getByText("パスワードを入力してください"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error when password is too short", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("パスワード"), "short");
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    expect(
+      screen.getByText("パスワードは8文字以上で入力してください"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error when passwords do not match", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.type(
+      screen.getByLabelText("パスワード（確認）"),
+      "different123",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    expect(screen.getByText("パスワードが一致しません")).toBeInTheDocument();
+  });
+
+  // -- Successful submission ---------------------------------------------------
+
+  it("calls setPasswordApi and shows completion on success", async () => {
+    vi.spyOn(auth, "setPasswordApi").mockResolvedValueOnce({
+      message: "Password set successfully",
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("パスワード"), "new-password-123");
+    await user.type(
+      screen.getByLabelText("パスワード（確認）"),
+      "new-password-123",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    await waitFor(() => {
+      expect(auth.setPasswordApi).toHaveBeenCalledWith(
+        "valid-token",
+        "new-password-123",
+      );
+    });
+
+    expect(await screen.findByText("パスワード設定完了")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "パスワードが設定されました。ログイン画面からログインしてください。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to login when clicking the login button after completion", async () => {
+    vi.spyOn(auth, "setPasswordApi").mockResolvedValueOnce({
+      message: "Password set successfully",
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("パスワード"), "new-password-123");
+    await user.type(
+      screen.getByLabelText("パスワード（確認）"),
+      "new-password-123",
+    );
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    await screen.findByText("パスワード設定完了");
+
+    await user.click(screen.getByRole("button", { name: "ログイン画面へ" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true });
+  });
+
+  // -- API errors -------------------------------------------------------------
+
+  it("shows API error message on SetPasswordError", async () => {
+    vi.spyOn(auth, "setPasswordApi").mockRejectedValueOnce(
+      new auth.SetPasswordError(400, "Invitation token has expired"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.type(screen.getByLabelText("パスワード（確認）"), "password123");
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    expect(
+      await screen.findByText("Invitation token has expired"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows generic error on unknown failure", async () => {
+    vi.spyOn(auth, "setPasswordApi").mockRejectedValueOnce(
+      new Error("Network error"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText("パスワード"), "password123");
+    await user.type(screen.getByLabelText("パスワード（確認）"), "password123");
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+
+    expect(
+      await screen.findByText("パスワードの設定に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  // -- Clears error on input --------------------------------------------------
+
+  it("clears error when user types in password field", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "パスワードを設定" }));
+    expect(
+      screen.getByText("パスワードを入力してください"),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("パスワード"), "a");
+    expect(
+      screen.queryByText("パスワードを入力してください"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #194（ログイン認証の実装）の PR3 として、認証機能のテスト全面追加を実施。

PR1（バックエンド認証基盤）、PR2（フロントエンド認証フロー）で実装された認証機能に対し、包括的なテストカバレッジを追加する。

## 変更内容

### バックエンド: 認証ユースケーステスト
- **LoginUseCase**: ログイン成功、パスワード不正、未登録ユーザー、パスワード未設定ユーザー、無効化アカウント、失敗記録、10回連続失敗によるアカウントロックアウト
- **RefreshUseCase**: トークンリフレッシュ成功、旧トークン失効確認、不明トークン、失効トークン再利用検知（family全失効）、期限切れ、無効化ユーザー
- **LogoutUseCase**: ログアウトによるfamily全失効、不明トークンでのnoop動作
- **SetPasswordUseCase**: パスワード設定成功、招待トークンのused化、既存リフレッシュトークン全失効、不明トークン、使用済みトークン、期限切れトークン、ユーザー未存在
- **CreateInvitationUseCase**: 招待トークン生成成功、ユーザー未存在エラー

### バックエンド: 認証ルーターテスト
- **POST /auth/login**: 成功時のアクセストークン・Cookie返却、パスワード不正401、未登録401、不正メール422、無効化アカウント403
- **POST /auth/refresh**: 成功時のトークンローテーション、Cookie不在401、Origin不在403（CSRF保護）
- **POST /auth/logout**: ログアウト成功204、Cookie不在でも204
- **POST /auth/set-password**: 招待トークンによるパスワード設定成功、不正トークン400、短パスワード422

### バックエンド: セットアップテスト更新
- **POST /system/setup**: パスワード付きセットアップでのハッシュ保存テスト（ユニット・インテグレーション）
- **SetupFirstUserUseCase**: パスワード有り・無しの両パターンテスト

### フロントエンド: 認証画面テスト
- **LoginPage**: フォーム表示、バリデーション（空メール・空パスワード）、ログイン成功時のAPI呼び出し・ナビゲーション・トークン保存、エラー表示（401/429/403/ネットワークエラー）、入力時のエラークリア
- **SetPasswordPage**: トークン不在時のエラー表示、フォーム表示、バリデーション（空パスワード・短パスワード・不一致）、パスワード設定成功後の完了画面・ログインナビゲーション、APIエラー表示

### テスト基盤
- `InMemoryRefreshTokenRepository`: リフレッシュトークンのインメモリ実装
- `InMemoryInvitationTokenRepository`: 招待トークンのインメモリ実装
- `InMemoryLoginAttemptRepository`: ログイン試行のインメモリ実装

## テスト計画
- [x] バックエンドユニットテスト全通過（1164テスト、`pytest -m "not integration"`）
- [x] フロントエンドテスト全通過（364テスト、`pnpm test --run`）
- [x] ruff lint / format チェック通過
- [x] pyright 型チェック通過（既知の4件の既存エラーのみ）
- [x] ESLint / Prettier チェック通過
- [ ] インテグレーションテスト（DB接続時に `test_setup_with_password_stores_hash` を含む）

Closes #194