### PR TITLE
fix: SetupGuardをAuthGuardの外側に配置

### DIFF
--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -25,10 +25,10 @@ export const router = createBrowserRouter([
   { path: "set-password", element: <SetPasswordPage /> },
   { path: "setup", element: <SetupPage /> },
   {
-    element: <AuthGuard />,
+    element: <SetupGuard />,
     children: [
       {
-        element: <SetupGuard />,
+        element: <AuthGuard />,
         children: [
           {
             element: <AppLayout />,


### PR DESCRIPTION
## 概要
- 未セットアップ状態で `/` にアクセスすると、AuthGuardが先に評価されて `/login` にリダイレクトされていた
- SetupGuardをAuthGuardの外側に配置し、セットアップ未完了時は `/setup` に正しくリダイレクトされるように修正

## 変更内容
- `routes.tsx`: SetupGuard → AuthGuard の順にネストを変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)