### PR TITLE
インテグレーションテスト: レコード作成・メモ更新・アジェンダ確定

### DIFF
--- a/backend/tests/contexts/record/presentation/test_router_integration.py
+++ b/backend/tests/contexts/record/presentation/test_router_integration.py
@@ -7,9 +7,11 @@ using the real FastAPI app with httpx.AsyncClient.  No DI overrides are used.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from api.event_setup import create_event_dispatcher
@@ -21,6 +23,11 @@ from tests.helpers import auth_headers, create_test_user
 pytestmark = pytest.mark.integration
 
 _BASE_URL = "http://test"
+
+
+def _future(days: int = 30) -> str:
+    """Return an ISO 8601 timestamp ``days`` into the future (UTC)."""
+    return (datetime.now(UTC) + timedelta(days=days)).isoformat()
 
 
 async def _new_user(session_factory: async_sessionmaker[AsyncSession]) -> str:
@@ -481,3 +488,269 @@ class TestMarkRecordAsViewedIntegration:
 
         assert response1.status_code == 200
         assert response2.status_code == 200
+
+
+# -----------------------------------------------------------------------
+# POST /records/from-schedule
+# -----------------------------------------------------------------------
+
+
+class TestCreateRecordFromScheduleAuth:
+    """POST /records/from-schedule -- authentication checks."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without Authorization header returns 401."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                "/records/from-schedule",
+                json={
+                    "schedule_id": str(uuid.uuid4()),
+                    "conducted_at": _future(0),
+                },
+            )
+
+        assert response.status_code == 401
+
+
+class TestCreateRecordFromSchedule:
+    """POST /records/from-schedule -- record creation from schedule."""
+
+    async def test_creates_record_and_returns_201(
+        self,
+        app,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Creating a record from a schedule returns 201 and persists the row."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # First create a schedule via the preparation API
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            schedule_resp = await client.post(
+                "/schedules",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "scheduled_at": _future(30),
+                    "title": "Record from schedule test",
+                },
+            )
+        assert schedule_resp.status_code == 201
+        schedule_id = schedule_resp.json()["schedule_id"]
+
+        # Create record from schedule
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                "/records/from-schedule",
+                headers=auth_headers(organizer_id),
+                json={
+                    "schedule_id": schedule_id,
+                    "conducted_at": _future(0),
+                },
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        record_id = data["record_id"]
+        uuid.UUID(record_id)  # validates UUID format
+
+        # Verify DB: record row exists and is linked to the schedule
+        async with session_factory() as s:
+            from contexts.record.infrastructure.tables import RecordTable
+
+            result = await s.execute(
+                select(RecordTable).where(RecordTable.id == record_id)
+            )
+            row = result.scalar_one()
+            assert row.schedule_id == schedule_id
+            assert row.organizer_id == organizer_id
+            assert row.counterpart_id == cp_id
+            assert row.status == "draft"
+
+    async def test_returns_404_for_nonexistent_schedule(
+        self, app, user_id: str
+    ) -> None:
+        """Creating a record from a nonexistent schedule returns 404."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                "/records/from-schedule",
+                headers=auth_headers(user_id),
+                json={
+                    "schedule_id": str(uuid.uuid4()),
+                    "conducted_at": _future(0),
+                },
+            )
+
+        assert response.status_code == 404
+
+
+# -----------------------------------------------------------------------
+# PUT /records/{id}/memo
+# -----------------------------------------------------------------------
+
+
+class TestUpdateMemoAuth:
+    """PUT /records/{id}/memo -- authentication checks."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without Authorization header returns 401."""
+        record_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.put(
+                f"/records/{record_id}/memo",
+                json={"memo": "some text"},
+            )
+
+        assert response.status_code == 401
+
+
+class TestUpdateMemo:
+    """PUT /records/{id}/memo -- memo update."""
+
+    async def test_updates_memo_and_returns_200(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Updating a memo returns 200 and persists the new memo in DB."""
+        counterpart_id = await _new_user(session_factory)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Create a record first
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(user_id),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            record_id = create_response.json()["record_id"]
+
+            # Update memo
+            response = await client.put(
+                f"/records/{record_id}/memo",
+                headers=auth_headers(user_id),
+                json={"memo": "Updated memo content"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["record_id"] == record_id
+
+        # Verify DB: memo is updated
+        async with session_factory() as s:
+            from contexts.record.infrastructure.tables import RecordTable
+
+            result = await s.execute(
+                select(RecordTable).where(RecordTable.id == record_id)
+            )
+            row = result.scalar_one()
+            assert row.memo == "Updated memo content"
+
+    async def test_returns_404_for_nonexistent_record(self, app, user_id: str) -> None:
+        """Updating a memo for a nonexistent record returns 404."""
+        record_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.put(
+                f"/records/{record_id}/memo",
+                headers=auth_headers(user_id),
+                json={"memo": "some text"},
+            )
+
+        assert response.status_code == 404
+
+
+# -----------------------------------------------------------------------
+# POST /records/{id}/agendas/{agenda_id}/confirm
+# -----------------------------------------------------------------------
+
+
+class TestConfirmAgendaAuth:
+    """POST /records/{id}/agendas/{agenda_id}/confirm -- authentication checks."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without Authorization header returns 401."""
+        record_id = str(uuid.uuid4())
+        agenda_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                f"/records/{record_id}/agendas/{agenda_id}/confirm",
+            )
+
+        assert response.status_code == 401
+
+
+class TestConfirmAgenda:
+    """POST /records/{id}/agendas/{agenda_id}/confirm -- agenda confirmation."""
+
+    async def test_confirms_agenda_and_returns_200(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Confirming an agenda returns 200 and persists the confirmed state in DB."""
+        counterpart_id = await _new_user(session_factory)
+        agenda_id = str(uuid.uuid4())
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Create a record first
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(user_id),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            record_id = create_response.json()["record_id"]
+
+            # Confirm agenda
+            response = await client.post(
+                f"/records/{record_id}/agendas/{agenda_id}/confirm",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["record_id"] == record_id
+        assert data["agenda_id"] == agenda_id
+
+        # Verify DB: confirmed agenda row exists
+        async with session_factory() as s:
+            from contexts.record.infrastructure.tables import (
+                RecordConfirmedAgendaTable,
+            )
+
+            result = await s.execute(
+                select(RecordConfirmedAgendaTable).where(
+                    RecordConfirmedAgendaTable.record_id == record_id,
+                    RecordConfirmedAgendaTable.agenda_id == agenda_id,
+                )
+            )
+            row = result.scalar_one()
+            assert row.record_id == record_id
+            assert row.agenda_id == agenda_id
+
+    async def test_returns_404_for_nonexistent_record(self, app, user_id: str) -> None:
+        """Confirming an agenda for a nonexistent record returns 404."""
+        record_id = str(uuid.uuid4())
+        agenda_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                f"/records/{record_id}/agendas/{agenda_id}/confirm",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 404


### PR DESCRIPTION
## 概要

Record コンテキストの以下のエンドポイントに対するインテグレーションテストを追加しました。

- `POST /records/from-schedule` — スケジュールからのレコード作成（201 + DB検証、404）
- `PUT /records/{id}/memo` — メモ更新（200 + DB検証、404）
- `POST /records/{id}/agendas/{agenda_id}/confirm` — アジェンダ確定（200 + DB検証、404）

## 実装内容

- 全テストに `@pytest.mark.integration` を付与
- DI override を使わず、実際の JWT 認証フローを通す
- DB 検証は別セッションからの SELECT で実施
- テストで固定日付をハードコードせず `_future()` ヘルパーで相対的な未来時刻を使用
- 認証なしリクエストの 401 チェックも各エンドポイントに追加

## テスト結果

全 26 テスト（既存 17 + 新規 9）がパスすることを確認済み。

Closes #213