### PR TITLE
UnitOfWork を自動 commit 方式に変更する

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -49,6 +49,7 @@ Reviewer からのレビュー指摘が prompt で渡されます。以下の手
 `docs/coding-standards.md` を必ず読んで従うこと。特に以下は厳守:
 
 - **DDD レイヤー依存ルール**: ユースケース・ルーターでインフラ具象を直接 import しない。DI プロバイダー経由で注入
+- **UnitOfWork 自動 commit**: `async with uow:` ブロック終了時に自動 commit される。use case 内で明示的に `await uow.commit()` を呼ばないこと
 - **命名規則**: UseCase / QueryService の使い分け、ファイル名規則
 - **カラートークン**: ハードコード色禁止、`:root` と `.dark` の両方に定義
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -61,5 +61,6 @@ preload された review-pr スキルのレビュー観点に従ってくださ�
 `docs/coding-standards.md` に基づき、以下を必ず確認する:
 
 - **DDD レイヤー依存**: ユースケース・ルーターでインフラ具象を直接 import していないか（`dependencies.py` 経由であること）
+- **UnitOfWork 自動 commit**: use case 内で明示的に `await uow.commit()` を呼んでいないか（`__aexit__` で自動 commit されるため不要）
 - **命名規則**: UseCase / QueryService の使い分け、ファイル名規則に準拠しているか
 - **カラートークン**: ハードコード色が使われていないか、`:root` と `.dark` の両方に定義されているか

--- a/backend/contexts/notification/application/mark_notification_as_read.py
+++ b/backend/contexts/notification/application/mark_notification_as_read.py
@@ -71,4 +71,3 @@ class MarkNotificationAsReadUseCase:
             record.mark_as_read(now=now)
 
             await self._notification_record_repository.save(record)
-            await self._unit_of_work.commit()

--- a/backend/contexts/notification/application/update_notification_setting.py
+++ b/backend/contexts/notification/application/update_notification_setting.py
@@ -88,7 +88,6 @@ class UpdateNotificationSettingUseCase:
 
             await self._notification_setting_repository.save(setting)
             events: list[DomainEvent] = list(setting.collect_events())
-            await self._unit_of_work.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/preparation/application/accept_consultation_request_use_case.py
+++ b/backend/contexts/preparation/application/accept_consultation_request_use_case.py
@@ -89,6 +89,5 @@ class AcceptConsultationRequestUseCase:
 
         async with self._uow:
             await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/add_agenda_comment_use_case.py
+++ b/backend/contexts/preparation/application/add_agenda_comment_use_case.py
@@ -127,7 +127,6 @@ class AddAgendaCommentUseCase:
 
         async with self._uow:
             await self._agenda_repo.save(agenda)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/preparation/application/add_agenda_to_group_use_case.py
+++ b/backend/contexts/preparation/application/add_agenda_to_group_use_case.py
@@ -94,6 +94,5 @@ class AddAgendaToGroupUseCase:
             await self._schedule_group_repo.save(group)
             if new_agendas:
                 await self._agenda_repo.save_all(new_agendas)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(all_events)

--- a/backend/contexts/preparation/application/add_agenda_use_case.py
+++ b/backend/contexts/preparation/application/add_agenda_use_case.py
@@ -122,7 +122,6 @@ class AddAgendaUseCase:
 
         async with self._uow:
             await self._agenda_repo.save(agenda)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/preparation/application/cancel_schedule_group_use_case.py
+++ b/backend/contexts/preparation/application/cancel_schedule_group_use_case.py
@@ -99,6 +99,5 @@ class CancelScheduleGroupUseCase:
         async with self._uow:
             for schedule in schedules:
                 await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(all_events)

--- a/backend/contexts/preparation/application/cancel_schedule_use_case.py
+++ b/backend/contexts/preparation/application/cancel_schedule_use_case.py
@@ -71,6 +71,5 @@ class CancelScheduleUseCase:
 
         async with self._uow:
             await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/create_schedule_group_from_past_use_case.py
+++ b/backend/contexts/preparation/application/create_schedule_group_from_past_use_case.py
@@ -164,7 +164,6 @@ class CreateScheduleGroupFromPastUseCase:
                 await self._schedule_repo.save(schedule)
             if all_agendas:
                 await self._agenda_repo.save_all(all_agendas)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(all_events)
 

--- a/backend/contexts/preparation/application/create_schedule_group_from_template_use_case.py
+++ b/backend/contexts/preparation/application/create_schedule_group_from_template_use_case.py
@@ -170,7 +170,6 @@ class CreateScheduleGroupFromTemplateUseCase:
                 await self._schedule_repo.save(schedule)
             if all_agendas:
                 await self._agenda_repo.save_all(all_agendas)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(all_events)
 

--- a/backend/contexts/preparation/application/create_schedule_group_use_case.py
+++ b/backend/contexts/preparation/application/create_schedule_group_use_case.py
@@ -146,7 +146,6 @@ class CreateScheduleGroupUseCase:
                 await self._schedule_repo.save(schedule)
             if all_agendas:
                 await self._agenda_repo.save_all(all_agendas)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(all_events)
 

--- a/backend/contexts/preparation/application/create_schedule_use_case.py
+++ b/backend/contexts/preparation/application/create_schedule_use_case.py
@@ -83,7 +83,6 @@ class CreateScheduleUseCase:
 
         async with self._uow:
             await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/preparation/application/delete_agenda_use_case.py
+++ b/backend/contexts/preparation/application/delete_agenda_use_case.py
@@ -110,6 +110,5 @@ class DeleteAgendaUseCase:
 
         async with self._uow:
             await self._agenda_repo.delete_by_ids([agenda.id])
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/reject_consultation_request_use_case.py
+++ b/backend/contexts/preparation/application/reject_consultation_request_use_case.py
@@ -91,6 +91,5 @@ class RejectConsultationRequestUseCase:
 
         async with self._uow:
             await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/remove_agenda_from_group_use_case.py
+++ b/backend/contexts/preparation/application/remove_agenda_from_group_use_case.py
@@ -94,6 +94,5 @@ class RemoveAgendaFromGroupUseCase:
             await self._schedule_group_repo.save(group)
             if removed_ids:
                 await self._agenda_repo.delete_by_ids(removed_ids)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(all_events)

--- a/backend/contexts/preparation/application/rename_schedule_group_use_case.py
+++ b/backend/contexts/preparation/application/rename_schedule_group_use_case.py
@@ -96,6 +96,5 @@ class RenameScheduleGroupUseCase:
             await self._schedule_group_repo.save(group)
             for schedule in schedules:
                 await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(all_events)

--- a/backend/contexts/preparation/application/rename_schedule_use_case.py
+++ b/backend/contexts/preparation/application/rename_schedule_use_case.py
@@ -83,6 +83,5 @@ class RenameScheduleUseCase:
 
         async with self._uow:
             await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/reschedule_use_case.py
+++ b/backend/contexts/preparation/application/reschedule_use_case.py
@@ -78,6 +78,5 @@ class RescheduleUseCase:
 
         async with self._uow:
             await self._schedule_repo.save(schedule)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/preparation/application/save_template_use_case.py
+++ b/backend/contexts/preparation/application/save_template_use_case.py
@@ -80,7 +80,6 @@ class SaveTemplateUseCase:
         async with self._uow:
             await self._template_repo.save(template)
             events = list(template.collect_events())
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/preparation/application/send_consultation_request_use_case.py
+++ b/backend/contexts/preparation/application/send_consultation_request_use_case.py
@@ -119,7 +119,6 @@ class SendConsultationRequestUseCase:
             await self._schedule_repo.save(schedule)
             if agendas:
                 await self._agenda_repo.save_all(agendas)
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/record/application/add_action_item.py
+++ b/backend/contexts/record/application/add_action_item.py
@@ -85,7 +85,6 @@ class AddActionItemUseCase:
             )
 
             await self._action_item_repository.save(action_item)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(action_item.collect_events())

--- a/backend/contexts/record/application/add_comment.py
+++ b/backend/contexts/record/application/add_comment.py
@@ -117,7 +117,6 @@ class AddCommentUseCase:
 
             await self._comment_repository.save(comment)
             await self._record_repository.save(record)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(comment.collect_events())

--- a/backend/contexts/record/application/complete_action_item.py
+++ b/backend/contexts/record/application/complete_action_item.py
@@ -77,7 +77,6 @@ class CompleteActionItemUseCase:
             action_item.complete(actor_id=input_dto.actor_id, now=now)
 
             await self._action_item_repository.save(action_item)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(action_item.collect_events())

--- a/backend/contexts/record/application/confirm_agenda.py
+++ b/backend/contexts/record/application/confirm_agenda.py
@@ -79,7 +79,6 @@ class ConfirmAgendaUseCase:
             )
 
             await self._record_repository.save(record)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(record.collect_events())

--- a/backend/contexts/record/application/create_post_hoc_record.py
+++ b/backend/contexts/record/application/create_post_hoc_record.py
@@ -87,7 +87,6 @@ class CreatePostHocRecordUseCase:
             )
 
             await self._record_repository.save(record)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(record.collect_events())

--- a/backend/contexts/record/application/create_record_from_schedule.py
+++ b/backend/contexts/record/application/create_record_from_schedule.py
@@ -114,7 +114,6 @@ class CreateRecordFromScheduleUseCase:
             )
 
             await self._record_repository.save(record)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         all_events: list[DomainEvent] = list(record.collect_events())

--- a/backend/contexts/record/application/delete_action_item.py
+++ b/backend/contexts/record/application/delete_action_item.py
@@ -80,9 +80,7 @@ class DeleteActionItemUseCase:
         self._unit_of_work = unit_of_work
         self._event_dispatcher = event_dispatcher
 
-    async def execute(
-        self, input_dto: DeleteActionItemInput
-    ) -> DeleteActionItemOutput:
+    async def execute(self, input_dto: DeleteActionItemInput) -> DeleteActionItemOutput:
         now = datetime.now(UTC)
 
         async with self._unit_of_work:
@@ -111,7 +109,6 @@ class DeleteActionItemUseCase:
                 raise ActionItemNotFoundError(input_dto.action_item_id)
 
             await self._action_item_repository.delete(input_dto.action_item_id)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = [

--- a/backend/contexts/record/application/mark_record_as_viewed.py
+++ b/backend/contexts/record/application/mark_record_as_viewed.py
@@ -87,4 +87,3 @@ class MarkRecordAsViewedUseCase:
             )
 
             await self._read_status_repository.upsert(read_status)
-            await self._unit_of_work.commit()

--- a/backend/contexts/record/application/publish_record.py
+++ b/backend/contexts/record/application/publish_record.py
@@ -84,7 +84,6 @@ class PublishRecordUseCase:
             )
 
             await self._record_repository.save(record)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(record.collect_events())

--- a/backend/contexts/record/application/save_draft.py
+++ b/backend/contexts/record/application/save_draft.py
@@ -79,7 +79,6 @@ class SaveDraftUseCase:
             )
 
             await self._record_repository.save(record)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(record.collect_events())

--- a/backend/contexts/record/application/set_viewers.py
+++ b/backend/contexts/record/application/set_viewers.py
@@ -118,8 +118,6 @@ class SetViewersUseCase:
                     user_id=viewer_id,
                 )
 
-            await self._unit_of_work.commit()
-
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(record.collect_events())
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/record/application/update_memo.py
+++ b/backend/contexts/record/application/update_memo.py
@@ -78,7 +78,6 @@ class UpdateMemoUseCase:
             )
 
             await self._record_repository.save(record)
-            await self._unit_of_work.commit()
 
         # Dispatch events after successful commit
         events: list[DomainEvent] = list(record.collect_events())

--- a/backend/contexts/workspace/application/add_member_use_case.py
+++ b/backend/contexts/workspace/application/add_member_use_case.py
@@ -87,7 +87,6 @@ class AddMemberUseCase:
             )
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/workspace/application/change_member_role_use_case.py
+++ b/backend/contexts/workspace/application/change_member_role_use_case.py
@@ -73,6 +73,5 @@ class ChangeMemberRoleUseCase:
             )
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/workspace/application/change_workspace_parent_use_case.py
+++ b/backend/contexts/workspace/application/change_workspace_parent_use_case.py
@@ -95,6 +95,5 @@ class ChangeWorkspaceParentUseCase:
             workspace.change_parent(new_parent_id=input_dto.new_parent_id, now=now)
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/workspace/application/create_workspace_use_case.py
+++ b/backend/contexts/workspace/application/create_workspace_use_case.py
@@ -84,7 +84,6 @@ class CreateWorkspaceUseCase:
 
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)
 

--- a/backend/contexts/workspace/application/remove_member_use_case.py
+++ b/backend/contexts/workspace/application/remove_member_use_case.py
@@ -67,6 +67,5 @@ class RemoveMemberUseCase:
             workspace.remove_member(user_id=input_dto.user_id, now=now)
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/contexts/workspace/application/rename_workspace_use_case.py
+++ b/backend/contexts/workspace/application/rename_workspace_use_case.py
@@ -63,6 +63,5 @@ class RenameWorkspaceUseCase:
             workspace.rename(new_name=input_dto.new_name, now=now)
             await self._workspace_repo.save(workspace)
             events: list[DomainEvent] = list(workspace.collect_events())
-            await self._uow.commit()
 
         await self._event_dispatcher.dispatch(events)

--- a/backend/foundation/application/unit_of_work.py
+++ b/backend/foundation/application/unit_of_work.py
@@ -7,15 +7,17 @@ from types import TracebackType
 class UnitOfWork(ABC):
     """Abstract base class for the Unit of Work pattern.
 
-    Designed to be used as an async context manager::
+    Designed to be used as an async context manager.  On normal exit
+    the transaction is **automatically committed**; on exception it is
+    rolled back::
 
         async with uow:
             repo.save(entity)
-            await uow.commit()
+        # auto-commit here
 
     ``commit()`` performs only the database commit.  Event dispatching
-    should be done explicitly by the application service after a
-    successful commit.
+    should be done explicitly by the application service after the
+    context manager block.
     """
 
     @abstractmethod
@@ -37,4 +39,7 @@ class UnitOfWork(ABC):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """Exit the async context, rolling back on unhandled exceptions."""
+        """Exit the async context.
+
+        Auto-commits on normal exit; rolls back on unhandled exceptions.
+        """

--- a/backend/foundation/auth/use_cases/create_invitation_use_case.py
+++ b/backend/foundation/auth/use_cases/create_invitation_use_case.py
@@ -65,6 +65,5 @@ class CreateInvitationUseCase:
                 created_at=now,
             )
             await self._invitation_token_repo.save(record)
-            await self._uow.commit()
 
         return CreateInvitationOutput(token=raw_token, expires_at=expires_at)

--- a/backend/foundation/infrastructure/sqlalchemy_unit_of_work.py
+++ b/backend/foundation/infrastructure/sqlalchemy_unit_of_work.py
@@ -54,4 +54,8 @@ class SqlAlchemyUnitOfWork(UnitOfWork):
         if exc_type is not None:
             await self.rollback()
         else:
-            await self.commit()
+            try:
+                await self.commit()
+            except BaseException:
+                await self.rollback()
+                raise

--- a/backend/foundation/infrastructure/sqlalchemy_unit_of_work.py
+++ b/backend/foundation/infrastructure/sqlalchemy_unit_of_work.py
@@ -18,12 +18,12 @@ class SqlAlchemyUnitOfWork(UnitOfWork):
         uow = SqlAlchemyUnitOfWork(session)
         async with uow:
             # repositories use the same session
-            await uow.commit()
+        # auto-commit here
 
     The UoW relies on SQLAlchemy's *autobegin* behaviour -- ``__aenter__``
-    does **not** call ``begin()`` explicitly.  On context-manager exit, any
-    uncommitted changes are rolled back automatically if an exception
-    propagates.
+    does **not** call ``begin()`` explicitly.  On normal exit the
+    transaction is committed automatically.  On exception exit, any
+    uncommitted changes are rolled back.
     """
 
     def __init__(self, session: AsyncSession) -> None:
@@ -53,3 +53,5 @@ class SqlAlchemyUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()

--- a/backend/shared/application/activate_user_use_case.py
+++ b/backend/shared/application/activate_user_use_case.py
@@ -43,7 +43,6 @@ class ActivateUserUseCase:
 
             user.activate()
             await self._user_repo.save(user)
-            await self._uow.commit()
 
         return ActivateUserOutput(
             id=user.id,

--- a/backend/shared/application/create_user_use_case.py
+++ b/backend/shared/application/create_user_use_case.py
@@ -53,7 +53,6 @@ class CreateUserUseCase:
                 role=input_dto.role,
             )
             await self._user_repo.save(user)
-            await self._uow.commit()
 
         return CreateUserOutput(
             id=user.id,

--- a/backend/shared/application/deactivate_user_use_case.py
+++ b/backend/shared/application/deactivate_user_use_case.py
@@ -53,7 +53,6 @@ class DeactivateUserUseCase:
 
             user.deactivate()
             await self._user_repo.save(user)
-            await self._uow.commit()
 
         return DeactivateUserOutput(
             id=user.id,

--- a/backend/shared/application/setup_first_user_use_case.py
+++ b/backend/shared/application/setup_first_user_use_case.py
@@ -76,8 +76,6 @@ class SetupFirstUserUseCase:
             settings.mark_setup_complete(now)
             await self._system_settings_repo.save(settings)
 
-            await self._uow.commit()
-
         return SetupFirstUserOutput(
             id=user.id,
             name=user.name,

--- a/backend/shared/application/update_my_profile_use_case.py
+++ b/backend/shared/application/update_my_profile_use_case.py
@@ -54,7 +54,6 @@ class UpdateMyProfileUseCase:
 
             current_user.update_profile(name=input_dto.name, email=input_dto.email)
             await self._user_repo.save(current_user)
-            await self._uow.commit()
 
         return UpdateMyProfileOutput(
             id=current_user.id,

--- a/backend/shared/application/update_user_use_case.py
+++ b/backend/shared/application/update_user_use_case.py
@@ -75,7 +75,6 @@ class UpdateUserUseCase:
             user.update_profile(name=input_dto.name, email=input_dto.email)
             user.change_role(input_dto.role)
             await self._user_repo.save(user)
-            await self._uow.commit()
 
         return UpdateUserOutput(
             id=user.id,

--- a/backend/tests/api/test_system_router.py
+++ b/backend/tests/api/test_system_router.py
@@ -50,6 +50,8 @@ class _FakeUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/contexts/notification/application/conftest.py
+++ b/backend/tests/contexts/notification/application/conftest.py
@@ -86,6 +86,8 @@ class FakeUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()
 
 
 class SpyEventDispatcher(EventDispatcher):

--- a/backend/tests/contexts/preparation/application/conftest.py
+++ b/backend/tests/contexts/preparation/application/conftest.py
@@ -53,6 +53,8 @@ class StubUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()
 
 
 class InMemoryScheduleGroupRepository(ScheduleGroupRepository):

--- a/backend/tests/contexts/record/application/conftest.py
+++ b/backend/tests/contexts/record/application/conftest.py
@@ -315,6 +315,8 @@ class FakeUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()
 
 
 class SpyEventDispatcher(EventDispatcher):

--- a/backend/tests/contexts/workspace/application/conftest.py
+++ b/backend/tests/contexts/workspace/application/conftest.py
@@ -35,6 +35,8 @@ class StubUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()
 
 
 class InMemoryWorkspaceRepository(WorkspaceRepository):

--- a/backend/tests/foundation/infrastructure/test_sqlalchemy_unit_of_work.py
+++ b/backend/tests/foundation/infrastructure/test_sqlalchemy_unit_of_work.py
@@ -53,3 +53,18 @@ class TestSqlAlchemyUnitOfWork:
 
         mock_session.commit.assert_awaited_once()
         mock_session.rollback.assert_not_awaited()
+
+    async def test_aexit_rolls_back_when_commit_fails(self) -> None:
+        """__aexit__ should rollback and re-raise when commit() fails."""
+        mock_session = AsyncMock()
+        mock_session.commit.side_effect = RuntimeError("DB error")
+        uow = SqlAlchemyUnitOfWork(mock_session)
+        await uow.__aenter__()
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="DB error"):
+            await uow.__aexit__(None, None, None)
+
+        mock_session.commit.assert_awaited_once()
+        mock_session.rollback.assert_awaited_once()

--- a/backend/tests/foundation/infrastructure/test_sqlalchemy_unit_of_work.py
+++ b/backend/tests/foundation/infrastructure/test_sqlalchemy_unit_of_work.py
@@ -43,12 +43,13 @@ class TestSqlAlchemyUnitOfWork:
 
         mock_session.rollback.assert_awaited_once()
 
-    async def test_aexit_does_not_rollback_on_normal_exit(self) -> None:
-        """__aexit__ should not rollback on normal (no exception) exit."""
+    async def test_aexit_commits_on_normal_exit(self) -> None:
+        """__aexit__ should auto-commit on normal (no exception) exit."""
         mock_session = AsyncMock()
         uow = SqlAlchemyUnitOfWork(mock_session)
         await uow.__aenter__()
 
         await uow.__aexit__(None, None, None)
 
+        mock_session.commit.assert_awaited_once()
         mock_session.rollback.assert_not_awaited()

--- a/backend/tests/shared/application/fake_unit_of_work.py
+++ b/backend/tests/shared/application/fake_unit_of_work.py
@@ -31,3 +31,5 @@ class FakeUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()

--- a/backend/tests/shared/application/test_setup_first_user_use_case.py
+++ b/backend/tests/shared/application/test_setup_first_user_use_case.py
@@ -44,6 +44,8 @@ class FakeUnitOfWork(UnitOfWork):
     ) -> None:
         if exc_type is not None:
             await self.rollback()
+        else:
+            await self.commit()
 
 
 @pytest.fixture

--- a/backend/tests/shared/presentation/test_users_me_router.py
+++ b/backend/tests/shared/presentation/test_users_me_router.py
@@ -35,7 +35,10 @@ class _NoOpUnitOfWork(UnitOfWork):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        pass
+        if exc_type is not None:
+            await self.rollback()
+        else:
+            await self.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -339,8 +339,10 @@ from contexts.preparation.infrastructure.tables import ScheduleTable  # noqa: F4
 
 ### UnitOfWork + EventDispatcher 統合パターン
 
+- `UnitOfWork` は `async with` ブロックを抜ける際に **自動 commit** する（例外発生時は rollback）
+- use case から明示的に `commit()` を呼ぶ必要はない
 - `UnitOfWork.commit()` は DB commit のみを行い、イベントディスパッチは含まない
-- アプリケーションサービスが commit 後に明示的にイベントをディスパッチする
+- アプリケーションサービスがコンテキストマネージャ終了後にイベントをディスパッチする
 - これにより、DB コミットとイベント処理の責務を分離し、テスト容易性を確保する
 
 ```python
@@ -362,7 +364,7 @@ class PublishRecordUseCase:
             record.publish(actor_id=actor_id, now=datetime.now(UTC))
             await self._record_repo.save(record)
             events = record.collect_events()
-            await self._uow.commit()
+        # __aexit__ で自動 commit される
 
         # commit 成功後にイベントをディスパッチ
         await self._event_dispatcher.dispatch(events)


### PR DESCRIPTION
## Summary
- `UnitOfWork.__aexit__` で例外がなければ自動 commit する方式に変更
- 全 use case（45箇所）から明示的な `await uow.commit()` 呼び出しを削除
- テスト用の FakeUnitOfWork / StubUnitOfWork（7箇所）も同様に更新
- `test_sqlalchemy_unit_of_work.py` の期待動作を自動 commit に更新
- `docs/architecture.md` のコード例・説明を自動 commit 方式に更新
- `.claude/agents/implementer.md` / `reviewer.md` に UoW 自動 commit ルールを追記

## 背景
`commit()` 呼び忘れにより「レスポンスは成功だが DB に反映されない」バグが複数発生（#208, #209）。自動 commit により構造的に防止する。

## Test plan
- [x] ユニットテスト全件パス（1165 passed）
- [ ] インテグレーションテスト（CI で確認）

Closes #229