### PR TITLE
インテグレーションテスト: preparation・record エンドポイント追加 (#212, #215)

### DIFF
--- a/backend/contexts/preparation/presentation/dependencies.py
+++ b/backend/contexts/preparation/presentation/dependencies.py
@@ -50,6 +50,8 @@ from contexts.preparation.infrastructure.sqlalchemy_schedule_repository import (
 from contexts.preparation.infrastructure.sqlalchemy_template_repository import (
     SqlAlchemyTemplateRepository,
 )
+from contexts.record.domain.action_item_repository import ActionItemRepository
+from contexts.record.domain.record_repository import RecordRepository
 from foundation.application.unit_of_work import UnitOfWork
 from foundation.domain.event_dispatcher import EventDispatcher
 
@@ -96,8 +98,6 @@ if TYPE_CHECKING:
     from contexts.record.application.list_pending_action_items import (
         ListPendingActionItemsQueryService,
     )
-    from contexts.record.domain.action_item_repository import ActionItemRepository
-    from contexts.record.domain.record_repository import RecordRepository
 
 
 def get_schedule_repository(

--- a/backend/contexts/preparation/presentation/schemas.py
+++ b/backend/contexts/preparation/presentation/schemas.py
@@ -321,10 +321,10 @@ class AllPendingActionItemSchema(BaseModel):
 
     action_item_id: UUID
     content: str
-    created_at: AwareDatetime
+    created_at: datetime
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: datetime
 
 
 class ListAllPendingActionItemsResponse(BaseModel):

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -277,9 +277,9 @@ class DraftRecordItemSchema(BaseModel):
 
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: datetime
     memo_excerpt: str
-    created_at: AwareDatetime
+    created_at: datetime
     schedule_id: UUID | None
 
 

--- a/backend/tests/contexts/preparation/presentation/test_router_integration.py
+++ b/backend/tests/contexts/preparation/presentation/test_router_integration.py
@@ -623,3 +623,562 @@ class TestGetScheduleDetail:
             )
 
         assert response.status_code == 403
+
+
+# =====================================================================
+# Agenda management -- POST / GET / DELETE agendas
+# =====================================================================
+
+
+class TestAddAgenda:
+    """POST /schedules/{schedule_id}/agendas -- agenda creation."""
+
+    async def test_adds_agenda_and_returns_201(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Adding an agenda returns 201 and persists the row in the DB."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create a schedule first
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            sched_resp = await client.post(
+                "/schedules",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "scheduled_at": _future(30),
+                    "title": "Agenda test",
+                },
+            )
+        assert sched_resp.status_code == 201
+        schedule_id = sched_resp.json()["schedule_id"]
+
+        # Add agenda
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                f"/schedules/{schedule_id}/agendas",
+                headers=auth_headers(organizer_id),
+                json={"topic": "Discuss project timeline"},
+            )
+
+        assert response.status_code == 201
+        agenda_id = response.json()["agenda_id"]
+        uuid.UUID(agenda_id)
+
+        # Verify DB
+        async with session_factory() as s:
+            from contexts.preparation.infrastructure.tables import AgendaTable
+
+            result = await s.execute(
+                select(AgendaTable).where(AgendaTable.id == agenda_id)
+            )
+            row = result.scalar_one()
+            assert row.topic == "Discuss project timeline"
+            assert row.schedule_id == schedule_id
+            assert row.added_by == organizer_id
+
+
+class TestListScheduleAgendas:
+    """GET /schedules/{schedule_id}/agendas -- agenda listing."""
+
+    async def test_returns_agendas_for_schedule(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Listing agendas returns previously added agendas."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create schedule
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            sched_resp = await client.post(
+                "/schedules",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "scheduled_at": _future(30),
+                    "title": "List agenda test",
+                },
+            )
+        assert sched_resp.status_code == 201
+        schedule_id = sched_resp.json()["schedule_id"]
+
+        # Add two agendas
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            resp1 = await client.post(
+                f"/schedules/{schedule_id}/agendas",
+                headers=auth_headers(organizer_id),
+                json={"topic": "Topic A"},
+            )
+            resp2 = await client.post(
+                f"/schedules/{schedule_id}/agendas",
+                headers=auth_headers(organizer_id),
+                json={"topic": "Topic B"},
+            )
+        assert resp1.status_code == 201
+        assert resp2.status_code == 201
+
+        # List agendas
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/schedules/{schedule_id}/agendas",
+                headers=auth_headers(organizer_id),
+            )
+
+        assert response.status_code == 200
+        agendas = response.json()["agendas"]
+        topics = sorted(a["topic"] for a in agendas)
+        assert topics == ["Topic A", "Topic B"]
+
+    async def test_returns_empty_list_when_no_agendas(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """A schedule with no agendas returns an empty list."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create schedule without agendas
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            sched_resp = await client.post(
+                "/schedules",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "scheduled_at": _future(30),
+                    "title": "Empty agenda test",
+                },
+            )
+        assert sched_resp.status_code == 201
+        schedule_id = sched_resp.json()["schedule_id"]
+
+        # List agendas
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/schedules/{schedule_id}/agendas",
+                headers=auth_headers(organizer_id),
+            )
+
+        assert response.status_code == 200
+        assert response.json()["agendas"] == []
+
+
+class TestDeleteAgenda:
+    """DELETE /schedules/{schedule_id}/agendas/{agenda_id} -- agenda deletion."""
+
+    async def test_deletes_agenda_and_returns_204(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Deleting an agenda returns 204 and removes the row from DB."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create schedule
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            sched_resp = await client.post(
+                "/schedules",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "scheduled_at": _future(30),
+                    "title": "Delete agenda test",
+                },
+            )
+        assert sched_resp.status_code == 201
+        schedule_id = sched_resp.json()["schedule_id"]
+
+        # Add agenda
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            add_resp = await client.post(
+                f"/schedules/{schedule_id}/agendas",
+                headers=auth_headers(organizer_id),
+                json={"topic": "To be deleted"},
+            )
+        assert add_resp.status_code == 201
+        agenda_id = add_resp.json()["agenda_id"]
+
+        # Delete agenda
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.delete(
+                f"/schedules/{schedule_id}/agendas/{agenda_id}",
+                headers=auth_headers(organizer_id),
+            )
+
+        assert response.status_code == 204
+
+        # Verify DB: row is gone
+        async with session_factory() as s:
+            from contexts.preparation.infrastructure.tables import AgendaTable
+
+            result = await s.execute(
+                select(AgendaTable).where(AgendaTable.id == agenda_id)
+            )
+            assert result.scalar_one_or_none() is None
+
+
+# =====================================================================
+# Agenda comments -- POST /agendas/{agenda_id}/comments
+# =====================================================================
+
+
+class TestAddAgendaComment:
+    """POST /agendas/{agenda_id}/comments -- comment creation."""
+
+    async def test_adds_comment_and_returns_201(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Adding a comment returns 201 and persists the row in agenda_comments."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create schedule
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            sched_resp = await client.post(
+                "/schedules",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "scheduled_at": _future(30),
+                    "title": "Comment test",
+                },
+            )
+        assert sched_resp.status_code == 201
+        schedule_id = sched_resp.json()["schedule_id"]
+
+        # Add agenda
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            agenda_resp = await client.post(
+                f"/schedules/{schedule_id}/agendas",
+                headers=auth_headers(organizer_id),
+                json={"topic": "Discussion point"},
+            )
+        assert agenda_resp.status_code == 201
+        agenda_id = agenda_resp.json()["agenda_id"]
+
+        # Add comment
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                f"/agendas/{agenda_id}/comments",
+                headers=auth_headers(organizer_id),
+                json={"body": "Let's discuss this first"},
+            )
+
+        assert response.status_code == 201
+        comment_id = response.json()["comment_id"]
+        uuid.UUID(comment_id)
+
+        # Verify DB
+        async with session_factory() as s:
+            from contexts.preparation.infrastructure.tables import AgendaCommentTable
+
+            result = await s.execute(
+                select(AgendaCommentTable).where(AgendaCommentTable.id == comment_id)
+            )
+            row = result.scalar_one()
+            assert row.agenda_id == agenda_id
+            assert row.author_id == organizer_id
+            assert row.body == "Let's discuss this first"
+
+
+# =====================================================================
+# Template detail -- GET /templates/{template_id}
+# =====================================================================
+
+
+class TestGetTemplate:
+    """GET /templates/{template_id} -- template detail retrieval."""
+
+    async def test_returns_template_detail(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Getting a template returns its full details matching DB state."""
+        organizer_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create a template
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            create_resp = await client.post(
+                "/templates",
+                headers=auth_headers(organizer_id),
+                json={
+                    "name": "Detail Template",
+                    "default_counterpart_ids": [],
+                    "agenda_topics": ["Review", "Planning"],
+                },
+            )
+        assert create_resp.status_code == 201
+        template_id = create_resp.json()["template_id"]
+
+        # Get template detail
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/templates/{template_id}",
+                headers=auth_headers(organizer_id),
+            )
+
+        assert response.status_code == 200
+        detail = response.json()
+        assert detail["template_id"] == template_id
+        assert detail["organizer_id"] == organizer_id
+        assert detail["name"] == "Detail Template"
+        assert detail["default_counterpart_ids"] == []
+        assert sorted(detail["agenda_topics"]) == ["Planning", "Review"]
+
+    async def test_returns_404_for_nonexistent_template(
+        self, app, user_id: str
+    ) -> None:
+        """Getting a nonexistent template returns 404."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/templates/{uuid.uuid4()}",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 404
+
+
+# =====================================================================
+# Pending action items -- GET /action-items/pending
+# =====================================================================
+
+
+class TestListAllPendingActionItems:
+    """GET /action-items/pending -- all pending action items."""
+
+    async def test_returns_pending_action_items(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Pending items from a published record are returned."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create a record, add action item, then publish
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            rec_resp = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "conducted_at": _future(0),
+                },
+            )
+        assert rec_resp.status_code == 201
+        record_id = rec_resp.json()["record_id"]
+
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            ai_resp = await client.post(
+                f"/records/{record_id}/action-items",
+                headers=auth_headers(organizer_id),
+                json={"title": "Follow up on metrics"},
+            )
+        assert ai_resp.status_code == 201
+        action_item_id = ai_resp.json()["action_item_id"]
+
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            pub_resp = await client.post(
+                f"/records/{record_id}/publish",
+                headers=auth_headers(organizer_id),
+                json={"viewer_ids": []},
+            )
+        assert pub_resp.status_code == 200
+
+        # Query pending action items
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/action-items/pending",
+                headers=auth_headers(organizer_id),
+            )
+
+        assert response.status_code == 200
+        items = response.json()["items"]
+        returned_ids = [i["action_item_id"] for i in items]
+        assert action_item_id in returned_ids
+
+    async def test_returns_empty_list_when_no_items(
+        self, app, user_id: str
+    ) -> None:
+        """A user with no action items gets an empty list."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/action-items/pending",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 200
+        assert response.json()["items"] == []
+
+
+# =====================================================================
+# Pending action items by counterpart -- GET /action-items/pending/{id}
+# =====================================================================
+
+
+class TestListPendingActionItemsByCounterpart:
+    """GET /action-items/pending/{counterpart_id} -- filtered by counterpart."""
+
+    async def test_filters_by_counterpart(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Only action items for the specified counterpart are returned."""
+        organizer_id = await _new_user(session_factory)
+        cp_a = await _new_user(session_factory)
+        cp_b = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create record with cp_a and add action item
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            rec_a = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(organizer_id),
+                json={"counterpart_id": cp_a, "conducted_at": _future(0)},
+            )
+        assert rec_a.status_code == 201
+        record_a_id = rec_a.json()["record_id"]
+
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            await client.post(
+                f"/records/{record_a_id}/action-items",
+                headers=auth_headers(organizer_id),
+                json={"title": "Item for A"},
+            )
+            pub = await client.post(
+                f"/records/{record_a_id}/publish",
+                headers=auth_headers(organizer_id),
+                json={"viewer_ids": []},
+            )
+        assert pub.status_code == 200
+
+        # Create record with cp_b and add action item
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            rec_b = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(organizer_id),
+                json={"counterpart_id": cp_b, "conducted_at": _future(0)},
+            )
+        assert rec_b.status_code == 201
+        record_b_id = rec_b.json()["record_id"]
+
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            await client.post(
+                f"/records/{record_b_id}/action-items",
+                headers=auth_headers(organizer_id),
+                json={"title": "Item for B"},
+            )
+            pub = await client.post(
+                f"/records/{record_b_id}/publish",
+                headers=auth_headers(organizer_id),
+                json={"viewer_ids": []},
+            )
+        assert pub.status_code == 200
+
+        # Query pending for cp_a only
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                f"/action-items/pending/{cp_a}",
+                headers=auth_headers(organizer_id),
+            )
+
+        assert response.status_code == 200
+        items = response.json()["items"]
+        assert len(items) >= 1
+        counterpart_ids = {i.get("counterpart_id") for i in items}
+        # All returned items should NOT include cp_b's counterpart_id
+        # (this endpoint returns organizer_id, not counterpart_id)
+        titles = [i["content"] for i in items]
+        assert "Item for A" in titles
+        assert "Item for B" not in titles
+
+
+# =====================================================================
+# Last session summary -- GET /records/last-summary
+# =====================================================================
+
+
+class TestGetLastSessionSummary:
+    """GET /records/last-summary -- last session summary."""
+
+    async def test_returns_last_summary(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Published record's summary is returned for the organizer-counterpart pair."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+
+        # Create record, update memo, publish
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            rec_resp = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(organizer_id),
+                json={
+                    "counterpart_id": cp_id,
+                    "conducted_at": _future(0),
+                },
+            )
+        assert rec_resp.status_code == 201
+        record_id = rec_resp.json()["record_id"]
+
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            await client.put(
+                f"/records/{record_id}/memo",
+                headers=auth_headers(organizer_id),
+                json={"memo": "Discussed quarterly goals"},
+            )
+            await client.post(
+                f"/records/{record_id}/publish",
+                headers=auth_headers(organizer_id),
+                json={"viewer_ids": []},
+            )
+
+        # Query last summary
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/records/last-summary",
+                headers=auth_headers(organizer_id),
+                params={
+                    "organizer_id": organizer_id,
+                    "counterpart_id": cp_id,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["record_id"] == record_id
+        assert "Discussed quarterly goals" in data["memo_excerpt"]
+
+    async def test_returns_null_when_no_records(
+        self, app, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Returns null when no published records exist for the pair."""
+        organizer_id = await _new_user(session_factory)
+        cp_id = await _new_user(session_factory)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get(
+                "/records/last-summary",
+                headers=auth_headers(organizer_id),
+                params={
+                    "organizer_id": organizer_id,
+                    "counterpart_id": cp_id,
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json() is None

--- a/backend/tests/contexts/record/presentation/test_router_integration.py
+++ b/backend/tests/contexts/record/presentation/test_router_integration.py
@@ -754,3 +754,264 @@ class TestConfirmAgenda:
             )
 
         assert response.status_code == 404
+
+
+# -----------------------------------------------------------------------
+# POST /records/{id}/save-draft
+# -----------------------------------------------------------------------
+
+
+class TestSaveDraftAuth:
+    """POST /records/{id}/save-draft -- authentication checks."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without Authorization header returns 401."""
+        record_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                f"/records/{record_id}/save-draft",
+            )
+
+        assert response.status_code == 401
+
+
+class TestSaveDraft:
+    """POST /records/{id}/save-draft -- save draft."""
+
+    async def test_saves_draft_and_returns_200(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Saving a draft returns 200 and keeps the record in draft status."""
+        counterpart_id = await _new_user(session_factory)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Create a record
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(user_id),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            record_id = create_response.json()["record_id"]
+
+            # Save as draft
+            response = await client.post(
+                f"/records/{record_id}/save-draft",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 200
+        assert response.json()["record_id"] == record_id
+
+        # Verify DB: status remains draft
+        async with session_factory() as s:
+            from contexts.record.infrastructure.tables import RecordTable
+
+            result = await s.execute(
+                select(RecordTable).where(RecordTable.id == record_id)
+            )
+            row = result.scalar_one()
+            assert row.status == "draft"
+
+    async def test_returns_404_for_nonexistent_record(self, app, user_id: str) -> None:
+        """Saving a draft for a nonexistent record returns 404."""
+        record_id = str(uuid.uuid4())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.post(
+                f"/records/{record_id}/save-draft",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 404
+
+    async def test_returns_409_for_published_record(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Saving a draft for an already published record returns 409."""
+        counterpart_id = await _new_user(session_factory)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Create and publish
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(user_id),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            record_id = create_response.json()["record_id"]
+            await client.post(
+                f"/records/{record_id}/publish",
+                headers=auth_headers(user_id),
+                json={"viewer_ids": []},
+            )
+
+            # Try to save draft
+            response = await client.post(
+                f"/records/{record_id}/save-draft",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 409
+
+    async def test_returns_403_for_non_organizer(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """A non-organizer cannot save a draft."""
+        stranger_id = await _new_user(session_factory)
+        counterpart_id = await _new_user(session_factory)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Create a record as organizer
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(user_id),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            record_id = create_response.json()["record_id"]
+
+            # Stranger tries to save draft
+            response = await client.post(
+                f"/records/{record_id}/save-draft",
+                headers=auth_headers(stranger_id),
+            )
+
+        assert response.status_code == 403
+
+
+# -----------------------------------------------------------------------
+# GET /records/drafts
+# -----------------------------------------------------------------------
+
+
+class TestListDraftsAuth:
+    """GET /records/drafts -- authentication checks."""
+
+    async def test_returns_401_without_auth_header(self, app) -> None:
+        """Request without Authorization header returns 401."""
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            response = await client.get("/records/drafts")
+
+        assert response.status_code == 401
+
+
+class TestListDrafts:
+    """GET /records/drafts -- draft listing."""
+
+    async def test_returns_draft_records(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Draft records are returned in the drafts list."""
+        counterpart_id = await _new_user(session_factory)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Create a record (starts as draft)
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(user_id),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            record_id = create_response.json()["record_id"]
+
+            # List drafts
+            response = await client.get(
+                "/records/drafts",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 200
+        items = response.json()["items"]
+        returned_ids = [i["record_id"] for i in items]
+        assert record_id in returned_ids
+
+    async def test_excludes_published_records(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Published records are not included in the drafts list."""
+        counterpart_id = await _new_user(session_factory)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Create and publish a record
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(user_id),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            published_id = create_response.json()["record_id"]
+            await client.post(
+                f"/records/{published_id}/publish",
+                headers=auth_headers(user_id),
+                json={"viewer_ids": []},
+            )
+
+            # List drafts
+            response = await client.get(
+                "/records/drafts",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 200
+        returned_ids = [i["record_id"] for i in response.json()["items"]]
+        assert published_id not in returned_ids
+
+    async def test_excludes_other_users_drafts(
+        self,
+        app,
+        user_id: str,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Another user's drafts are not visible."""
+        other_user = await _new_user(session_factory)
+        counterpart_id = await _new_user(session_factory)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+            # Other user creates a draft
+            create_response = await client.post(
+                "/records/post-hoc",
+                headers=auth_headers(other_user),
+                json={
+                    "counterpart_id": counterpart_id,
+                    "conducted_at": _future(0),
+                },
+            )
+            other_record_id = create_response.json()["record_id"]
+
+            # Current user lists their drafts
+            response = await client.get(
+                "/records/drafts",
+                headers=auth_headers(user_id),
+            )
+
+        assert response.status_code == 200
+        returned_ids = [i["record_id"] for i in response.json()["items"]]
+        assert other_record_id not in returned_ids


### PR DESCRIPTION
## Summary
- Preparation コンテキスト（アジェンダCRUD、テンプレート詳細、ペンディングアクションアイテム、前回サマリ）に12テスト追加
- Record コンテキスト（save-draft、list-drafts）に9テスト追加
- テスト中に発見した3件の既存バグを修正:
  - `dependencies.py`: `RecordRepository`/`ActionItemRepository` が `TYPE_CHECKING` 内にあり、FastAPIのDI解決が実行時に失敗していた
  - `preparation/schemas.py`: `AllPendingActionItemSchema` の `AwareDatetime` がDBのnaive datetimeと不整合
  - `record/schemas.py`: `DraftRecordItemSchema` の `AwareDatetime` が同様に不整合

## Test plan
- [x] 全21テストが `pytest -m integration` で通過
- [x] 既存ユニットテスト1166件がパス（リグレッションなし）
- [x] 既存インテグレーションテスト全件パス（合計231件）
- [x] ruff / pyright チェック通過

Closes #212
Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)