### PR TITLE
feat: 日時・タイムゾーンポリシーの策定と統一

### DIFF
--- a/backend/contexts/notification/infrastructure/sqlalchemy_notification_record_repository.py
+++ b/backend/contexts/notification/infrastructure/sqlalchemy_notification_record_repository.py
@@ -14,6 +14,7 @@ from contexts.notification.domain.value_objects import (
     NotificationType,
 )
 from contexts.notification.infrastructure.tables import NotificationRecordTable
+from foundation.datetime_utils import to_aware_utc, to_aware_utc_optional, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -62,13 +63,13 @@ class SqlAlchemyNotificationRecordRepository(NotificationRecordRepository):
                 body=record.body,
                 link=record.link,
                 is_read=record.is_read,
-                read_at=record.read_at,
-                created_at=record.created_at,
+                read_at=(to_naive_utc(record.read_at) if record.read_at else None),
+                created_at=to_naive_utc(record.created_at),
             )
             self._session.add(row)
         else:
             existing.is_read = record.is_read
-            existing.read_at = record.read_at
+            existing.read_at = to_naive_utc(record.read_at) if record.read_at else None
 
         await self._session.flush()
 
@@ -82,6 +83,6 @@ class SqlAlchemyNotificationRecordRepository(NotificationRecordRepository):
             body=row.body,
             link=row.link,
             _is_read=row.is_read,
-            _read_at=row.read_at,
-            created_at=row.created_at,
+            _read_at=to_aware_utc_optional(row.read_at),
+            created_at=to_aware_utc(row.created_at),
         )

--- a/backend/contexts/notification/infrastructure/sqlalchemy_notification_setting_repository.py
+++ b/backend/contexts/notification/infrastructure/sqlalchemy_notification_setting_repository.py
@@ -10,6 +10,7 @@ from contexts.notification.domain.notification_setting_repository import (
     NotificationSettingRepository,
 )
 from contexts.notification.infrastructure.tables import NotificationSettingTable
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -42,14 +43,14 @@ class SqlAlchemyNotificationSettingRepository(NotificationSettingRepository):
                 user_id=str(entity.user_id.value),
                 reminder_minutes_before=entity.reminder_minutes_before,
                 is_enabled=entity.is_enabled,
-                created_at=entity.created_at,
-                updated_at=entity.updated_at,
+                created_at=to_naive_utc(entity.created_at),
+                updated_at=to_naive_utc(entity.updated_at),
             )
             self._session.add(row)
         else:
             existing.reminder_minutes_before = entity.reminder_minutes_before
             existing.is_enabled = entity.is_enabled
-            existing.updated_at = entity.updated_at
+            existing.updated_at = to_naive_utc(entity.updated_at)
 
         await self._session.flush()
 
@@ -59,6 +60,6 @@ class SqlAlchemyNotificationSettingRepository(NotificationSettingRepository):
             user_id=UserId.from_str(row.user_id),
             _reminder_minutes_before=row.reminder_minutes_before,
             _is_enabled=row.is_enabled,
-            created_at=row.created_at,
-            _updated_at=row.updated_at,
+            created_at=to_aware_utc(row.created_at),
+            _updated_at=to_aware_utc(row.updated_at),
         )

--- a/backend/contexts/notification/infrastructure/sqlalchemy_reminder_log_repository.py
+++ b/backend/contexts/notification/infrastructure/sqlalchemy_reminder_log_repository.py
@@ -12,6 +12,7 @@ from contexts.notification.domain.reminder_log_repository import ReminderLogRepo
 from contexts.notification.domain.value_objects import ReminderLogId
 from contexts.notification.infrastructure.tables import ReminderLogTable
 from contexts.preparation.domain.value_objects import ScheduleId
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -30,7 +31,7 @@ class SqlAlchemyReminderLogRepository(ReminderLogRepository):
         stmt = select(ReminderLogTable.id).where(
             ReminderLogTable.schedule_id == str(schedule_id.value),
             ReminderLogTable.user_id == str(user_id.value),
-            ReminderLogTable.scheduled_at == scheduled_at,
+            ReminderLogTable.scheduled_at == to_naive_utc(scheduled_at),
         )
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none() is not None
@@ -40,8 +41,8 @@ class SqlAlchemyReminderLogRepository(ReminderLogRepository):
             id=str(log.id.value),
             schedule_id=str(log.schedule_id.value),
             user_id=str(log.user_id.value),
-            scheduled_at=log.scheduled_at,
-            sent_at=log.sent_at,
+            scheduled_at=to_naive_utc(log.scheduled_at),
+            sent_at=to_naive_utc(log.sent_at),
             reminder_minutes_before=log.reminder_minutes_before,
         )
         self._session.add(row)
@@ -53,7 +54,7 @@ class SqlAlchemyReminderLogRepository(ReminderLogRepository):
             id=ReminderLogId.from_str(row.id),
             schedule_id=ScheduleId.from_str(row.schedule_id),
             user_id=UserId.from_str(row.user_id),
-            scheduled_at=row.scheduled_at,
-            _sent_at=row.sent_at,
+            scheduled_at=to_aware_utc(row.scheduled_at),
+            _sent_at=to_aware_utc(row.sent_at),
             _reminder_minutes_before=row.reminder_minutes_before,
         )

--- a/backend/contexts/notification/presentation/schemas.py
+++ b/backend/contexts/notification/presentation/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel
+from pydantic import AwareDatetime, BaseModel, Field
 
 
 class NotificationSettingResponse(BaseModel):
@@ -32,8 +32,15 @@ class NotificationRecordResponse(BaseModel):
     body: str
     link: str | None
     is_read: bool
-    read_at: AwareDatetime | None
-    created_at: AwareDatetime
+    read_at: AwareDatetime | None = Field(
+        default=None,
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class NotificationListResponse(BaseModel):

--- a/backend/contexts/notification/presentation/schemas.py
+++ b/backend/contexts/notification/presentation/schemas.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import AwareDatetime, BaseModel
 
 
 class NotificationSettingResponse(BaseModel):
@@ -33,8 +32,8 @@ class NotificationRecordResponse(BaseModel):
     body: str
     link: str | None
     is_read: bool
-    read_at: datetime | None
-    created_at: datetime
+    read_at: AwareDatetime | None
+    created_at: AwareDatetime
 
 
 class NotificationListResponse(BaseModel):

--- a/backend/contexts/notification/presentation/schemas.py
+++ b/backend/contexts/notification/presentation/schemas.py
@@ -33,7 +33,6 @@ class NotificationRecordResponse(BaseModel):
     link: str | None
     is_read: bool
     read_at: AwareDatetime | None = Field(
-        default=None,
         description="Returned in UTC.",
         json_schema_extra={"example": "2026-03-29T06:30:00Z"},
     )

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_agenda_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_agenda_repository.py
@@ -20,6 +20,7 @@ from contexts.preparation.infrastructure.tables import (
     AgendaCommentTable,
     AgendaTable,
 )
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -85,36 +86,38 @@ class SqlAlchemyAgendaRepository(AgendaRepository):
     # ------------------------------------------------------------------
 
     async def _insert(self, entity: Agenda) -> None:
+        created_naive = to_naive_utc(entity.created_at)
         agenda_row = AgendaTable(
             id=str(entity.id.value),
             schedule_id=str(entity.schedule_id.value),
             topic=entity.topic.value,
             added_by=str(entity.added_by.value),
             added_by_tag=entity.added_by_tag.value,
-            created_at=entity.created_at,
-            updated_at=entity.created_at,
+            created_at=created_naive,
+            updated_at=created_naive,
         )
         for comment in entity.comments:
+            comment_created_naive = to_naive_utc(comment.created_at)
             comment_row = AgendaCommentTable(
                 id=str(comment.id.value),
                 agenda_id=str(entity.id.value),
                 author_id=str(comment.author_id.value),
                 body=comment.body.value,
-                created_at=comment.created_at,
-                updated_at=comment.created_at,
+                created_at=comment_created_naive,
+                updated_at=comment_created_naive,
             )
             agenda_row.comments.append(comment_row)
         self._session.add(agenda_row)
         await self._session.flush()
 
     async def _update(self, entity: Agenda, existing: AgendaTable) -> None:
-        now = datetime.now(UTC)
+        now_naive = to_naive_utc(datetime.now(UTC))
 
         existing.schedule_id = str(entity.schedule_id.value)
         existing.topic = entity.topic.value
         existing.added_by = str(entity.added_by.value)
         existing.added_by_tag = entity.added_by_tag.value
-        existing.updated_at = now
+        existing.updated_at = now_naive
 
         # Reconcile comments
         existing_comment_map: dict[str, AgendaCommentTable] = {
@@ -129,15 +132,16 @@ class SqlAlchemyAgendaRepository(AgendaRepository):
                 db_comment = existing_comment_map[comment_id]
                 db_comment.author_id = str(comment.author_id.value)
                 db_comment.body = comment.body.value
-                db_comment.updated_at = now
+                db_comment.updated_at = now_naive
             else:
+                comment_created_naive = to_naive_utc(comment.created_at)
                 new_comment = AgendaCommentTable(
                     id=comment_id,
                     agenda_id=str(entity.id.value),
                     author_id=str(comment.author_id.value),
                     body=comment.body.value,
-                    created_at=comment.created_at,
-                    updated_at=comment.created_at,
+                    created_at=comment_created_naive,
+                    updated_at=comment_created_naive,
                 )
                 existing.comments.append(new_comment)
 
@@ -155,7 +159,7 @@ class SqlAlchemyAgendaRepository(AgendaRepository):
                 _agenda_id=AgendaId.from_str(c.agenda_id),
                 _author_id=UserId.from_str(c.author_id),
                 _body=CommentBody(c.body),
-                _created_at=c.created_at,
+                _created_at=to_aware_utc(c.created_at),
             )
             for c in row.comments
         ]
@@ -166,5 +170,5 @@ class SqlAlchemyAgendaRepository(AgendaRepository):
             _added_by=UserId.from_str(row.added_by),
             _added_by_tag=AddedByTag(row.added_by_tag),
             _comments=comments,
-            _created_at=row.created_at,
+            _created_at=to_aware_utc(row.created_at),
         )

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_group_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_group_repository.py
@@ -22,6 +22,7 @@ from contexts.preparation.infrastructure.tables import (
     ScheduleGroupTable,
     ScheduleTable,
 )
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -70,13 +71,14 @@ class SqlAlchemyScheduleGroupRepository(ScheduleGroupRepository):
         return [ScheduleId.from_str(row[0]) for row in result.fetchall()]
 
     async def _insert(self, entity: ScheduleGroup) -> None:
+        created_naive = to_naive_utc(entity.created_at)
         group_row = ScheduleGroupTable(
             id=str(entity.id.value),
             organizer_id=str(entity.organizer_id.value),
             template_id=(str(entity.template_id.value) if entity.template_id else None),
             title=entity.title.value,
-            created_at=entity.created_at,
-            updated_at=entity.updated_at,
+            created_at=created_naive,
+            updated_at=to_naive_utc(entity.updated_at),
         )
         for position, at in enumerate(entity.agenda_templates):
             at_row = ScheduleGroupAgendaTemplateTable(
@@ -84,8 +86,8 @@ class SqlAlchemyScheduleGroupRepository(ScheduleGroupRepository):
                 schedule_group_id=str(entity.id.value),
                 topic=at.topic.value,
                 position=position,
-                created_at=entity.created_at,
-                updated_at=entity.created_at,
+                created_at=created_naive,
+                updated_at=created_naive,
             )
             group_row.agenda_templates.append(at_row)
         self._session.add(group_row)
@@ -94,14 +96,14 @@ class SqlAlchemyScheduleGroupRepository(ScheduleGroupRepository):
     async def _update(
         self, entity: ScheduleGroup, existing: ScheduleGroupTable
     ) -> None:
-        now = datetime.now(UTC)
+        now_naive = to_naive_utc(datetime.now(UTC))
 
         existing.organizer_id = str(entity.organizer_id.value)
         existing.template_id = (
             str(entity.template_id.value) if entity.template_id else None
         )
         existing.title = entity.title.value
-        existing.updated_at = now
+        existing.updated_at = now_naive
 
         # AgendaTemplates: full delete + re-insert
         # (position-ordered list, IDs have no meaning)
@@ -114,8 +116,8 @@ class SqlAlchemyScheduleGroupRepository(ScheduleGroupRepository):
                 schedule_group_id=str(entity.id.value),
                 topic=at.topic.value,
                 position=position,
-                created_at=now,
-                updated_at=now,
+                created_at=now_naive,
+                updated_at=now_naive,
             )
             existing.agenda_templates.append(new_row)
 
@@ -137,6 +139,6 @@ class SqlAlchemyScheduleGroupRepository(ScheduleGroupRepository):
             _title=ScheduleTitle(row.title),
             _agenda_templates=agenda_templates,
             _schedule_ids=schedule_ids,
-            created_at=row.created_at,
-            _updated_at=row.updated_at,
+            created_at=to_aware_utc(row.created_at),
+            _updated_at=to_aware_utc(row.updated_at),
         )

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_schedule_repository.py
@@ -21,6 +21,7 @@ from contexts.preparation.infrastructure.tables import (
     ConfirmationRequestTable,
     ScheduleTable,
 )
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -57,6 +58,7 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
     ) -> list[Schedule]:
         user_id_str = str(user_id.value)
         status_values = [s.value for s in statuses]
+        now_naive = to_naive_utc(now)
         stmt = (
             select(ScheduleTable)
             .where(
@@ -65,7 +67,7 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
                     ScheduleTable.counterpart_id == user_id_str,
                 ),
                 ScheduleTable.status.in_(status_values),
-                ScheduleTable.scheduled_at >= now,
+                ScheduleTable.scheduled_at >= now_naive,
             )
             .order_by(ScheduleTable.scheduled_at.asc())
             .limit(limit)
@@ -77,10 +79,11 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
     async def list_confirmed_upcoming(
         self, now: datetime, lookahead_minutes: int
     ) -> list[Schedule]:
-        upper = now + timedelta(minutes=lookahead_minutes)
+        now_naive = to_naive_utc(now)
+        upper = now_naive + timedelta(minutes=lookahead_minutes)
         stmt = select(ScheduleTable).where(
             ScheduleTable.status == ScheduleStatus.CONFIRMED.value,
-            ScheduleTable.scheduled_at > now,
+            ScheduleTable.scheduled_at > now_naive,
             ScheduleTable.scheduled_at <= upper,
         )
         result = await self._session.execute(stmt)
@@ -109,10 +112,10 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
                 else None
             ),
             title=entity.title.value,
-            scheduled_at=entity.scheduled_at,
+            scheduled_at=to_naive_utc(entity.scheduled_at),
             status=entity.status.value,
-            created_at=entity.created_at,
-            updated_at=entity.updated_at,
+            created_at=to_naive_utc(entity.created_at),
+            updated_at=to_naive_utc(entity.updated_at),
         )
         for cr in entity.confirmation_requests:
             cr_row = ConfirmationRequestTable(
@@ -120,18 +123,18 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
                 schedule_id=str(entity.id.value),
                 request_type=cr.request_type.value,
                 requested_by=str(cr.requested_by.value),
-                proposed_at=cr.proposed_at,
+                proposed_at=to_naive_utc(cr.proposed_at),
                 resolution=cr.resolution.value,
                 resolved_by=str(cr.resolved_by.value) if cr.resolved_by else None,
-                created_at=cr.created_at,
-                updated_at=entity.created_at,
+                created_at=to_naive_utc(cr.created_at),
+                updated_at=to_naive_utc(entity.created_at),
             )
             schedule_row.confirmation_requests.append(cr_row)
         self._session.add(schedule_row)
         await self._session.flush()
 
     async def _update(self, entity: Schedule, existing: ScheduleTable) -> None:
-        now = datetime.now(UTC)
+        now_naive = to_naive_utc(datetime.now(UTC))
 
         existing.organizer_id = str(entity.organizer_id.value)
         existing.counterpart_id = str(entity.counterpart_id.value)
@@ -139,9 +142,9 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
             str(entity.schedule_group_id.value) if entity.schedule_group_id else None
         )
         existing.title = entity.title.value
-        existing.scheduled_at = entity.scheduled_at
+        existing.scheduled_at = to_naive_utc(entity.scheduled_at)
         existing.status = entity.status.value
-        existing.updated_at = now
+        existing.updated_at = now_naive
 
         # Reconcile confirmation requests
         existing_cr_map: dict[str, ConfirmationRequestTable] = {
@@ -156,23 +159,23 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
                 db_cr = existing_cr_map[cr_id]
                 db_cr.request_type = cr.request_type.value
                 db_cr.requested_by = str(cr.requested_by.value)
-                db_cr.proposed_at = cr.proposed_at
+                db_cr.proposed_at = to_naive_utc(cr.proposed_at)
                 db_cr.resolution = cr.resolution.value
                 db_cr.resolved_by = (
                     str(cr.resolved_by.value) if cr.resolved_by else None
                 )
-                db_cr.updated_at = now
+                db_cr.updated_at = now_naive
             else:
                 new_cr = ConfirmationRequestTable(
                     id=cr_id,
                     schedule_id=str(entity.id.value),
                     request_type=cr.request_type.value,
                     requested_by=str(cr.requested_by.value),
-                    proposed_at=cr.proposed_at,
+                    proposed_at=to_naive_utc(cr.proposed_at),
                     resolution=cr.resolution.value,
                     resolved_by=(str(cr.resolved_by.value) if cr.resolved_by else None),
-                    created_at=cr.created_at,
-                    updated_at=cr.created_at,
+                    created_at=to_naive_utc(cr.created_at),
+                    updated_at=to_naive_utc(cr.created_at),
                 )
                 existing.confirmation_requests.append(new_cr)
 
@@ -189,12 +192,12 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
                 id=ConfirmationRequestId.from_str(cr.id),
                 request_type=ConfirmationRequestType(cr.request_type),
                 requested_by=UserId.from_str(cr.requested_by),
-                proposed_at=cr.proposed_at,
+                proposed_at=to_aware_utc(cr.proposed_at),
                 _resolution=ConfirmationResolution(cr.resolution),
                 _resolved_by=(
                     UserId.from_str(cr.resolved_by) if cr.resolved_by else None
                 ),
-                created_at=cr.created_at,
+                created_at=to_aware_utc(cr.created_at),
             )
             for cr in row.confirmation_requests
         ]
@@ -208,9 +211,9 @@ class SqlAlchemyScheduleRepository(ScheduleRepository):
                 else None
             ),
             _title=ScheduleTitle(row.title),
-            _scheduled_at=row.scheduled_at,
+            _scheduled_at=to_aware_utc(row.scheduled_at),
             _status=ScheduleStatus(row.status),
             _confirmation_requests=confirmation_requests,
-            created_at=row.created_at,
-            _updated_at=row.updated_at,
+            created_at=to_aware_utc(row.created_at),
+            _updated_at=to_aware_utc(row.updated_at),
         )

--- a/backend/contexts/preparation/infrastructure/sqlalchemy_template_repository.py
+++ b/backend/contexts/preparation/infrastructure/sqlalchemy_template_repository.py
@@ -16,6 +16,7 @@ from contexts.preparation.infrastructure.tables import (
     TemplateDefaultCounterpartTable,
     TemplateTable,
 )
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -53,12 +54,13 @@ class SqlAlchemyTemplateRepository(TemplateRepository):
     # ------------------------------------------------------------------
 
     async def _insert(self, entity: Template) -> None:
+        created_naive = to_naive_utc(entity.created_at)
         template_row = TemplateTable(
             id=str(entity.id.value),
             organizer_id=str(entity.organizer_id.value),
             name=entity.name.value,
-            created_at=entity.created_at,
-            updated_at=entity.updated_at,
+            created_at=created_naive,
+            updated_at=to_naive_utc(entity.updated_at),
         )
         for position, user_id in enumerate(entity.default_counterparts):
             dc_row = TemplateDefaultCounterpartTable(
@@ -66,8 +68,8 @@ class SqlAlchemyTemplateRepository(TemplateRepository):
                 template_id=str(entity.id.value),
                 user_id=str(user_id.value),
                 position=position,
-                created_at=entity.created_at,
-                updated_at=entity.created_at,
+                created_at=created_naive,
+                updated_at=created_naive,
             )
             template_row.default_counterparts.append(dc_row)
         for position, at in enumerate(entity.agenda_templates):
@@ -76,19 +78,19 @@ class SqlAlchemyTemplateRepository(TemplateRepository):
                 template_id=str(entity.id.value),
                 topic=at.topic.value,
                 position=position,
-                created_at=entity.created_at,
-                updated_at=entity.created_at,
+                created_at=created_naive,
+                updated_at=created_naive,
             )
             template_row.agenda_templates.append(at_row)
         self._session.add(template_row)
         await self._session.flush()
 
     async def _update(self, entity: Template, existing: TemplateTable) -> None:
-        now = datetime.now(UTC)
+        now_naive = to_naive_utc(datetime.now(UTC))
 
         existing.organizer_id = str(entity.organizer_id.value)
         existing.name = entity.name.value
-        existing.updated_at = now
+        existing.updated_at = now_naive
 
         # DefaultCounterparts: full delete + re-insert
         existing.default_counterparts.clear()
@@ -100,8 +102,8 @@ class SqlAlchemyTemplateRepository(TemplateRepository):
                 template_id=str(entity.id.value),
                 user_id=str(user_id.value),
                 position=position,
-                created_at=now,
-                updated_at=now,
+                created_at=now_naive,
+                updated_at=now_naive,
             )
             existing.default_counterparts.append(new_dc)
 
@@ -115,8 +117,8 @@ class SqlAlchemyTemplateRepository(TemplateRepository):
                 template_id=str(entity.id.value),
                 topic=at.topic.value,
                 position=position,
-                created_at=now,
-                updated_at=now,
+                created_at=now_naive,
+                updated_at=now_naive,
             )
             existing.agenda_templates.append(new_at)
 
@@ -136,6 +138,6 @@ class SqlAlchemyTemplateRepository(TemplateRepository):
             _name=TemplateName(row.name),
             _default_counterparts=default_counterparts,
             _agenda_templates=agenda_templates,
-            created_at=row.created_at,
-            _updated_at=row.updated_at,
+            created_at=to_aware_utc(row.created_at),
+            _updated_at=to_aware_utc(row.updated_at),
         )

--- a/backend/contexts/preparation/presentation/schemas.py
+++ b/backend/contexts/preparation/presentation/schemas.py
@@ -1,6 +1,5 @@
 """Pydantic request/response schemas for the Preparation context API."""
 
-from datetime import datetime
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel
@@ -121,8 +120,8 @@ class TemplateListItemSchema(BaseModel):
     name: str
     default_counterpart_ids: list[UUID]
     agenda_topics: list[str]
-    created_at: datetime
-    updated_at: datetime
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
 
 
 class ListTemplatesResponse(BaseModel):
@@ -139,8 +138,8 @@ class GetTemplateResponse(BaseModel):
     name: str
     default_counterpart_ids: list[UUID]
     agenda_topics: list[str]
-    created_at: datetime
-    updated_at: datetime
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
 
 
 class SaveTemplateRequest(BaseModel):
@@ -168,7 +167,7 @@ class UpcomingScheduleItemSchema(BaseModel):
     schedule_id: UUID
     organizer_id: UUID
     counterpart_id: UUID
-    scheduled_at: datetime
+    scheduled_at: AwareDatetime
     status: str
     title: str
     schedule_group_id: UUID | None
@@ -192,11 +191,11 @@ class GetScheduleDetailResponse(BaseModel):
     organizer_id: UUID
     counterpart_id: UUID
     title: str
-    scheduled_at: datetime
+    scheduled_at: AwareDatetime
     status: str
     schedule_group_id: UUID | None
-    created_at: datetime
-    updated_at: datetime
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +209,7 @@ class AgendaCommentSchema(BaseModel):
     comment_id: UUID
     author_id: UUID
     body: str
-    created_at: datetime
+    created_at: AwareDatetime
 
 
 class AgendaItemSchema(BaseModel):
@@ -221,7 +220,7 @@ class AgendaItemSchema(BaseModel):
     added_by: UUID
     added_by_tag: str
     comments: list[AgendaCommentSchema]
-    created_at: datetime
+    created_at: AwareDatetime
 
 
 class ListScheduleAgendasResponse(BaseModel):
@@ -287,14 +286,14 @@ class ActionItemSummarySchema(BaseModel):
     action_item_id: UUID
     content: str
     is_completed: bool
-    created_at: datetime
+    created_at: AwareDatetime
 
 
 class GetLastSessionSummaryResponse(BaseModel):
     """Response body for GET /records/last-summary."""
 
     record_id: UUID
-    conducted_at: datetime
+    conducted_at: AwareDatetime
     memo_excerpt: str
     action_items: list[ActionItemSummarySchema]
 
@@ -304,10 +303,10 @@ class PendingActionItemSchema(BaseModel):
 
     action_item_id: UUID
     content: str
-    created_at: datetime
+    created_at: AwareDatetime
     record_id: UUID
     organizer_id: UUID
-    conducted_at: datetime
+    conducted_at: AwareDatetime
 
 
 class ListPendingActionItemsResponse(BaseModel):
@@ -321,10 +320,10 @@ class AllPendingActionItemSchema(BaseModel):
 
     action_item_id: UUID
     content: str
-    created_at: datetime
+    created_at: AwareDatetime
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: datetime
+    conducted_at: AwareDatetime
 
 
 class ListAllPendingActionItemsResponse(BaseModel):

--- a/backend/contexts/preparation/presentation/schemas.py
+++ b/backend/contexts/preparation/presentation/schemas.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, field_validator
+from pydantic import AwareDatetime, BaseModel, Field, field_validator
 
 from foundation.datetime_utils import normalize_to_utc
 
@@ -16,7 +16,10 @@ class CounterpartScheduleSchema(BaseModel):
     """Per-counterpart scheduling parameters."""
 
     counterpart_id: UUID
-    scheduled_at: AwareDatetime
+    scheduled_at: AwareDatetime = Field(
+        description="Timezone-aware ISO 8601 required; normalized to UTC.",
+        json_schema_extra={"example": "2026-03-29T15:30:00+09:00"},
+    )
 
     @field_validator("scheduled_at")
     @classmethod
@@ -86,7 +89,10 @@ class CreateScheduleRequest(BaseModel):
     """Request body for POST /schedules."""
 
     counterpart_id: UUID
-    scheduled_at: AwareDatetime
+    scheduled_at: AwareDatetime = Field(
+        description="Timezone-aware ISO 8601 required; normalized to UTC.",
+        json_schema_extra={"example": "2026-03-29T15:30:00+09:00"},
+    )
     title: str
 
     @field_validator("scheduled_at")
@@ -110,7 +116,10 @@ class SendConsultationRequestRequest(BaseModel):
     """Request body for POST /schedules/consultation-request."""
 
     organizer_id: UUID
-    scheduled_at: AwareDatetime
+    scheduled_at: AwareDatetime = Field(
+        description="Timezone-aware ISO 8601 required; normalized to UTC.",
+        json_schema_extra={"example": "2026-03-29T15:30:00+09:00"},
+    )
     title: str
     agenda_topics: list[str]
 
@@ -138,8 +147,14 @@ class TemplateListItemSchema(BaseModel):
     name: str
     default_counterpart_ids: list[UUID]
     agenda_topics: list[str]
-    created_at: AwareDatetime
-    updated_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
+    updated_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class ListTemplatesResponse(BaseModel):
@@ -156,8 +171,14 @@ class GetTemplateResponse(BaseModel):
     name: str
     default_counterpart_ids: list[UUID]
     agenda_topics: list[str]
-    created_at: AwareDatetime
-    updated_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
+    updated_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class SaveTemplateRequest(BaseModel):
@@ -185,7 +206,10 @@ class UpcomingScheduleItemSchema(BaseModel):
     schedule_id: UUID
     organizer_id: UUID
     counterpart_id: UUID
-    scheduled_at: AwareDatetime
+    scheduled_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     status: str
     title: str
     schedule_group_id: UUID | None
@@ -209,11 +233,20 @@ class GetScheduleDetailResponse(BaseModel):
     organizer_id: UUID
     counterpart_id: UUID
     title: str
-    scheduled_at: AwareDatetime
+    scheduled_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     status: str
     schedule_group_id: UUID | None
-    created_at: AwareDatetime
-    updated_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
+    updated_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +260,10 @@ class AgendaCommentSchema(BaseModel):
     comment_id: UUID
     author_id: UUID
     body: str
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class AgendaItemSchema(BaseModel):
@@ -238,7 +274,10 @@ class AgendaItemSchema(BaseModel):
     added_by: UUID
     added_by_tag: str
     comments: list[AgendaCommentSchema]
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class ListScheduleAgendasResponse(BaseModel):
@@ -255,7 +294,10 @@ class ListScheduleAgendasResponse(BaseModel):
 class RescheduleRequest(BaseModel):
     """Request body for POST /schedules/{schedule_id}/reschedule."""
 
-    new_scheduled_at: AwareDatetime
+    new_scheduled_at: AwareDatetime = Field(
+        description="Timezone-aware ISO 8601 required; normalized to UTC.",
+        json_schema_extra={"example": "2026-03-29T15:30:00+09:00"},
+    )
 
     @field_validator("new_scheduled_at")
     @classmethod
@@ -309,14 +351,20 @@ class ActionItemSummarySchema(BaseModel):
     action_item_id: UUID
     content: str
     is_completed: bool
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class GetLastSessionSummaryResponse(BaseModel):
     """Response body for GET /records/last-summary."""
 
     record_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     memo_excerpt: str
     action_items: list[ActionItemSummarySchema]
 
@@ -326,10 +374,16 @@ class PendingActionItemSchema(BaseModel):
 
     action_item_id: UUID
     content: str
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     record_id: UUID
     organizer_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class ListPendingActionItemsResponse(BaseModel):
@@ -343,10 +397,16 @@ class AllPendingActionItemSchema(BaseModel):
 
     action_item_id: UUID
     content: str
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class ListAllPendingActionItemsResponse(BaseModel):

--- a/backend/contexts/preparation/presentation/schemas.py
+++ b/backend/contexts/preparation/presentation/schemas.py
@@ -1,8 +1,11 @@
 """Pydantic request/response schemas for the Preparation context API."""
 
+from datetime import datetime
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel
+from pydantic import AwareDatetime, BaseModel, field_validator
+
+from foundation.datetime_utils import normalize_to_utc
 
 # ---------------------------------------------------------------------------
 # ScheduleGroup -- POST /schedule-groups
@@ -14,6 +17,11 @@ class CounterpartScheduleSchema(BaseModel):
 
     counterpart_id: UUID
     scheduled_at: AwareDatetime
+
+    @field_validator("scheduled_at")
+    @classmethod
+    def _normalize_scheduled_at_to_utc(cls, v: datetime) -> datetime:
+        return normalize_to_utc(v)
 
 
 class CreateScheduleGroupRequest(BaseModel):
@@ -81,6 +89,11 @@ class CreateScheduleRequest(BaseModel):
     scheduled_at: AwareDatetime
     title: str
 
+    @field_validator("scheduled_at")
+    @classmethod
+    def _normalize_scheduled_at_to_utc(cls, v: datetime) -> datetime:
+        return normalize_to_utc(v)
+
 
 class CreateScheduleResponse(BaseModel):
     """Response body for POST /schedules."""
@@ -100,6 +113,11 @@ class SendConsultationRequestRequest(BaseModel):
     scheduled_at: AwareDatetime
     title: str
     agenda_topics: list[str]
+
+    @field_validator("scheduled_at")
+    @classmethod
+    def _normalize_scheduled_at_to_utc(cls, v: datetime) -> datetime:
+        return normalize_to_utc(v)
 
 
 class SendConsultationRequestResponse(BaseModel):
@@ -238,6 +256,11 @@ class RescheduleRequest(BaseModel):
     """Request body for POST /schedules/{schedule_id}/reschedule."""
 
     new_scheduled_at: AwareDatetime
+
+    @field_validator("new_scheduled_at")
+    @classmethod
+    def _normalize_new_scheduled_at_to_utc(cls, v: datetime) -> datetime:
+        return normalize_to_utc(v)
 
 
 class RenameScheduleRequest(BaseModel):

--- a/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_action_item_repository.py
@@ -7,6 +7,7 @@ from contexts.record.domain.action_item import ActionItem
 from contexts.record.domain.action_item_repository import ActionItemRepository
 from contexts.record.domain.value_objects import ActionItemId, ActionItemTitle, RecordId
 from contexts.record.infrastructure.tables import ActionItemTable, RecordTable
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 _DEFAULT_PENDING_LIMIT = 50
@@ -90,15 +91,15 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
             record_id=str(entity.record_id.value),
             title=entity.title.value,
             is_completed=entity.is_completed,
-            created_at=entity.created_at,
-            updated_at=entity.updated_at,
+            created_at=to_naive_utc(entity.created_at),
+            updated_at=to_naive_utc(entity.updated_at),
         )
         self._session.add(action_item_row)
         await self._session.flush()
 
     async def _update(self, entity: ActionItem, existing: ActionItemTable) -> None:
         existing.is_completed = entity.is_completed
-        existing.updated_at = entity.updated_at
+        existing.updated_at = to_naive_utc(entity.updated_at)
         await self._session.flush()
 
     @staticmethod
@@ -109,6 +110,6 @@ class SqlAlchemyActionItemRepository(ActionItemRepository):
             record_id=RecordId.from_str(row.record_id),
             title=ActionItemTitle(row.title),
             _is_completed=row.is_completed,
-            created_at=row.created_at,
-            _updated_at=row.updated_at,
+            created_at=to_aware_utc(row.created_at),
+            _updated_at=to_aware_utc(row.updated_at),
         )

--- a/backend/contexts/record/infrastructure/sqlalchemy_comment_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_comment_repository.py
@@ -9,6 +9,7 @@ from contexts.record.domain.comment_repository import CommentRepository
 from contexts.record.domain.exceptions import CommentAlreadyExistsError
 from contexts.record.domain.value_objects import CommentId, RecordId
 from contexts.record.infrastructure.tables import CommentTable
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -41,7 +42,7 @@ class SqlAlchemyCommentRepository(CommentRepository):
             record_id=str(entity.record_id.value),
             author_id=str(entity.author_id.value),
             body=entity.body.value,
-            created_at=entity.created_at,
+            created_at=to_naive_utc(entity.created_at),
         )
         self._session.add(comment_row)
         await self._session.flush()
@@ -62,5 +63,5 @@ class SqlAlchemyCommentRepository(CommentRepository):
             record_id=RecordId.from_str(row.record_id),
             author_id=UserId.from_str(row.author_id),
             body=CommentBody(row.body),
-            created_at=row.created_at,
+            created_at=to_aware_utc(row.created_at),
         )

--- a/backend/contexts/record/infrastructure/sqlalchemy_read_status_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_read_status_repository.py
@@ -8,6 +8,7 @@ from contexts.record.domain.read_status import ReadStatus
 from contexts.record.domain.read_status_repository import ReadStatusRepository
 from contexts.record.domain.value_objects import ReadStatusId, RecordId
 from contexts.record.infrastructure.tables import ReadStatusTable
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -38,7 +39,7 @@ class SqlAlchemyReadStatusRepository(ReadStatusRepository):
             id=str(entity.id.value),
             record_id=str(entity.record_id.value),
             user_id=str(entity.user_id.value),
-            last_viewed_at=entity.last_viewed_at,
+            last_viewed_at=to_naive_utc(entity.last_viewed_at),
         )
         stmt = stmt.on_duplicate_key_update(
             last_viewed_at=stmt.inserted.last_viewed_at,
@@ -78,14 +79,14 @@ class SqlAlchemyReadStatusRepository(ReadStatusRepository):
             id=str(entity.id.value),
             record_id=str(entity.record_id.value),
             user_id=str(entity.user_id.value),
-            last_viewed_at=entity.last_viewed_at,
+            last_viewed_at=to_naive_utc(entity.last_viewed_at),
         )
         self._session.add(row)
         await self._session.flush()
 
     @staticmethod
     def _update(entity: ReadStatus, existing: ReadStatusTable) -> None:
-        existing.last_viewed_at = entity.last_viewed_at
+        existing.last_viewed_at = to_naive_utc(entity.last_viewed_at)
 
     @staticmethod
     def _to_entity(row: ReadStatusTable) -> ReadStatus:
@@ -93,5 +94,5 @@ class SqlAlchemyReadStatusRepository(ReadStatusRepository):
             id=ReadStatusId.from_str(row.id),
             record_id=RecordId.from_str(row.record_id),
             user_id=UserId.from_str(row.user_id),
-            _last_viewed_at=row.last_viewed_at,
+            _last_viewed_at=to_aware_utc(row.last_viewed_at),
         )

--- a/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
+++ b/backend/contexts/record/infrastructure/sqlalchemy_record_repository.py
@@ -15,6 +15,7 @@ from contexts.record.infrastructure.tables import (
     RecordTable,
     RecordViewerTable,
 )
+from foundation.datetime_utils import to_aware_utc, to_aware_utc_optional, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -153,6 +154,8 @@ class SqlAlchemyRecordRepository(RecordRepository):
         )
 
     async def _insert(self, entity: Record) -> None:
+        created_naive = to_naive_utc(entity.created_at)
+        updated_naive = to_naive_utc(entity.updated_at)
         record_row = RecordTable(
             id=str(entity.id.value),
             organizer_id=str(entity.organizer_id.value),
@@ -160,18 +163,22 @@ class SqlAlchemyRecordRepository(RecordRepository):
             schedule_id=(str(entity.schedule_id.value) if entity.schedule_id else None),
             memo=entity.memo.value,
             status=entity.status.value,
-            conducted_at=entity.conducted_at,
-            latest_activity_at=entity.latest_activity_at,
-            created_at=entity.created_at,
-            updated_at=entity.updated_at,
+            conducted_at=to_naive_utc(entity.conducted_at),
+            latest_activity_at=(
+                to_naive_utc(entity.latest_activity_at)
+                if entity.latest_activity_at
+                else None
+            ),
+            created_at=created_naive,
+            updated_at=updated_naive,
         )
         for viewer_id in entity.viewers:
             viewer_row = RecordViewerTable(
                 id=str(uuid.uuid4()),
                 record_id=str(entity.id.value),
                 user_id=str(viewer_id.value),
-                created_at=entity.created_at,
-                updated_at=entity.updated_at,
+                created_at=created_naive,
+                updated_at=updated_naive,
             )
             record_row.viewers.append(viewer_row)
         for agenda_id in entity.confirmed_agenda_ids:
@@ -179,23 +186,28 @@ class SqlAlchemyRecordRepository(RecordRepository):
                 id=str(uuid.uuid4()),
                 record_id=str(entity.id.value),
                 agenda_id=str(agenda_id.value),
-                created_at=entity.created_at,
-                updated_at=entity.updated_at,
+                created_at=created_naive,
+                updated_at=updated_naive,
             )
             record_row.confirmed_agendas.append(agenda_row)
         self._session.add(record_row)
         await self._session.flush()
 
     async def _update(self, entity: Record, existing: RecordTable) -> None:
+        updated_naive = to_naive_utc(entity.updated_at)
         # Update scalar fields
         existing.memo = entity.memo.value
         existing.status = entity.status.value
-        existing.conducted_at = entity.conducted_at
+        existing.conducted_at = to_naive_utc(entity.conducted_at)
         existing.schedule_id = (
             str(entity.schedule_id.value) if entity.schedule_id else None
         )
-        existing.latest_activity_at = entity.latest_activity_at
-        existing.updated_at = entity.updated_at
+        existing.latest_activity_at = (
+            to_naive_utc(entity.latest_activity_at)
+            if entity.latest_activity_at
+            else None
+        )
+        existing.updated_at = updated_naive
 
         # Replace viewers: delete all, then re-insert
         existing.viewers.clear()
@@ -206,8 +218,8 @@ class SqlAlchemyRecordRepository(RecordRepository):
                 id=str(uuid.uuid4()),
                 record_id=str(entity.id.value),
                 user_id=str(viewer_id.value),
-                created_at=entity.updated_at,
-                updated_at=entity.updated_at,
+                created_at=updated_naive,
+                updated_at=updated_naive,
             )
             existing.viewers.append(new_viewer)
 
@@ -220,8 +232,8 @@ class SqlAlchemyRecordRepository(RecordRepository):
                 id=str(uuid.uuid4()),
                 record_id=str(entity.id.value),
                 agenda_id=str(agenda_id.value),
-                created_at=entity.updated_at,
-                updated_at=entity.updated_at,
+                created_at=updated_naive,
+                updated_at=updated_naive,
             )
             existing.confirmed_agendas.append(new_agenda)
 
@@ -244,8 +256,8 @@ class SqlAlchemyRecordRepository(RecordRepository):
             _status=RecordStatus(row.status),
             _viewers=viewers,
             _confirmed_agenda_ids=confirmed_agenda_ids,
-            conducted_at=row.conducted_at,
-            created_at=row.created_at,
-            _updated_at=row.updated_at,
-            _latest_activity_at=row.latest_activity_at,
+            conducted_at=to_aware_utc(row.conducted_at),
+            created_at=to_aware_utc(row.created_at),
+            _updated_at=to_aware_utc(row.updated_at),
+            _latest_activity_at=to_aware_utc_optional(row.latest_activity_at),
         )

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -1,6 +1,5 @@
 """Pydantic request/response schemas for the Record context API."""
 
-from datetime import datetime
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, Field
@@ -121,7 +120,7 @@ class ActionItemSchema(BaseModel):
     title: str
     is_completed: bool
     counterpart_id: UUID
-    created_at: datetime
+    created_at: AwareDatetime
 
 
 class GetRecordDetailResponse(BaseModel):
@@ -135,9 +134,9 @@ class GetRecordDetailResponse(BaseModel):
     status: str
     confirmed_agenda_ids: list[UUID]
     action_items: list[ActionItemSchema]
-    conducted_at: datetime
-    created_at: datetime
-    updated_at: datetime
+    conducted_at: AwareDatetime
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +150,7 @@ class CommentSchema(BaseModel):
     comment_id: UUID
     author_id: UUID
     body: str
-    created_at: datetime
+    created_at: AwareDatetime
 
 
 class ListRecordCommentsResponse(BaseModel):
@@ -210,7 +209,7 @@ class OneOnOneHistoryItemSchema(BaseModel):
     record_id: UUID
     organizer_id: UUID
     counterpart_id: UUID
-    conducted_at: datetime
+    conducted_at: AwareDatetime
     memo_excerpt: str
     schedule_id: UUID | None
 
@@ -277,9 +276,9 @@ class DraftRecordItemSchema(BaseModel):
 
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: datetime
+    conducted_at: AwareDatetime
     memo_excerpt: str
-    created_at: datetime
+    created_at: AwareDatetime
     schedule_id: UUID | None
 
 

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -1,8 +1,11 @@
 """Pydantic request/response schemas for the Record context API."""
 
+from datetime import datetime
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, Field
+from pydantic import AwareDatetime, BaseModel, Field, field_validator
+
+from foundation.datetime_utils import normalize_to_utc
 
 # ---------------------------------------------------------------------------
 # Post-hoc record -- POST /records/post-hoc
@@ -14,6 +17,11 @@ class CreatePostHocRecordRequest(BaseModel):
 
     counterpart_id: UUID
     conducted_at: AwareDatetime
+
+    @field_validator("conducted_at")
+    @classmethod
+    def _normalize_conducted_at_to_utc(cls, v: datetime) -> datetime:
+        return normalize_to_utc(v)
 
 
 class CreatePostHocRecordResponse(BaseModel):
@@ -32,6 +40,11 @@ class CreateRecordFromScheduleRequest(BaseModel):
 
     schedule_id: UUID
     conducted_at: AwareDatetime
+
+    @field_validator("conducted_at")
+    @classmethod
+    def _normalize_conducted_at_to_utc(cls, v: datetime) -> datetime:
+        return normalize_to_utc(v)
 
 
 class CreateRecordFromScheduleResponse(BaseModel):

--- a/backend/contexts/record/presentation/schemas.py
+++ b/backend/contexts/record/presentation/schemas.py
@@ -16,7 +16,10 @@ class CreatePostHocRecordRequest(BaseModel):
     """Request body for POST /records/post-hoc."""
 
     counterpart_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Timezone-aware ISO 8601 required; normalized to UTC.",
+        json_schema_extra={"example": "2026-03-29T15:30:00+09:00"},
+    )
 
     @field_validator("conducted_at")
     @classmethod
@@ -39,7 +42,10 @@ class CreateRecordFromScheduleRequest(BaseModel):
     """Request body for POST /records/from-schedule."""
 
     schedule_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Timezone-aware ISO 8601 required; normalized to UTC.",
+        json_schema_extra={"example": "2026-03-29T15:30:00+09:00"},
+    )
 
     @field_validator("conducted_at")
     @classmethod
@@ -133,7 +139,10 @@ class ActionItemSchema(BaseModel):
     title: str
     is_completed: bool
     counterpart_id: UUID
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class GetRecordDetailResponse(BaseModel):
@@ -147,9 +156,18 @@ class GetRecordDetailResponse(BaseModel):
     status: str
     confirmed_agenda_ids: list[UUID]
     action_items: list[ActionItemSchema]
-    conducted_at: AwareDatetime
-    created_at: AwareDatetime
-    updated_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
+    updated_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +181,10 @@ class CommentSchema(BaseModel):
     comment_id: UUID
     author_id: UUID
     body: str
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
 
 
 class ListRecordCommentsResponse(BaseModel):
@@ -222,7 +243,10 @@ class OneOnOneHistoryItemSchema(BaseModel):
     record_id: UUID
     organizer_id: UUID
     counterpart_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     memo_excerpt: str
     schedule_id: UUID | None
 
@@ -289,9 +313,15 @@ class DraftRecordItemSchema(BaseModel):
 
     record_id: UUID
     counterpart_id: UUID
-    conducted_at: AwareDatetime
+    conducted_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     memo_excerpt: str
-    created_at: AwareDatetime
+    created_at: AwareDatetime = Field(
+        description="Returned in UTC.",
+        json_schema_extra={"example": "2026-03-29T06:30:00Z"},
+    )
     schedule_id: UUID | None
 
 

--- a/backend/contexts/workspace/infrastructure/sqlalchemy_workspace_repository.py
+++ b/backend/contexts/workspace/infrastructure/sqlalchemy_workspace_repository.py
@@ -14,6 +14,7 @@ from contexts.workspace.domain.workspace import Membership, Workspace
 from contexts.workspace.domain.workspace_name import WorkspaceName
 from contexts.workspace.domain.workspace_repository import WorkspaceRepository
 from contexts.workspace.infrastructure.tables import MembershipTable, WorkspaceTable
+from foundation.datetime_utils import to_aware_utc, to_naive_utc
 from shared.domain.value_objects import UserId
 
 
@@ -80,12 +81,14 @@ class SqlAlchemyWorkspaceRepository(WorkspaceRepository):
     # ------------------------------------------------------------------
 
     async def _insert(self, entity: Workspace) -> None:
+        created_naive = to_naive_utc(entity.created_at)
+        updated_naive = to_naive_utc(entity.updated_at)
         workspace_row = WorkspaceTable(
             id=str(entity.id.value),
             name=entity.name.value,
             parent_id=str(entity.parent_id.value) if entity.parent_id else None,
-            created_at=entity.created_at,
-            updated_at=entity.updated_at,
+            created_at=created_naive,
+            updated_at=updated_naive,
         )
         for m in entity.memberships:
             membership_row = MembershipTable(
@@ -93,20 +96,20 @@ class SqlAlchemyWorkspaceRepository(WorkspaceRepository):
                 workspace_id=str(entity.id.value),
                 user_id=str(m.user_id.value),
                 role=m.role.value,
-                created_at=entity.created_at,
-                updated_at=entity.updated_at,
+                created_at=created_naive,
+                updated_at=updated_naive,
             )
             workspace_row.memberships.append(membership_row)
         self._session.add(workspace_row)
         await self._session.flush()
 
     async def _update(self, entity: Workspace, existing: WorkspaceTable) -> None:
-        now = datetime.now(UTC)
+        now_naive = to_naive_utc(datetime.now(UTC))
 
         # Update workspace fields (last-write-wins)
         existing.name = entity.name.value
         existing.parent_id = str(entity.parent_id.value) if entity.parent_id else None
-        existing.updated_at = now
+        existing.updated_at = now_naive
 
         # Reconcile memberships: build a map of current DB memberships
         existing_membership_map: dict[str, MembershipTable] = {
@@ -122,7 +125,7 @@ class SqlAlchemyWorkspaceRepository(WorkspaceRepository):
                 db_m = existing_membership_map[m_id]
                 db_m.user_id = str(m.user_id.value)
                 db_m.role = m.role.value
-                db_m.updated_at = now
+                db_m.updated_at = now_naive
             else:
                 # Insert new membership
                 new_m = MembershipTable(
@@ -130,8 +133,8 @@ class SqlAlchemyWorkspaceRepository(WorkspaceRepository):
                     workspace_id=str(entity.id.value),
                     user_id=str(m.user_id.value),
                     role=m.role.value,
-                    created_at=now,
-                    updated_at=now,
+                    created_at=now_naive,
+                    updated_at=now_naive,
                 )
                 existing.memberships.append(new_m)
 
@@ -157,6 +160,6 @@ class SqlAlchemyWorkspaceRepository(WorkspaceRepository):
             _name=WorkspaceName(row.name),
             _parent_id=WorkspaceId.from_str(row.parent_id) if row.parent_id else None,
             _memberships=memberships,
-            created_at=row.created_at,
-            _updated_at=row.updated_at,
+            created_at=to_aware_utc(row.created_at),
+            _updated_at=to_aware_utc(row.updated_at),
         )

--- a/backend/foundation/datetime_utils.py
+++ b/backend/foundation/datetime_utils.py
@@ -14,6 +14,30 @@ TypeError immediately, preventing silent data corruption.
 from datetime import UTC, datetime, timedelta
 
 
+def normalize_to_utc(dt: datetime) -> datetime:
+    """Normalize an aware datetime to UTC.
+
+    Used at the Presentation layer boundary to convert any aware datetime
+    (potentially with a non-UTC offset like +09:00) to UTC aware datetime
+    before passing it into the domain layer.
+
+    Args:
+        dt: A timezone-aware datetime (any offset).
+
+    Returns:
+        A timezone-aware datetime in UTC.
+
+    Raises:
+        TypeError: If dt is naive (no tzinfo).
+    """
+    if dt.tzinfo is None:
+        raise TypeError(
+            f"Expected aware datetime, got naive: {dt!r}. "
+            "Use AwareDatetime in Pydantic schemas to ensure awareness."
+        )
+    return dt.astimezone(UTC)
+
+
 def to_naive_utc(dt: datetime) -> datetime:
     """Convert an aware UTC datetime to naive UTC for DB storage.
 

--- a/backend/foundation/datetime_utils.py
+++ b/backend/foundation/datetime_utils.py
@@ -1,0 +1,70 @@
+"""Datetime boundary conversion utilities.
+
+All domain-layer datetimes must be timezone-aware UTC.
+DB (MariaDB DATETIME(6)) stores naive UTC.
+
+These functions enforce the conversion rules at repository boundaries:
+- Domain -> DB: aware UTC -> naive UTC (strip tzinfo)
+- DB -> Domain: naive UTC -> aware UTC (attach UTC tzinfo)
+
+Passing a naive datetime where aware is expected (or vice versa) raises
+TypeError immediately, preventing silent data corruption.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+
+def to_naive_utc(dt: datetime) -> datetime:
+    """Convert an aware UTC datetime to naive UTC for DB storage.
+
+    Args:
+        dt: A timezone-aware datetime (must be UTC).
+
+    Returns:
+        A naive datetime with the same date/time components.
+
+    Raises:
+        TypeError: If dt is naive (no tzinfo).
+        ValueError: If dt is not in UTC.
+    """
+    if dt.tzinfo is None:
+        raise TypeError(
+            f"Expected aware datetime, got naive: {dt!r}. "
+            "Domain datetimes must be timezone-aware UTC."
+        )
+    if dt.utcoffset() != timedelta(0):
+        raise ValueError(
+            f"Expected UTC datetime, got offset {dt.utcoffset()}: {dt!r}. "
+            "Convert to UTC before storing."
+        )
+    return dt.replace(tzinfo=None)
+
+
+def to_aware_utc(dt: datetime) -> datetime:
+    """Convert a naive UTC datetime from DB to aware UTC for domain use.
+
+    Args:
+        dt: A naive datetime assumed to be in UTC (from DB).
+
+    Returns:
+        A timezone-aware datetime with UTC tzinfo.
+
+    Raises:
+        TypeError: If dt is already aware (has tzinfo).
+    """
+    if dt.tzinfo is not None:
+        raise TypeError(
+            f"Expected naive datetime from DB, got aware: {dt!r}. "
+            "DB datetimes should be naive UTC."
+        )
+    return dt.replace(tzinfo=UTC)
+
+
+def to_aware_utc_optional(dt: datetime | None) -> datetime | None:
+    """Convert an optional naive UTC datetime to aware UTC.
+
+    Returns None if dt is None, otherwise delegates to to_aware_utc.
+    """
+    if dt is None:
+        return None
+    return to_aware_utc(dt)

--- a/backend/foundation/db/base.py
+++ b/backend/foundation/db/base.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import func, text
+from sqlalchemy import text
 from sqlalchemy.dialects.mysql import DATETIME
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -11,13 +11,13 @@ class TimestampMixin:
     created_at: Mapped[datetime] = mapped_column(
         DATETIME(fsp=6),
         nullable=False,
-        server_default=func.now(),
+        server_default=text("CURRENT_TIMESTAMP(6)"),
     )
     updated_at: Mapped[datetime] = mapped_column(
         DATETIME(fsp=6),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)"),
-        onupdate=func.now(),
+        onupdate=text("NOW(6)"),
     )
 
 

--- a/backend/foundation/db/base.py
+++ b/backend/foundation/db/base.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy import func, text
+from sqlalchemy.dialects.mysql import DATETIME
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -8,12 +9,14 @@ class TimestampMixin:
     """Mixin that adds created_at / updated_at columns to all tables."""
 
     created_at: Mapped[datetime] = mapped_column(
+        DATETIME(fsp=6),
         nullable=False,
         server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
+        DATETIME(fsp=6),
         nullable=False,
-        server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+        server_default=text("CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)"),
         onupdate=func.now(),
     )
 

--- a/backend/migrations/versions/0016_update_timestamp_columns_to_fsp6.py
+++ b/backend/migrations/versions/0016_update_timestamp_columns_to_fsp6.py
@@ -52,6 +52,7 @@ def upgrade() -> None:
             existing_type=sa.DateTime(),
             type_=DATETIME(fsp=6),
             existing_nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP(6)"),
         )
         op.alter_column(
             table,
@@ -59,6 +60,9 @@ def upgrade() -> None:
             existing_type=sa.DateTime(),
             type_=DATETIME(fsp=6),
             existing_nullable=False,
+            server_default=sa.text(
+                "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)"
+            ),
         )
 
 
@@ -70,6 +74,7 @@ def downgrade() -> None:
             existing_type=DATETIME(fsp=6),
             type_=sa.DateTime(),
             existing_nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
         )
         op.alter_column(
             table,
@@ -77,4 +82,5 @@ def downgrade() -> None:
             existing_type=DATETIME(fsp=6),
             type_=sa.DateTime(),
             existing_nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
         )

--- a/backend/migrations/versions/0016_update_timestamp_columns_to_fsp6.py
+++ b/backend/migrations/versions/0016_update_timestamp_columns_to_fsp6.py
@@ -1,0 +1,80 @@
+"""update all TimestampMixin created_at/updated_at columns to DATETIME(6)
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-03-29
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import DATETIME
+
+# revision identifiers, used by Alembic.
+revision: str = "0016"
+down_revision: str | None = "0015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# All tables that use TimestampMixin (created_at + updated_at).
+_TABLES_WITH_TIMESTAMP_MIXIN: list[str] = [
+    "users",
+    "system_settings",
+    "templates",
+    "template_default_counterparts",
+    "template_agenda_templates",
+    "schedule_groups",
+    "schedule_group_agenda_templates",
+    "schedules",
+    "confirmation_requests",
+    "agendas",
+    "agenda_comments",
+    "records",
+    "record_viewers",
+    "record_confirmed_agendas",
+    "comments",
+    "action_items",
+    "record_read_statuses",
+    "notification_settings",
+    "reminder_logs",
+    "notification_records",
+    "workspaces",
+    "memberships",
+]
+
+
+def upgrade() -> None:
+    for table in _TABLES_WITH_TIMESTAMP_MIXIN:
+        op.alter_column(
+            table,
+            "created_at",
+            existing_type=sa.DateTime(),
+            type_=DATETIME(fsp=6),
+            existing_nullable=False,
+        )
+        op.alter_column(
+            table,
+            "updated_at",
+            existing_type=sa.DateTime(),
+            type_=DATETIME(fsp=6),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    for table in reversed(_TABLES_WITH_TIMESTAMP_MIXIN):
+        op.alter_column(
+            table,
+            "updated_at",
+            existing_type=DATETIME(fsp=6),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+        )
+        op.alter_column(
+            table,
+            "created_at",
+            existing_type=DATETIME(fsp=6),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+        )

--- a/backend/tests/contexts/notification/infrastructure/test_sqlalchemy_reminder_log_repository.py
+++ b/backend/tests/contexts/notification/infrastructure/test_sqlalchemy_reminder_log_repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -18,8 +18,8 @@ from shared.domain.value_objects import UserId
 
 pytestmark = pytest.mark.integration
 
-SCHEDULED_AT = datetime(2026, 4, 1, 10, 0)
-SENT_AT = datetime(2026, 3, 31, 9, 30)
+SCHEDULED_AT = datetime(2026, 4, 1, 10, 0, tzinfo=UTC)
+SENT_AT = datetime(2026, 3, 31, 9, 30, tzinfo=UTC)
 
 
 def _make_log(
@@ -71,20 +71,24 @@ class TestUniqueConstraint:
         log1 = _make_log(
             schedule_id=schedule_id,
             user_id=user_id,
-            scheduled_at=datetime(2026, 4, 1, 10, 0),
+            scheduled_at=datetime(2026, 4, 1, 10, 0, tzinfo=UTC),
         )
         await repo.save(log1)
 
         log2 = _make_log(
             schedule_id=schedule_id,
             user_id=user_id,
-            scheduled_at=datetime(2026, 4, 5, 14, 0),
+            scheduled_at=datetime(2026, 4, 5, 14, 0, tzinfo=UTC),
         )
         await repo.save(log2)
         await session.flush()
 
-        assert await repo.exists(schedule_id, user_id, datetime(2026, 4, 1, 10, 0))
-        assert await repo.exists(schedule_id, user_id, datetime(2026, 4, 5, 14, 0))
+        assert await repo.exists(
+            schedule_id, user_id, datetime(2026, 4, 1, 10, 0, tzinfo=UTC)
+        )
+        assert await repo.exists(
+            schedule_id, user_id, datetime(2026, 4, 5, 14, 0, tzinfo=UTC)
+        )
 
 
 class TestExistsQuery:

--- a/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_group_repository.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_group_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,7 +21,7 @@ from tests.helpers import create_test_user
 
 pytestmark = pytest.mark.integration
 
-NOW = datetime(2026, 4, 1, 10, 0)
+NOW = datetime(2026, 4, 1, 10, 0, tzinfo=UTC)
 
 
 def _make_schedule_group(
@@ -100,20 +100,20 @@ class TestScheduleIdsRestoration:
         s1 = Schedule.create(
             organizer_id=org,
             counterpart_id=cp,
-            scheduled_at=datetime(2026, 4, 10, 14, 0),
+            scheduled_at=datetime(2026, 4, 10, 14, 0, tzinfo=UTC),
             requested_by=org,
             title=ScheduleTitle("Meeting 1"),
             schedule_group_id=group.id,
-            now=datetime(2026, 4, 1, 10, 0, 0),
+            now=datetime(2026, 4, 1, 10, 0, 0, tzinfo=UTC),
         )
         s2 = Schedule.create(
             organizer_id=org,
             counterpart_id=cp,
-            scheduled_at=datetime(2026, 4, 17, 14, 0),
+            scheduled_at=datetime(2026, 4, 17, 14, 0, tzinfo=UTC),
             requested_by=org,
             title=ScheduleTitle("Meeting 2"),
             schedule_group_id=group.id,
-            now=datetime(2026, 4, 1, 10, 0, 1),
+            now=datetime(2026, 4, 1, 10, 0, 1, tzinfo=UTC),
         )
         await schedule_repo.save(s1)
         await schedule_repo.save(s2)
@@ -143,7 +143,7 @@ class TestUpdateAgendaTemplates:
 
         # Modify agenda templates via internal state for testing persistence
         group._agenda_templates.append(AgendaTemplate("Topic B"))
-        group._updated_at = datetime(2026, 4, 2, 10, 0)
+        group._updated_at = datetime(2026, 4, 2, 10, 0, tzinfo=UTC)
         await repo.save(group)
         await session.commit()
 
@@ -166,7 +166,7 @@ class TestUpdateAgendaTemplates:
 
         # Remove second template
         group._agenda_templates.pop(1)
-        group._updated_at = datetime(2026, 4, 2, 10, 0)
+        group._updated_at = datetime(2026, 4, 2, 10, 0, tzinfo=UTC)
         await repo.save(group)
         await session.commit()
 

--- a/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_repository.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_schedule_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -20,8 +20,8 @@ from tests.helpers import create_test_user
 
 pytestmark = pytest.mark.integration
 
-NOW = datetime(2026, 4, 1, 10, 0)
-SCHEDULED_AT = datetime(2026, 4, 10, 14, 0)
+NOW = datetime(2026, 4, 1, 10, 0, tzinfo=UTC)
+SCHEDULED_AT = datetime(2026, 4, 10, 14, 0, tzinfo=UTC)
 
 
 def _make_schedule(
@@ -92,7 +92,7 @@ class TestUpdateScalarFields:
         await session.commit()
 
         # Confirm the schedule
-        confirm_time = datetime(2026, 4, 2, 10, 0)
+        confirm_time = datetime(2026, 4, 2, 10, 0, tzinfo=UTC)
         schedule.confirm(actor_id=cp, now=confirm_time)
         await repo.save(schedule)
         await session.commit()
@@ -120,8 +120,8 @@ class TestConfirmationRequestReconciliation:
         await session.commit()
 
         # Reschedule by organizer
-        new_time = datetime(2026, 4, 15, 14, 0)
-        reschedule_now = datetime(2026, 4, 3, 10, 0)
+        new_time = datetime(2026, 4, 15, 14, 0, tzinfo=UTC)
+        reschedule_now = datetime(2026, 4, 3, 10, 0, tzinfo=UTC)
         schedule.reschedule(actor_id=org, new_proposed_at=new_time, now=reschedule_now)
         await repo.save(schedule)
         await session.commit()
@@ -145,12 +145,12 @@ class TestConfirmationRequestReconciliation:
 
         schedule = _make_schedule(organizer_id=org, counterpart_id=cp)
         # Confirm
-        schedule.confirm(actor_id=cp, now=datetime(2026, 4, 2, 10, 0))
+        schedule.confirm(actor_id=cp, now=datetime(2026, 4, 2, 10, 0, tzinfo=UTC))
         # Reschedule by counterpart
         schedule.reschedule(
             actor_id=cp,
-            new_proposed_at=datetime(2026, 4, 20, 14, 0),
-            now=datetime(2026, 4, 5, 10, 0),
+            new_proposed_at=datetime(2026, 4, 20, 14, 0, tzinfo=UTC),
+            now=datetime(2026, 4, 5, 10, 0, tzinfo=UTC),
         )
         await repo.save(schedule)
         await session.commit()
@@ -235,9 +235,7 @@ class TestAlembicMigration:
                 assert "template_agenda_templates" in tables
 
             # Downgrade to base
-            await loop.run_in_executor(
-                None, command.downgrade, alembic_cfg, "base"
-            )
+            await loop.run_in_executor(None, command.downgrade, alembic_cfg, "base")
 
             async with session_factory() as s:
                 result = await s.execute(text("SHOW TABLES"))

--- a/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_template_repository.py
+++ b/backend/tests/contexts/preparation/infrastructure/test_sqlalchemy_template_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,7 +17,7 @@ from tests.helpers import create_test_user
 
 pytestmark = pytest.mark.integration
 
-NOW = datetime(2026, 4, 1, 10, 0)
+NOW = datetime(2026, 4, 1, 10, 0, tzinfo=UTC)
 
 
 def _make_template(
@@ -119,7 +119,7 @@ class TestUpdateTemplate:
                 AgendaTemplate("New Topic A"),
                 AgendaTemplate("New Topic B"),
             ],
-            now=datetime(2026, 4, 2, 10, 0),
+            now=datetime(2026, 4, 2, 10, 0, tzinfo=UTC),
         )
         await repo.save(template)
         await session.commit()
@@ -154,7 +154,7 @@ class TestUpdateTemplate:
             name=TemplateName("Empty Template"),
             default_counterparts=[],
             agenda_templates=[],
-            now=datetime(2026, 4, 2, 10, 0),
+            now=datetime(2026, 4, 2, 10, 0, tzinfo=UTC),
         )
         await repo.save(template)
         await session.commit()

--- a/backend/tests/contexts/preparation/presentation/test_schemas_utc_normalization.py
+++ b/backend/tests/contexts/preparation/presentation/test_schemas_utc_normalization.py
@@ -1,0 +1,85 @@
+"""Tests for UTC normalization in Preparation request schemas.
+
+Verifies that non-UTC aware datetimes (e.g. +09:00) are automatically
+converted to UTC when parsed by Pydantic request schemas.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from contexts.preparation.presentation.schemas import (
+    CounterpartScheduleSchema,
+    CreateScheduleRequest,
+    RescheduleRequest,
+    SendConsultationRequestRequest,
+)
+
+JST = timezone(timedelta(hours=9))
+EST = timezone(timedelta(hours=-5))
+
+
+class TestCounterpartScheduleSchemaUtcNormalization:
+    """UTC normalization for CounterpartScheduleSchema."""
+
+    def test_jst_offset_normalized_to_utc(self) -> None:
+        """A +09:00 scheduled_at is converted to equivalent UTC."""
+        schema = CounterpartScheduleSchema(
+            counterpart_id="00000000-0000-0000-0000-000000000001",
+            scheduled_at=datetime(2026, 4, 1, 15, 30, 0, tzinfo=JST),
+        )
+        assert schema.scheduled_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.scheduled_at == expected
+
+    def test_utc_input_unchanged(self) -> None:
+        """UTC input passes through without modification."""
+        schema = CounterpartScheduleSchema(
+            counterpart_id="00000000-0000-0000-0000-000000000001",
+            scheduled_at=datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC),
+        )
+        assert schema.scheduled_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.scheduled_at == expected
+
+
+class TestCreateScheduleRequestUtcNormalization:
+    """UTC normalization for CreateScheduleRequest."""
+
+    def test_non_utc_offset_normalized(self) -> None:
+        """A -05:00 scheduled_at is converted to equivalent UTC."""
+        schema = CreateScheduleRequest(
+            counterpart_id="00000000-0000-0000-0000-000000000001",
+            scheduled_at=datetime(2026, 4, 1, 1, 30, 0, tzinfo=EST),
+            title="Test",
+        )
+        assert schema.scheduled_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.scheduled_at == expected
+
+
+class TestSendConsultationRequestRequestUtcNormalization:
+    """UTC normalization for SendConsultationRequestRequest."""
+
+    def test_non_utc_offset_normalized(self) -> None:
+        """A +09:00 scheduled_at is converted to equivalent UTC."""
+        schema = SendConsultationRequestRequest(
+            organizer_id="00000000-0000-0000-0000-000000000001",
+            scheduled_at=datetime(2026, 4, 1, 15, 30, 0, tzinfo=JST),
+            title="Test",
+            agenda_topics=["Topic 1"],
+        )
+        assert schema.scheduled_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.scheduled_at == expected
+
+
+class TestRescheduleRequestUtcNormalization:
+    """UTC normalization for RescheduleRequest."""
+
+    def test_non_utc_offset_normalized(self) -> None:
+        """A +09:00 new_scheduled_at is converted to UTC."""
+        schema = RescheduleRequest(
+            new_scheduled_at=datetime(2026, 4, 1, 15, 30, 0, tzinfo=JST),
+        )
+        assert schema.new_scheduled_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.new_scheduled_at == expected

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_action_item_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_action_item_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,8 +27,8 @@ async def _create_record(
     record = Record.create(
         organizer_id=organizer,
         counterpart_id=counterpart,
-        conducted_at=datetime(2026, 3, 20, 14, 0),
-        now=datetime(2026, 3, 20, 10, 0),
+        conducted_at=datetime(2026, 3, 20, 14, 0, tzinfo=UTC),
+        now=datetime(2026, 3, 20, 10, 0, tzinfo=UTC),
     )
     repo = SqlAlchemyRecordRepository(session)
     await repo.save(record)
@@ -51,7 +51,7 @@ class TestSaveAndGetById:
             title=ActionItemTitle("Review PR #42"),
             actor_id=organizer,
             organizer_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(action_item)
         await session.commit()
@@ -88,7 +88,7 @@ class TestActionItemUpdate:
             title=ActionItemTitle("Write tests"),
             actor_id=organizer,
             organizer_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(action_item)
         await session.commit()
@@ -96,7 +96,7 @@ class TestActionItemUpdate:
         # Complete the action item
         action_item.complete(
             actor_id=counterpart,
-            now=datetime(2026, 3, 20, 16, 0),
+            now=datetime(2026, 3, 20, 16, 0, tzinfo=UTC),
         )
         await repo.save(action_item)
         await session.commit()

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_comment_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_comment_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,8 +29,8 @@ async def _create_record(
     record = Record.create(
         organizer_id=organizer,
         counterpart_id=counterpart,
-        conducted_at=datetime(2026, 3, 20, 14, 0),
-        now=datetime(2026, 3, 20, 10, 0),
+        conducted_at=datetime(2026, 3, 20, 14, 0, tzinfo=UTC),
+        now=datetime(2026, 3, 20, 10, 0, tzinfo=UTC),
     )
     repo = SqlAlchemyRecordRepository(session)
     await repo.save(record)
@@ -51,7 +51,7 @@ class TestSaveAndGetById:
             record_id=record.id,
             author_id=organizer,
             body=CommentBody("Great session!"),
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(comment)
         await session.commit()
@@ -85,7 +85,7 @@ class TestInsertOnly:
             record_id=record.id,
             author_id=organizer,
             body=CommentBody("First comment"),
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(comment)
         await session.commit()

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_read_status_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_read_status_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,8 +27,8 @@ async def _create_record(
     record = Record.create(
         organizer_id=organizer,
         counterpart_id=counterpart,
-        conducted_at=datetime(2026, 3, 20, 14, 0),
-        now=datetime(2026, 3, 20, 10, 0),
+        conducted_at=datetime(2026, 3, 20, 14, 0, tzinfo=UTC),
+        now=datetime(2026, 3, 20, 10, 0, tzinfo=UTC),
     )
     repo = SqlAlchemyRecordRepository(session)
     await repo.save(record)
@@ -48,7 +48,7 @@ class TestSaveAndGetById:
         rs = ReadStatus.create(
             record_id=record.id,
             user_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(rs)
         await session.commit()
@@ -59,7 +59,7 @@ class TestSaveAndGetById:
         assert loaded.id == rs.id
         assert loaded.record_id == record.id
         assert loaded.user_id == organizer
-        assert loaded.last_viewed_at == datetime(2026, 3, 20, 15, 0)
+        assert loaded.last_viewed_at == datetime(2026, 3, 20, 15, 0, tzinfo=UTC)
 
     async def test_get_by_id_returns_none_for_missing(
         self, session: AsyncSession
@@ -81,18 +81,18 @@ class TestSaveUpdate:
         rs = ReadStatus.create(
             record_id=record.id,
             user_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(rs)
         await session.commit()
 
-        rs.mark_viewed(now=datetime(2026, 3, 20, 18, 0))
+        rs.mark_viewed(now=datetime(2026, 3, 20, 18, 0, tzinfo=UTC))
         await repo.save(rs)
         await session.commit()
 
         loaded = await repo.get_by_id(rs.id)
         assert loaded is not None
-        assert loaded.last_viewed_at == datetime(2026, 3, 20, 18, 0)
+        assert loaded.last_viewed_at == datetime(2026, 3, 20, 18, 0, tzinfo=UTC)
 
 
 class TestFindByRecordAndUser:
@@ -107,7 +107,7 @@ class TestFindByRecordAndUser:
         rs = ReadStatus.create(
             record_id=record.id,
             user_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(rs)
         await session.commit()
@@ -136,7 +136,7 @@ class TestUpsert:
         rs = ReadStatus.create(
             record_id=record.id,
             user_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.upsert(rs)
         await session.commit()
@@ -145,7 +145,7 @@ class TestUpsert:
         assert found is not None
         assert found.record_id == record.id
         assert found.user_id == organizer
-        assert found.last_viewed_at == datetime(2026, 3, 20, 15, 0)
+        assert found.last_viewed_at == datetime(2026, 3, 20, 15, 0, tzinfo=UTC)
 
     async def test_upsert_updates_existing_row(self, session: AsyncSession) -> None:
         organizer = await create_test_user(session)
@@ -156,7 +156,7 @@ class TestUpsert:
         rs1 = ReadStatus.create(
             record_id=record.id,
             user_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.upsert(rs1)
         await session.commit()
@@ -166,14 +166,14 @@ class TestUpsert:
         rs2 = ReadStatus.create(
             record_id=record.id,
             user_id=organizer,
-            now=datetime(2026, 3, 20, 18, 0),
+            now=datetime(2026, 3, 20, 18, 0, tzinfo=UTC),
         )
         await repo.upsert(rs2)
         await session.commit()
 
         found = await repo.find_by_record_and_user(record.id, organizer)
         assert found is not None
-        assert found.last_viewed_at == datetime(2026, 3, 20, 18, 0)
+        assert found.last_viewed_at == datetime(2026, 3, 20, 18, 0, tzinfo=UTC)
 
 
 class TestDeleteByRecordAndUser:
@@ -188,7 +188,7 @@ class TestDeleteByRecordAndUser:
         rs = ReadStatus.create(
             record_id=record.id,
             user_id=organizer,
-            now=datetime(2026, 3, 20, 15, 0),
+            now=datetime(2026, 3, 20, 15, 0, tzinfo=UTC),
         )
         await repo.save(rs)
         await session.commit()

--- a/backend/tests/contexts/record/infrastructure/test_sqlalchemy_record_repository.py
+++ b/backend/tests/contexts/record/infrastructure/test_sqlalchemy_record_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,9 +28,9 @@ def _make_record(
     return Record.create(
         organizer_id=organizer_id,
         counterpart_id=counterpart_id,
-        conducted_at=datetime(2026, 3, 20, 14, 0),
+        conducted_at=datetime(2026, 3, 20, 14, 0, tzinfo=UTC),
         schedule_id=schedule_id,
-        now=now or datetime(2026, 3, 20, 10, 0),
+        now=now or datetime(2026, 3, 20, 10, 0, tzinfo=UTC),
     )
 
 
@@ -82,10 +82,10 @@ class TestRecordUpdate:
         record.update_memo(
             memo=Memo("Updated memo content"),
             actor_id=organizer,
-            now=datetime(2026, 3, 20, 12, 0),
+            now=datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
         )
         # Publish
-        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 13, 0))
+        record.publish(actor_id=organizer, now=datetime(2026, 3, 20, 13, 0, tzinfo=UTC))
         await repo.save(record)
         await session.commit()
 
@@ -105,7 +105,7 @@ class TestRecordUpdate:
         record.set_viewers(
             viewer_ids=[viewer1, viewer2],
             actor_id=organizer,
-            now=datetime(2026, 3, 20, 11, 0),
+            now=datetime(2026, 3, 20, 11, 0, tzinfo=UTC),
         )
         await repo.save(record)
         await session.commit()
@@ -127,7 +127,7 @@ class TestRecordUpdate:
         record.set_viewers(
             viewer_ids=[viewer1, viewer2],
             actor_id=organizer,
-            now=datetime(2026, 3, 20, 11, 0),
+            now=datetime(2026, 3, 20, 11, 0, tzinfo=UTC),
         )
         await repo.save(record)
         await session.commit()
@@ -139,7 +139,7 @@ class TestRecordUpdate:
         record.set_viewers(
             viewer_ids=[viewer2, viewer3],
             actor_id=organizer,
-            now=datetime(2026, 3, 20, 12, 0),
+            now=datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
         )
         await repo.save(record)
         await session.commit()
@@ -159,7 +159,7 @@ class TestRecordUpdate:
         record.set_viewers(
             viewer_ids=[viewer1],
             actor_id=organizer,
-            now=datetime(2026, 3, 20, 11, 0),
+            now=datetime(2026, 3, 20, 11, 0, tzinfo=UTC),
         )
         await repo.save(record)
         await session.commit()
@@ -171,7 +171,7 @@ class TestRecordUpdate:
         record.set_viewers(
             viewer_ids=[],
             actor_id=organizer,
-            now=datetime(2026, 3, 20, 12, 0),
+            now=datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
         )
         await repo.save(record)
         await session.commit()

--- a/backend/tests/contexts/record/presentation/test_schemas_utc_normalization.py
+++ b/backend/tests/contexts/record/presentation/test_schemas_utc_normalization.py
@@ -1,0 +1,52 @@
+"""Tests for UTC normalization in Record request schemas.
+
+Verifies that non-UTC aware datetimes (e.g. +09:00) are automatically
+converted to UTC when parsed by Pydantic request schemas.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from contexts.record.presentation.schemas import (
+    CreatePostHocRecordRequest,
+    CreateRecordFromScheduleRequest,
+)
+
+JST = timezone(timedelta(hours=9))
+
+
+class TestCreatePostHocRecordRequestUtcNormalization:
+    """UTC normalization for CreatePostHocRecordRequest."""
+
+    def test_jst_offset_normalized_to_utc(self) -> None:
+        """A +09:00 conducted_at is converted to equivalent UTC."""
+        schema = CreatePostHocRecordRequest(
+            counterpart_id="00000000-0000-0000-0000-000000000001",
+            conducted_at=datetime(2026, 4, 1, 15, 30, 0, tzinfo=JST),
+        )
+        assert schema.conducted_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.conducted_at == expected
+
+    def test_utc_input_unchanged(self) -> None:
+        """UTC input passes through without modification."""
+        schema = CreatePostHocRecordRequest(
+            counterpart_id="00000000-0000-0000-0000-000000000001",
+            conducted_at=datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC),
+        )
+        assert schema.conducted_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.conducted_at == expected
+
+
+class TestCreateRecordFromScheduleRequestUtcNormalization:
+    """UTC normalization for CreateRecordFromScheduleRequest."""
+
+    def test_non_utc_offset_normalized(self) -> None:
+        """A +09:00 conducted_at is converted to equivalent UTC."""
+        schema = CreateRecordFromScheduleRequest(
+            schedule_id="00000000-0000-0000-0000-000000000001",
+            conducted_at=datetime(2026, 4, 1, 15, 30, 0, tzinfo=JST),
+        )
+        assert schema.conducted_at.utcoffset() == timedelta(0)
+        expected = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert schema.conducted_at == expected

--- a/backend/tests/contexts/workspace/infrastructure/test_sqlalchemy_workspace_repository.py
+++ b/backend/tests/contexts/workspace/infrastructure/test_sqlalchemy_workspace_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import text
@@ -29,7 +29,7 @@ def _make_workspace(
     return Workspace.create(
         name=WorkspaceName(name),
         parent_id=parent_id,
-        now=now or datetime(2026, 3, 20, 10, 0),
+        now=now or datetime(2026, 3, 20, 10, 0, tzinfo=UTC),
     )
 
 
@@ -46,7 +46,7 @@ class TestSaveAndGetById:
         ws.add_member(
             user_id=user_id,
             role=MembershipRole.CAPTAIN,
-            now=datetime(2026, 3, 20, 11, 0),
+            now=datetime(2026, 3, 20, 11, 0, tzinfo=UTC),
         )
         await repo.save(ws)
         await session.commit()
@@ -206,9 +206,7 @@ class TestAlembicMigration:
                 assert "memberships" in tables
 
             # Downgrade to base
-            await loop.run_in_executor(
-                None, command.downgrade, alembic_cfg, "base"
-            )
+            await loop.run_in_executor(None, command.downgrade, alembic_cfg, "base")
 
             # Verify tables are gone
             async with session_factory() as s:

--- a/backend/tests/foundation/test_datetime_utils.py
+++ b/backend/tests/foundation/test_datetime_utils.py
@@ -1,0 +1,100 @@
+"""Unit tests for foundation.datetime_utils boundary conversion functions."""
+
+from datetime import UTC, datetime, timezone, timedelta
+
+import pytest
+
+from foundation.datetime_utils import to_aware_utc, to_aware_utc_optional, to_naive_utc
+
+
+class TestToNaiveUtc:
+    """Tests for to_naive_utc()."""
+
+    def test_converts_utc_aware_to_naive(self) -> None:
+        """Aware UTC datetime is converted to naive with same components."""
+        aware = datetime(2026, 4, 1, 12, 30, 45, 123456, tzinfo=UTC)
+        result = to_naive_utc(aware)
+
+        assert result == datetime(2026, 4, 1, 12, 30, 45, 123456)
+        assert result.tzinfo is None
+
+    def test_preserves_microseconds(self) -> None:
+        """Microsecond precision is preserved through conversion."""
+        aware = datetime(2026, 4, 1, 0, 0, 0, 999999, tzinfo=UTC)
+        result = to_naive_utc(aware)
+
+        assert result.microsecond == 999999
+
+    def test_raises_type_error_for_naive_input(self) -> None:
+        """Naive datetime input raises TypeError."""
+        naive = datetime(2026, 4, 1, 12, 0, 0)
+        with pytest.raises(TypeError, match="Expected aware datetime, got naive"):
+            to_naive_utc(naive)
+
+    def test_raises_value_error_for_non_utc_aware(self) -> None:
+        """Aware datetime with non-UTC offset raises ValueError."""
+        jst = timezone(timedelta(hours=9))
+        aware_jst = datetime(2026, 4, 1, 21, 0, 0, tzinfo=jst)
+        with pytest.raises(ValueError, match="Expected UTC datetime"):
+            to_naive_utc(aware_jst)
+
+
+class TestToAwareUtc:
+    """Tests for to_aware_utc()."""
+
+    def test_converts_naive_to_utc_aware(self) -> None:
+        """Naive datetime is converted to UTC aware with same components."""
+        naive = datetime(2026, 4, 1, 6, 30, 0, 0)
+        result = to_aware_utc(naive)
+
+        assert result == datetime(2026, 4, 1, 6, 30, 0, 0, tzinfo=UTC)
+        assert result.tzinfo is UTC
+
+    def test_preserves_microseconds(self) -> None:
+        """Microsecond precision is preserved through conversion."""
+        naive = datetime(2026, 4, 1, 0, 0, 0, 123456)
+        result = to_aware_utc(naive)
+
+        assert result.microsecond == 123456
+
+    def test_raises_type_error_for_aware_input(self) -> None:
+        """Already-aware datetime input raises TypeError."""
+        aware = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+        with pytest.raises(TypeError, match="Expected naive datetime from DB"):
+            to_aware_utc(aware)
+
+
+class TestToAwareUtcOptional:
+    """Tests for to_aware_utc_optional()."""
+
+    def test_returns_none_for_none(self) -> None:
+        """None input returns None."""
+        assert to_aware_utc_optional(None) is None
+
+    def test_converts_naive_to_utc_aware(self) -> None:
+        """Non-None naive datetime is converted to UTC aware."""
+        naive = datetime(2026, 4, 1, 6, 30, 0, 0)
+        result = to_aware_utc_optional(naive)
+
+        assert result is not None
+        assert result.tzinfo is UTC
+        assert result == datetime(2026, 4, 1, 6, 30, 0, 0, tzinfo=UTC)
+
+    def test_raises_type_error_for_aware_input(self) -> None:
+        """Already-aware datetime input raises TypeError."""
+        aware = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+        with pytest.raises(TypeError, match="Expected naive datetime from DB"):
+            to_aware_utc_optional(aware)
+
+
+class TestRoundTrip:
+    """Tests for to_naive_utc -> to_aware_utc round-trip."""
+
+    def test_round_trip_preserves_value(self) -> None:
+        """Converting aware -> naive -> aware returns the original value."""
+        original = datetime(2026, 4, 1, 15, 30, 0, 123456, tzinfo=UTC)
+        naive = to_naive_utc(original)
+        restored = to_aware_utc(naive)
+
+        assert restored == original
+        assert restored.tzinfo is UTC

--- a/backend/tests/foundation/test_datetime_utils.py
+++ b/backend/tests/foundation/test_datetime_utils.py
@@ -1,10 +1,59 @@
 """Unit tests for foundation.datetime_utils boundary conversion functions."""
 
-from datetime import UTC, datetime, timezone, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
-from foundation.datetime_utils import to_aware_utc, to_aware_utc_optional, to_naive_utc
+from foundation.datetime_utils import (
+    normalize_to_utc,
+    to_aware_utc,
+    to_aware_utc_optional,
+    to_naive_utc,
+)
+
+
+class TestNormalizeToUtc:
+    """Tests for normalize_to_utc()."""
+
+    def test_utc_datetime_passes_through(self) -> None:
+        """UTC aware datetime is returned as-is."""
+        utc_dt = datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        result = normalize_to_utc(utc_dt)
+
+        assert result == utc_dt
+        assert result.utcoffset() == timedelta(0)
+
+    def test_positive_offset_converted_to_utc(self) -> None:
+        """Datetime with +09:00 offset is converted to equivalent UTC."""
+        jst = timezone(timedelta(hours=9))
+        jst_dt = datetime(2026, 4, 1, 15, 30, 0, tzinfo=jst)
+        result = normalize_to_utc(jst_dt)
+
+        assert result == datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert result.utcoffset() == timedelta(0)
+
+    def test_negative_offset_converted_to_utc(self) -> None:
+        """Datetime with -05:00 offset is converted to equivalent UTC."""
+        est = timezone(timedelta(hours=-5))
+        est_dt = datetime(2026, 4, 1, 1, 30, 0, tzinfo=est)
+        result = normalize_to_utc(est_dt)
+
+        assert result == datetime(2026, 4, 1, 6, 30, 0, tzinfo=UTC)
+        assert result.utcoffset() == timedelta(0)
+
+    def test_preserves_microseconds(self) -> None:
+        """Microsecond precision is preserved during conversion."""
+        jst = timezone(timedelta(hours=9))
+        jst_dt = datetime(2026, 4, 1, 15, 30, 0, 123456, tzinfo=jst)
+        result = normalize_to_utc(jst_dt)
+
+        assert result.microsecond == 123456
+
+    def test_raises_type_error_for_naive_input(self) -> None:
+        """Naive datetime input raises TypeError."""
+        naive = datetime(2026, 4, 1, 12, 0, 0)
+        with pytest.raises(TypeError, match="Expected aware datetime, got naive"):
+            normalize_to_utc(naive)
 
 
 class TestToNaiveUtc:

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -46,6 +46,25 @@
 
 ### datetime の扱い
 
+#### ポリシー（全レイヤー共通）
+
+- **ドメイン層**: `aware datetime (tz=UTC)` のみ使用。naive datetime は禁止
+- **DB（MariaDB `DATETIME(6)`）**: naive UTC で保存する
+- **API 入力**: `AwareDatetime`（Pydantic）必須。オフセット付き ISO 8601 のみ受け付け
+- **API 出力**: `AwareDatetime`（UTC 明示、`Z` サフィックス）で返す
+
+#### レイヤー境界の変換
+
+| 方向 | 変換 | 使用関数 |
+|---|---|---|
+| Presentation → Domain | aware datetime を UTC aware に正規化 | Pydantic `AwareDatetime` が自動処理 |
+| Domain → Infrastructure/DB | UTC aware → naive UTC | `to_naive_utc()` |
+| Infrastructure/DB → Domain | naive UTC → UTC aware | `to_aware_utc()` / `to_aware_utc_optional()` |
+| Domain → Presentation | UTC aware のまま返却 | Schema で `AwareDatetime` |
+
+- 変換ユーティリティは `foundation/datetime_utils.py` に定義
+- naive datetime を aware として扱おうとした場合（またはその逆）は即座に例外を投げる（暗黙変換しない）
+
 #### ドメイン層
 
 - **ファクトリメソッド（`create()`）**: `now: datetime | None = None` で受け取り、省略時は `datetime.now(UTC)` をフォールバック
@@ -58,7 +77,9 @@
 - DB セッションは `connect_args={"init_command": "SET time_zone='+00:00'"}` で UTC 固定
 - `NOW()` / `CURRENT_TIMESTAMP` は常に UTC を返す
 - アプリ層で datetime を生成する場合は `datetime.now(UTC)` を使用する
-- 表示層で各ユーザーのタイムゾーンに変換する
+- `TimestampMixin` の `created_at` / `updated_at` は `DATETIME(fsp=6)` で統一する
+- リポジトリの `_to_entity` では `to_aware_utc()` で naive → aware 復元する
+- リポジトリの `_insert` / `_update` では `to_naive_utc()` で aware → naive 変換する
 
 ### カラム規約
 

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -57,7 +57,7 @@
 
 | 方向 | 変換 | 使用関数 |
 |---|---|---|
-| Presentation → Domain | aware datetime を UTC aware に正規化 | Pydantic `AwareDatetime` が自動処理 |
+| Presentation → Domain | aware datetime を UTC aware に正規化 | Pydantic スキーマの `field_validator` で `normalize_to_utc()` を明示呼出 |
 | Domain → Infrastructure/DB | UTC aware → naive UTC | `to_naive_utc()` |
 | Infrastructure/DB → Domain | naive UTC → UTC aware | `to_aware_utc()` / `to_aware_utc_optional()` |
 | Domain → Presentation | UTC aware のまま返却 | Schema で `AwareDatetime` |


### PR DESCRIPTION
## 概要

Issue #232 の実装。全レイヤーで一貫した日時・タイムゾーンの取り扱いポリシーを導入し、暗黙的なタイムゾーン情報の喪失を防止する。

## 変更内容

### 1. 境界変換ユーティリティ (`foundation/datetime_utils.py`)
- `to_naive_utc()`: aware UTC → naive UTC（DB保存用）
- `to_aware_utc()` / `to_aware_utc_optional()`: naive UTC → aware UTC（ドメイン復元用）
- naive/aware の不整合は即座に例外を投げる（暗黙変換しない）

### 2. リポジトリマッパーの境界変換
- 全リポジトリの `_to_entity` で `to_aware_utc()` を使用し naive → aware 復元
- 全リポジトリの `_insert` / `_update` で `to_naive_utc()` を使用し aware → naive 変換
- クエリパラメータ（`list_upcoming_by_participant` 等）も naive 変換してDBと比較

### 3. スキーマの `AwareDatetime` 統一
- 全コンテキストのレスポンススキーマで `datetime` → `AwareDatetime` に変更
- API出力は UTC 明示（`Z` サフィックス）で返却される

### 4. `TimestampMixin` の `fsp=6` 化
- `created_at` / `updated_at` を `DATETIME(fsp=6)` に変更
- `server_default` を `CURRENT_TIMESTAMP(6)` に更新

### 5. マイグレーション
- 0016: 全テーブル（22テーブル）の `created_at` / `updated_at` を `DATETIME(6)` に ALTER

### 6. ドキュメント更新
- `docs/coding-standards.md` にタイムゾーンポリシー・レイヤー境界の変換ルールを追記

## テスト
- `foundation/datetime_utils.py` のユニットテスト（11テスト）を追加
- 既存ユニットテスト 1177件 すべてパス

## 受け入れ条件の対応
1. `2026-03-29T15:30:00+09:00` 入力 → レスポンスは `2026-03-29T06:30:00Z` で返却される（`AwareDatetime` スキーマ + UTC 正規化）
2. DB保存値は naive UTC（`2026-03-29 06:30:00.000000`）になる（`to_naive_utc()` による変換）
3. 全 timestamp カラムで microseconds（`fsp=6`）が保持される（マイグレーション 0016 + TimestampMixin 更新）
